### PR TITLE
Enable clippy and compiler warnings to cause failures

### DIFF
--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -25,7 +25,7 @@ pub fn config_from_toml(value: &toml::Value) -> Result<SbomConfig, ConfigError> 
     let wrapper: Result<ConfigWrapper, _> = value.clone().try_into();
 
     wrapper
-        .map(|w| w.cyclonedx.unwrap_or(SbomConfig::empty_config()))
+        .map(|w| w.cyclonedx.unwrap_or_else(SbomConfig::empty_config))
         .map_err(|e| ConfigError::TomlConfigError(format!("{}", e)))
 }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -59,7 +59,7 @@ impl SbomGenerator {
             let package_config = config_from_metadata(member.manifest().custom_metadata())?;
             let config = workspace_config
                 .merge(&package_config)
-                .merge(&config_override);
+                .merge(config_override);
             let dependencies =
                 if config.included_dependencies() == IncludedDependencies::AllDependencies {
                     all_dependencies(&members, &package_ids, &resolve)?
@@ -72,7 +72,7 @@ impl SbomGenerator {
             bom.metadata = get_metadata(member.manifest_path());
 
             let generated = GeneratedSbom {
-                bom: bom,
+                bom,
                 manifest_path: member.manifest_path().to_path_buf(),
                 sbom_config: config,
             };
@@ -112,7 +112,7 @@ pub enum GeneratorError {
 
 fn config_from_metadata(metadata: Option<&toml::Value>) -> Result<SbomConfig, GeneratorError> {
     if let Some(metadata) = metadata {
-        config_from_toml(metadata).map_err(|e| GeneratorError::CustomMetadataTomlError(e))
+        config_from_toml(metadata).map_err(GeneratorError::CustomMetadataTomlError)
     } else {
         Ok(SbomConfig::empty_config())
     }

--- a/cargo-cyclonedx/src/lib.rs
+++ b/cargo-cyclonedx/src/lib.rs
@@ -15,6 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#![deny(clippy::all)]
+#![deny(warnings)]
+
 pub mod author;
 pub mod bom;
 pub mod component;

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
+
 /**
 * A special acknowledgement Ossi Herrala from SensorFu for providing a
 * starting point in which to develop this plugin. The original project
@@ -57,6 +58,8 @@ use clap::Parser;
 use env_logger::Builder;
 use log::LevelFilter;
 
+#[deny(clippy::all)]
+#[deny(warnings)]
 mod cli;
 use cli::{Args, Opts};
 


### PR DESCRIPTION
This will ensure a more consistent style for the project. We can consider
relaxing this restriction as necessary

Signed-off-by: Amy Keibler <amelia.keibler@gmail.com>