### PR TITLE
Allow nightly to fail

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,3 +27,5 @@ jobs:
       run: cargo +beta test --verbose
     - name: Execute nightly tests
       run: cargo +nightly test --verbose
+      # Allow nightly to fail
+      continue-on-error: true


### PR DESCRIPTION
Nightly Rust might fail for reasons unrelated to our project. We should be aware
of this, but should not have it block pull requests