### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,8 @@ name: Rust CI
 on: [push, pull_request]
 
 jobs:
-  build:
-
+  lint:
+    name: Linting & Coding Standards
     runs-on: ubuntu-latest
 
     steps:
@@ -13,19 +13,41 @@ jobs:
       run: |
         rustup update
         rustup component add clippy
-        rustup install beta
-        rustup install nightly
-    - name: Build
-      run: cargo build --verbose
     - name: Lint
-      run: cargo fmt -- --check
-    - name: Execute stable tests
       run: |
-        cargo test --verbose
+        cargo fmt -- --check
         cargo clippy
-    - name: Execute beta tests
-      run: cargo +beta test --verbose
-    - name: Execute nightly tests
-      run: cargo +nightly test --verbose
-      # Allow nightly to fail
-      continue-on-error: true
+
+  test:
+    name: Test Suite Runs - ${{ matrix.test-arm }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - # test with the current stable version
+            test-arm: 'Stable'
+            rust-version: 'stable'
+            continue-on-error: false
+          - # test with the MSRV version
+            test-arm: 'Minimum Supported Rust Version'
+            rust-version: '1.53.0'
+            continue-on-error: false
+          - # test with the current nightly version (allowed to fail)
+            test-arm: 'Nightly'
+            rust-version: 'nightly'
+            continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - name: Install Rust Toolchain
+      run: |
+        rustup update
+        rustup install ${{ matrix.rust-version }}
+    - name: Build
+      run: cargo +${{ matrix.rust-version }} build --verbose
+      continue-on-error: ${{ matrix.continue-on-error }}
+    - name: Execute tests
+      run: cargo +${{ matrix.rust-version }} test --verbose
+      continue-on-error: ${{ matrix.continue-on-error }}


### PR DESCRIPTION
Use a test matrix to run the build / test process in parallel for different branches
Drop beta and add a potential minimum supported Rust version
Keep the condition that nightly is allowed to fail

This reduces the total CI time to a third of what it previously was and has some other quality of life improvements