### PR TITLE
Add deploy workflow for project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type (major, minor, patch)'
+        required: true
+        default: 'patch'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cargo bump
+        run: |
+          cargo install cargo-bump
+          cargo bump ${{ github.event.inputs.releaseType }}
+      - name: Retrieve new version
+        run: |
+          echo "::set-output name=CARGO_VERSION::$(grep -e '^version' Cargo.toml | cut -d "=" -f2 | tr -d '/"' | tr -d ' ')"
+        id: version
+      - name: Build one time, for sanity
+        run: cargo build
+      - uses: katyo/publish-crates@v1
+        with:
+          args: --verbose --allow-dirty
+          dry-run: true
+      - name: Configure git and add files
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -am "New development bump to ${{steps.version.outputs.CARGO_VERSION}}"
+          git tag -a ${{steps.version.outputs.CARGO_VERSION}} -m "${{steps.version.outputs.CARGO_VERSION}} release"
+          git push
+          git push origin ${{steps.version.outputs.CARGO_VERSION}}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2.3.4
-    - name: Install Rust Toolchain
+    - name: Install latest nightly
       run: |
         rustup update
         rustup component add clippy
@@ -17,6 +17,8 @@ jobs:
         rustup install nightly
     - name: Build
       run: cargo build --verbose
+    - name: Lint
+      run: cargo fmt -- --check
     - name: Execute stable tests
       run: |
         cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+bom.xml
+bom.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
+name = "camino"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo"
 version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +153,7 @@ dependencies = [
  "rand",
  "rustc-workspace-hack",
  "rustfix",
- "semver",
+ "semver 0.10.0",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -190,6 +199,20 @@ dependencies = [
  "tempfile",
  "walkdir",
  "winapi",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 0.11.0",
+ "semver-parser 0.10.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -352,8 +375,10 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "cargo",
+ "cargo_metadata",
  "chrono",
  "lazy_static",
+ "log",
  "packageurl",
  "regex",
  "serde",
@@ -834,6 +859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1066,17 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+ "serde",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
  "serde",
 ]
 
@@ -1041,6 +1085,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1249,6 +1302,12 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ serde_json = "1.0.64"
 structopt = { version = "0.3", default-features = false }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 xml_writer = "0.4.0"
+cargo_metadata = "0.13.1"
+log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CycloneDX/cyclonedx-rust-cargo"
 readme = "README.md"
 
 categories = ["command-line-utilities", "development-tools", "development-tools::cargo-plugins"]
-keywords = ["sbom", "bom", "bill-of-materials", "components", "dependencies", "owasp"]
+keywords = ["sbom", "bom", "components", "dependencies", "owasp"]
 
 [profile.release]
 lto = true

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright OWASP Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 CycloneDX Rust Cargo
-Copyright (c) Steve Springett
+Copyright (c) OWASP Foundation
 
 This product includes software developed by the
 CycloneDX community (https://cyclonedx.org/).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ cargo cyclonedx
 ```
 
 
-## License
+## Copyright & License
+
+CycloneDX Rust Cargo is Copyright (c) OWASP Foundation. All Rights Reserved.
+
 Permission to modify and redistribute is granted under the terms of the Apache 2.0 license. See the [LICENSE] file for the full license.
 
 [License]: https://github.com/CycloneDX/cyclonedx-rust-cargo/blob/master/LICENSE

--- a/src/author.rs
+++ b/src/author.rs
@@ -1,3 +1,21 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
 use std::{io, str::FromStr};
 
 use cargo::core::Package;

--- a/src/bom.rs
+++ b/src/bom.rs
@@ -16,13 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-use std::{io, iter::FromIterator};
+use std::io;
+use std::iter::FromIterator;
 
 use cargo::core::Package;
 use serde::{Serialize, Serializer};
 use uuid::Uuid;
 use xml_writer::XmlWriter;
 
+use crate::metadata::Metadata;
 use crate::{Component, ToXml};
 
 static SPEC_VERSION: &'static str = "1.3";
@@ -39,29 +41,42 @@ fn uuid_to_urn<S: Serializer>(uuid: &Uuid, serializer: S) -> Result<S::Ok, S::Er
 /// A software bill of materials for a Rust crate.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Bom<'a> {
+pub struct Bom {
     bom_format: BomFormat,
     spec_version: &'static str,
     #[serde(serialize_with = "uuid_to_urn")]
     serial_number: Uuid,
     version: u32,
-    components: Vec<Component<'a>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    components: Vec<Component>,
 }
 
-/// Create a new BOM from a sequence of cargo package references.
-impl<'a> FromIterator<&'a Package> for Bom<'a> {
-    fn from_iter<T: IntoIterator<Item = &'a Package>>(iter: T) -> Self {
+impl<'a> Default for Bom {
+    fn default() -> Bom {
         Self {
             bom_format: BomFormat::CycloneDX,
             spec_version: SPEC_VERSION,
             version: 1,
             serial_number: Uuid::new_v4(),
-            components: iter.into_iter().map(Component::library).collect(),
+            metadata: None::<Metadata>,
+            components: Vec::new(),
         }
     }
 }
 
-impl ToXml for Bom<'_> {
+/// Create a new BOM from a sequence of cargo package references.
+impl<'a> FromIterator<&'a Package> for Bom {
+    fn from_iter<T: IntoIterator<Item = &'a Package>>(iter: T) -> Self {
+        Self {
+            components: iter.into_iter().map(Component::from).collect(),
+            metadata: Some(Metadata::default()),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToXml for Bom {
     fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
         let namespace = format!("http://cyclonedx.org/schema/bom/{}", SPEC_VERSION);
         xml.dtd("UTF-8")?;
@@ -69,6 +84,10 @@ impl ToXml for Bom<'_> {
         xml.attr("serialNumber", &self.serial_number.to_urn().to_string())?;
         xml.attr("version", "1")?;
         xml.attr("xmlns", namespace.as_str())?;
+
+        if let Some(metadata) = &self.metadata {
+            metadata.to_xml(xml)?;
+        }
 
         xml.begin_elem("components")?;
         for component in &self.components {

--- a/src/bom.rs
+++ b/src/bom.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 use std::{io, iter::FromIterator};
 

--- a/src/bom/metadata.rs
+++ b/src/bom/metadata.rs
@@ -1,3 +1,21 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
 use std::io;
 
 use cargo::core::{Package, TargetKind};

--- a/src/component.rs
+++ b/src/component.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 use std::{fmt, io};
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -25,15 +25,12 @@ use xml_writer::XmlWriter;
 
 use crate::traits::ToXml;
 
-mod license;
-mod reference;
-
-use self::license::Licenses;
-use self::reference::ExternalReferences;
+use crate::license::License;
+use crate::reference::ExternalReference;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
-enum ComponentType {
+pub enum ComponentType {
     Application,
     Library,
 }
@@ -49,7 +46,7 @@ impl fmt::Display for ComponentType {
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "camelCase")]
-enum Scope {
+pub enum Scope {
     Required,
 }
 
@@ -63,28 +60,38 @@ impl fmt::Display for Scope {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Component<'a> {
+pub struct Component {
     #[serde(flatten)]
-    metadata: Metadata<'a>,
+    pub metadata: ComponentCommon,
     #[serde(rename = "type")]
-    component_type: ComponentType,
+    pub component_type: ComponentType,
     #[serde(skip_serializing_if = "Option::is_none")]
-    scope: Option<Scope>,
-    #[serde(skip_serializing_if = "Licenses::is_empty")]
-    licenses: Licenses<'a>,
-    #[serde(skip_serializing_if = "ExternalReferences::is_empty")]
-    external_references: ExternalReferences<'a>,
+    pub scope: Option<Scope>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub licenses: Option<Vec<License>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_references: Option<Vec<ExternalReference>>,
 }
 
-impl<'a> Component<'a> {
+impl<'a> Component {
     /// Create a component which describes the package as a library.
     pub fn library(pkg: &'a Package) -> Self {
         Self {
             component_type: ComponentType::Library,
             scope: Some(Scope::Required),
-            metadata: Metadata::from(pkg),
-            licenses: Licenses::from(pkg),
-            external_references: ExternalReferences::from(pkg),
+            metadata: ComponentCommon::from(pkg),
+            licenses: Some(vec![License::from(pkg)]),
+            external_references: get_external_references(pkg),
+        }
+    }
+
+    pub fn library_cm(package: &'a cargo_metadata::Package) -> Self {
+        Self {
+            component_type: ComponentType::Library,
+            external_references: get_external_references_cm(package),
+            licenses: Some(vec![License::from(package)]),
+            metadata: ComponentCommon::from(package),
+            scope: Some(Scope::Required),
         }
     }
 
@@ -93,9 +100,19 @@ impl<'a> Component<'a> {
         Self {
             component_type: ComponentType::Application,
             scope: Some(Scope::Required),
-            metadata: Metadata::from(pkg),
-            licenses: Licenses::from(pkg),
-            external_references: ExternalReferences::from(pkg),
+            metadata: ComponentCommon::from(pkg),
+            licenses: Some(vec![License::from(pkg)]),
+            external_references: get_external_references(pkg),
+        }
+    }
+
+    pub fn application_cm(package: &'a cargo_metadata::Package) -> Self {
+        Self {
+            component_type: ComponentType::Application,
+            external_references: get_external_references_cm(package),
+            licenses: Some(vec![License::from(package)]),
+            metadata: ComponentCommon::from(package),
+            scope: Some(Scope::Required),
         }
     }
 
@@ -106,7 +123,31 @@ impl<'a> Component<'a> {
     }
 }
 
-impl ToXml for Component<'_> {
+impl<'a> From<&'a Package> for Component {
+    fn from(package: &'a Package) -> Self {
+        Self {
+            component_type: ComponentType::Library,
+            scope: Some(Scope::Required),
+            metadata: ComponentCommon::from(package),
+            licenses: Some(vec![License::from(package)]),
+            external_references: get_external_references(package),
+        }
+    }
+}
+
+impl<'a> From<&'a cargo_metadata::Package> for Component {
+    fn from(package: &'a cargo_metadata::Package) -> Self {
+        Self {
+            component_type: ComponentType::Library,
+            external_references: get_external_references_cm(package),
+            licenses: Some(vec![License::from(package)]),
+            metadata: ComponentCommon::from(package),
+            scope: Some(Scope::Required),
+        }
+    }
+}
+
+impl ToXml for Component {
     fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
         xml.begin_elem("component")?;
         xml.attr("type", &self.component_type.to_string())?;
@@ -119,30 +160,35 @@ impl ToXml for Component<'_> {
 
         //TODO: Add hashes. May require file components and manual calculation of all files
 
-        self.licenses.to_xml(xml)?;
-        self.external_references.to_xml(xml)?;
+        if let Some(licenses) = &self.licenses {
+            licenses.to_xml(xml)?;
+        }
+
+        if let Some(external_references) = &self.external_references {
+            external_references.to_xml(xml)?;
+        }
 
         xml.end_elem()
     }
 }
 
 #[derive(Serialize)]
-struct Metadata<'a> {
-    name: &'a str,
-    version: String,
+pub struct ComponentCommon {
+    pub name: String,
+    pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
-    purl: String,
+    pub description: Option<String>,
+    pub purl: String,
 }
 
-impl<'a> From<&'a Package> for Metadata<'a> {
+impl<'a> From<&'a Package> for ComponentCommon {
     fn from(package: &'a Package) -> Self {
-        let name = package.name().to_owned().as_str().trim();
+        let name = package.name().to_owned().trim().to_string();
         let version = package.version().to_string();
 
         Self {
-            name,
-            purl: PackageUrl::new("cargo", name)
+            name: name.clone(),
+            purl: PackageUrl::new("cargo", name.clone())
                 .with_version(version.trim())
                 .to_string(),
             version,
@@ -151,22 +197,38 @@ impl<'a> From<&'a Package> for Metadata<'a> {
                 .metadata()
                 .description
                 .as_ref()
-                .map(|s| s.as_str()),
+                .map(|s| s.to_string()),
         }
     }
 }
 
-impl ToXml for Metadata<'_> {
+impl<'a> From<&'a cargo_metadata::Package> for ComponentCommon {
+    fn from(package: &'a cargo_metadata::Package) -> Self {
+        let name = package.name.trim().to_string();
+        let version = package.version.to_string();
+
+        Self {
+            name: name.clone(),
+            purl: PackageUrl::new("cargo", name.clone())
+                .with_version(version.trim())
+                .to_string(),
+            version,
+            description: package.description.as_ref().map(|s| s.to_string()),
+        }
+    }
+}
+
+impl ToXml for ComponentCommon {
     fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
         xml.begin_elem("name")?;
-        xml.text(self.name)?;
+        xml.text(&self.name)?;
         xml.end_elem()?;
 
         xml.begin_elem("version")?;
         xml.text(self.version.trim())?;
         xml.end_elem()?;
 
-        if let Some(x) = self.description {
+        if let Some(x) = &self.description {
             xml.begin_elem("description")?;
             xml.cdata(x.trim())?;
             xml.end_elem()?;
@@ -178,4 +240,86 @@ impl ToXml for Metadata<'_> {
 
         Ok(())
     }
+}
+
+// Moved to component.rs because references need not be aware of a package, but a component that wants to create external references can be
+fn get_external_references<'a>(package: &'a Package) -> Option<Vec<ExternalReference>> {
+    let mut references = Vec::new();
+
+    let metadata = package.manifest().metadata();
+
+    if let Some(documentation) = &metadata.documentation {
+        references.push(ExternalReference {
+            ref_type: "documentation".to_string(),
+            url: documentation.to_string(),
+        });
+    }
+
+    if let Some(website) = &metadata.homepage {
+        references.push(ExternalReference {
+            ref_type: "website".to_string(),
+            url: website.to_string(),
+        });
+    }
+
+    if let Some(other) = &metadata.links {
+        references.push(ExternalReference {
+            ref_type: "other".to_string(),
+            url: other.to_string(),
+        });
+    }
+
+    if let Some(vcs) = &metadata.repository {
+        references.push(ExternalReference {
+            ref_type: "vcs".to_string(),
+            url: vcs.to_string(),
+        });
+    }
+
+    if references.len() > 0 {
+        return Some(references);
+    }
+
+    None
+}
+
+// Duplicate of the above fn get_external_references, largely just for parsing `cargo_metadata::Package`
+fn get_external_references_cm<'a>(
+    package: &'a cargo_metadata::Package,
+) -> Option<Vec<ExternalReference>> {
+    let mut references = Vec::new();
+
+    if let Some(documentation) = &package.documentation {
+        references.push(ExternalReference {
+            ref_type: "documentation".to_string(),
+            url: documentation.to_string(),
+        });
+    }
+
+    if let Some(website) = &package.homepage {
+        references.push(ExternalReference {
+            ref_type: "website".to_string(),
+            url: website.to_string(),
+        });
+    }
+
+    if let Some(other) = &package.links {
+        references.push(ExternalReference {
+            ref_type: "other".to_string(),
+            url: other.to_string(),
+        });
+    }
+
+    if let Some(vcs) = &package.repository {
+        references.push(ExternalReference {
+            ref_type: "vcs".to_string(),
+            url: vcs.to_string(),
+        });
+    }
+
+    if references.len() > 0 {
+        return Some(references);
+    }
+
+    None
 }

--- a/src/component/license.rs
+++ b/src/component/license.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 use std::io;
 

--- a/src/component/reference.rs
+++ b/src/component/reference.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 use std::io;
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 use std::{fmt, str::FromStr};
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,0 +1,150 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use crate::Bom;
+use crate::Metadata;
+use anyhow::anyhow;
+use cargo::core::dependency::DepKind;
+use cargo::core::Package;
+use cargo::core::PackageSet;
+use cargo::core::Resolve;
+use cargo::core::Workspace;
+use cargo::ops;
+use cargo::CargoResult;
+use cargo::Config;
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+use std::path::PathBuf;
+
+pub trait Generator {
+    fn create_sbom<'a>(&self, manifest_path: PathBuf) -> Result<Bom, GeneratorError>;
+}
+
+pub struct SbomGenerator {
+    pub all: Option<bool>,
+}
+
+impl Generator for SbomGenerator {
+    fn create_sbom<'a>(&self, manifest_path: PathBuf) -> Result<Bom, GeneratorError> {
+        let config = Config::default()?;
+
+        let ws = Workspace::new(&manifest_path, &config)?;
+        let members: Vec<Package> = ws.members().cloned().collect();
+        let (package_ids, resolve) = ops::resolve_ws(&ws)?;
+
+        let root = get_root_package(manifest_path)?;
+
+        let dependencies = if self.all.unwrap_or(true) {
+            all_dependencies(&members, package_ids, resolve)?
+        } else {
+            top_level_dependencies(&members, package_ids)?
+        };
+
+        let mut bom: Bom = dependencies.iter().collect();
+
+        let metadata = Metadata::from(&root);
+
+        bom.metadata = Some(metadata);
+
+        Ok(bom)
+    }
+}
+
+fn get_root_package(toml_file_path: PathBuf) -> anyhow::Result<cargo_metadata::Package> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .manifest_path(toml_file_path)
+        .features(cargo_metadata::CargoOpt::AllFeatures)
+        .exec()?;
+
+    if let Some(root) = metadata.clone().root_package() {
+        return Ok(root.to_owned());
+    }
+
+    Err(anyhow!("Could not get root package"))
+}
+
+fn top_level_dependencies(
+    members: &[Package],
+    package_ids: PackageSet<'_>,
+) -> CargoResult<BTreeSet<Package>> {
+    let mut dependencies = BTreeSet::new();
+
+    for member in members {
+        for dependency in member.dependencies() {
+            // Filter out Build and Development dependencies
+            match dependency.kind() {
+                DepKind::Normal => (),
+                DepKind::Build | DepKind::Development => continue,
+            }
+            if let Some(dep) = package_ids
+                .package_ids()
+                .find(|id| dependency.matches_id(*id))
+            {
+                let package = package_ids.get_one(dep)?;
+                dependencies.insert(package.to_owned());
+            }
+        }
+    }
+
+    // Filter out our own workspace crates from dependency list
+    for member in members {
+        dependencies.remove(member);
+    }
+
+    Ok(dependencies)
+}
+
+fn all_dependencies(
+    members: &[Package],
+    package_ids: PackageSet<'_>,
+    resolve: Resolve,
+) -> CargoResult<BTreeSet<Package>> {
+    let mut dependencies = BTreeSet::new();
+
+    for package_id in resolve.iter() {
+        let package = package_ids.get_one(package_id)?;
+        if members.contains(&package) {
+            // Skip listing our own packages in our workspace
+            continue;
+        }
+        dependencies.insert(package.to_owned());
+    }
+
+    Ok(dependencies)
+}
+
+#[derive(Debug)]
+pub struct GeneratorError {
+    details: String,
+}
+
+impl From<anyhow::Error> for GeneratorError {
+    fn from(_: anyhow::Error) -> Self {
+        Self {
+            details: "An error occurred returning an anyhow error".to_string(),
+        }
+    }
+}
+
+impl fmt::Display for GeneratorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "An error occurred generating a Bom")
+    }
+}
+
+impl Error for GeneratorError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,30 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+pub mod author;
+pub mod bom;
+pub mod component;
+pub mod generator;
+pub mod license;
+pub mod metadata;
+pub mod reference;
+pub mod traits;
+
+pub use crate::{
+    author::Author, bom::Bom, component::*, generator::*, license::License, metadata::Metadata,
+    reference::ExternalReference, traits::*,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 
 /**

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,0 +1,161 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+use std::io;
+use xml_writer::XmlWriter;
+
+use cargo::core::{Package, TargetKind};
+use chrono::{DateTime, Utc};
+use log::debug;
+use serde::Serialize;
+use std::str::FromStr;
+
+use crate::author::Author;
+use crate::component::Component;
+use crate::traits::ToXml;
+
+#[derive(Serialize)]
+pub struct Metadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authors: Option<Vec<Author>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component: Option<Component>,
+}
+
+impl<'a> Default for Metadata {
+    fn default() -> Self {
+        Self {
+            timestamp: Some(Utc::now()),
+            authors: None::<Vec<Author>>,
+            component: None::<Component>,
+        }
+    }
+}
+
+impl<'a> From<&'a Package> for Metadata {
+    fn from(pkg: &'a Package) -> Self {
+        Self {
+            authors: get_authors_from_package(pkg),
+            component: Some(if could_be_application(pkg) {
+                Component::application(pkg).without_scope()
+            } else {
+                Component::library(pkg).without_scope()
+            }),
+            ..Default::default()
+        }
+    }
+}
+
+impl<'a> From<&'a cargo_metadata::Package> for Metadata {
+    fn from(package: &'a cargo_metadata::Package) -> Self {
+        Self {
+            authors: get_authors_from_package_cm(package),
+            component: Some(if is_an_application(package) {
+                Component::application_cm(package).without_scope()
+            } else {
+                Component::library_cm(package).without_scope()
+            }),
+            ..Default::default()
+        }
+    }
+}
+
+impl ToXml for Metadata {
+    fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
+        xml.begin_elem("metadata")?;
+
+        if let Some(timestamp) = &self.timestamp {
+            xml.elem_text(
+                "timestamp",
+                &timestamp.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+            )?;
+        }
+
+        if let Some(authors) = &self.authors {
+            authors.to_xml(xml)?;
+        }
+
+        if let Some(component) = &self.component {
+            component.to_xml(xml)?;
+        }
+
+        xml.end_elem()
+    }
+}
+
+fn get_authors_from_package<'a>(package: &'a Package) -> Option<Vec<Author>> {
+    let mut authors = Vec::new();
+    let mut invalid_authors = Vec::new();
+
+    for author in package.authors() {
+        match Author::from_str(&author) {
+            Ok(author) => authors.push(author),
+            Err(e) => invalid_authors.push((author, e)),
+        }
+    }
+    invalid_authors
+        .into_iter()
+        .for_each(|(author, error)| debug!("Invalid author {}: {:?}", author, error));
+
+    if authors.len() > 0 {
+        return Some(authors);
+    }
+
+    None
+}
+
+fn get_authors_from_package_cm<'a>(package: &'a cargo_metadata::Package) -> Option<Vec<Author>> {
+    let mut authors = Vec::new();
+    let mut invalid_authors = Vec::new();
+
+    for author in &package.authors {
+        match Author::from_str(&author) {
+            Ok(author) => authors.push(author),
+            Err(e) => invalid_authors.push((author, e)),
+        }
+    }
+    invalid_authors
+        .into_iter()
+        .for_each(|(author, error)| debug!("Invalid author {}: {:?}", author, error));
+
+    if authors.len() > 0 {
+        return Some(authors);
+    }
+
+    None
+}
+
+/// Check if `pkg` might be an executable application based on the presence of binary targets.
+fn could_be_application(pkg: &Package) -> bool {
+    pkg.targets()
+        .iter()
+        .any(|tgt| *tgt.kind() == TargetKind::Bin)
+}
+
+/// Is the `package` an application? This will tell us!
+fn is_an_application(pkg: &cargo_metadata::Package) -> bool {
+    let mut kinds = pkg
+        .targets
+        .iter()
+        .map(|target| target.clone().kind)
+        .flatten();
+
+    kinds.any(|kind| kind == "bin")
+}

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -18,57 +18,12 @@
  */
 use std::io;
 
-use cargo::core::Package;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::Serialize;
 use xml_writer::XmlWriter;
 
 use crate::traits::ToXml;
-
-#[derive(Serialize)]
-pub struct ExternalReferences<'a>(Vec<ExternalReference<'a>>);
-
-impl<'a> ExternalReferences<'a> {
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl<'a> From<&'a Package> for ExternalReferences<'a> {
-    fn from(v: &'a Package) -> Self {
-        fn ext_ref<'a>(
-            ref_type: &'a str,
-            uri: &'a Option<String>,
-        ) -> Option<ExternalReference<'a>> {
-            ExternalReference::new(ref_type, uri.as_ref()?).ok()
-        }
-
-        let metadata = v.manifest().metadata();
-        Self(
-            ext_ref("documentation", &metadata.documentation)
-                .into_iter()
-                .chain(ext_ref("website", &metadata.homepage))
-                .chain(ext_ref("other", &metadata.links))
-                .chain(ext_ref("vcs", &metadata.repository))
-                .collect(),
-        )
-    }
-}
-
-impl ToXml for ExternalReferences<'_> {
-    fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
-        if !self.0.is_empty() {
-            xml.begin_elem("externalReferences")?;
-            for reference in &self.0 {
-                reference.to_xml(xml)?;
-            }
-            xml.end_elem()?;
-        }
-
-        Ok(())
-    }
-}
 
 pub struct ExternalReferenceError;
 
@@ -78,30 +33,47 @@ lazy_static! {
 
 #[derive(Serialize)]
 /// A reference to external materials, such as documentation.
-pub struct ExternalReference<'a> {
+pub struct ExternalReference {
     #[serde(rename = "type")]
-    ref_type: &'a str,
-    url: &'a str,
+    pub ref_type: String,
+    pub url: String,
 }
 
-impl<'a> ExternalReference<'a> {
+impl<'a> ExternalReference {
     pub fn new(ref_type: &'a str, url: &'a str) -> Result<Self, ExternalReferenceError> {
         if URL_REGEX.is_match(url) {
-            Ok(Self { ref_type, url })
+            Ok(Self {
+                ref_type: ref_type.to_string(),
+                url: url.to_string(),
+            })
         } else {
             Err(ExternalReferenceError)
         }
     }
 }
 
-impl ToXml for ExternalReference<'_> {
+impl ToXml for ExternalReference {
     fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
         xml.begin_elem("reference")?;
-        xml.attr("type", self.ref_type)?;
+        xml.attr("type", &self.ref_type)?;
         xml.begin_elem("url")?;
         // XXX is this trim() needed? The regex doesn't permit leading or trailing whitespace.
         xml.text(self.url.trim())?;
         xml.end_elem()?;
         xml.end_elem()
+    }
+}
+
+impl ToXml for Vec<ExternalReference> {
+    fn to_xml<W: io::Write>(&self, xml: &mut XmlWriter<W>) -> io::Result<()> {
+        if self.len() > 0 {
+            xml.begin_elem("externalReferences")?;
+            for reference in self {
+                reference.to_xml(xml)?;
+            }
+            xml.end_elem()?;
+        }
+
+        Ok(())
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 use std::io::{self, Write};
 


### PR DESCRIPTION
This new workflow can only be triggered manually, and you can specify the release type (major, minor, patch). It bumps the version in the toml file, and also the lock file, and commits this + a new tag of the version to the main branch.

As well, it has the ability to run `cargo publish` baked in, we just need to turn off dry run and provide a crates token.

I mainly created this so we have a repeatable, transparent release process in the future for the project!

Sorry for the one zillion commits, just look at the state of the files as they sit now :)
