### PR TITLE
Fix: Add type and scope field to JSON BOMs

### DIFF
--- a/src/bom.rs
+++ b/src/bom.rs
@@ -36,7 +36,7 @@ impl<'a> FromIterator<&'a Package> for Bom<'a> {
             spec_version: "1.3",
             version: 1,
             serial_number: Uuid::new_v4(),
-            components: iter.into_iter().map(Component::from).collect(),
+            components: iter.into_iter().map(Component::library).collect(),
         }
     }
 }

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{fmt, io};
 
 use cargo::core::Package;
 use packageurl::PackageUrl;
@@ -13,20 +13,54 @@ mod reference;
 use self::license::Licenses;
 use self::reference::ExternalReferences;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum ComponentType {
+    Library,
+}
+
+impl fmt::Display for ComponentType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Library => "library".fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum Scope {
+    Required,
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Required => "required".fmt(f),
+        }
+    }
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Component<'a> {
     #[serde(flatten)]
     metadata: Metadata<'a>,
+    #[serde(rename = "type")]
+    component_type: ComponentType,
+    scope: Scope,
     #[serde(skip_serializing_if = "Licenses::is_empty")]
     licenses: Licenses<'a>,
     #[serde(skip_serializing_if = "ExternalReferences::is_empty")]
     external_references: ExternalReferences<'a>,
 }
 
-impl<'a> From<&'a Package> for Component<'a> {
-    fn from(pkg: &'a Package) -> Self {
+impl<'a> Component<'a> {
+    /// Create a component which describes the package as a library.
+    pub fn library(pkg: &'a Package) -> Self {
         Self {
+            component_type: ComponentType::Library,
+            scope: Scope::Required,
             metadata: Metadata::from(pkg),
             licenses: Licenses::from(pkg),
             external_references: ExternalReferences::from(pkg),
@@ -37,13 +71,11 @@ impl<'a> From<&'a Package> for Component<'a> {
 impl ToXml for Component<'_> {
     fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
         xml.begin_elem("component")?;
-        xml.attr("type", "library")?;
+        xml.attr("type", &self.component_type.to_string())?;
 
         self.metadata.to_xml(xml)?;
 
-        xml.begin_elem("scope")?;
-        xml.text("required")?;
-        xml.end_elem()?;
+        xml.elem_text("scope", &self.scope.to_string())?;
 
         //TODO: Add hashes. May require file components and manual calculation of all files
 


### PR DESCRIPTION
These fields were hardcoded in `ToXml`, and therefore not seen or included by serde when serializing to JSON.