### PR TITLE
Working deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: 'Release type (major, minor, patch)'
+        required: true
+        default: 'patch'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Cargo bump
+        run: |
+          cargo install cargo-bump
+          cargo bump ${{ github.event.inputs.releaseType }}
+      - name: Retrieve new version
+        run: |
+          echo "::set-output name=CARGO_VERSION::$(grep -e '^version' Cargo.toml | cut -d "=" -f2 | tr -d '/"' | tr -d ' ')"
+        id: version
+      - name: Build one time, for sanity
+        run: cargo build
+      - uses: katyo/publish-crates@v1
+        with:
+          args: --verbose --allow-dirty
+          dry-run: true
+      - name: Configure git and add files
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -am "New development bump to ${{steps.version.outputs.CARGO_VERSION}}"
+          git tag -a ${{steps.version.outputs.CARGO_VERSION}} -m "${{steps.version.outputs.CARGO_VERSION}} release"
+          git push
+          git push origin ${{steps.version.outputs.CARGO_VERSION}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,5 +37,4 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git commit -am "New development bump to ${{steps.version.outputs.CARGO_VERSION}}"
           git tag -a ${{steps.version.outputs.CARGO_VERSION}} -m "${{steps.version.outputs.CARGO_VERSION}} release"
-          git push
-          git push origin ${{steps.version.outputs.CARGO_VERSION}}
+          git push --follow-tags

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: katyo/publish-crates@v1
         with:
           args: --verbose --allow-dirty
-          dry-run: true
+          registry-token: ${{ secrets.CARGO_API_KEY }}
       - name: Configure git and add files
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Supercedes #40 , merged everything down into one commit rather than the mess of "LOL how do github actions work"?!

This new workflow can only be triggered manually, and you can specify the release type (major, minor, patch). It bumps the version in the toml file, and also the lock file, and commits this + a new tag of the version to the main branch.

As well, it has the ability to run cargo publish baked in, we just need to turn off dry run and provide a crates token.

I mainly created this so we have a repeatable, transparent release process in the future for the project!