### PR TITLE
Update cargo manually & tweak GitHub action behavior

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,10 @@
 name: Rust CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
 
 jobs:
   lint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.59.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08705bf607eb738364863d8435e69f88dd5c131b7f9752777a7ce328085cf95"
+checksum = "bc194fab2f0394703f2794faeb9fcca34301af33eee96fa943b856028f279a77"
 dependencies = [
  "anyhow",
  "atty",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bf633f7ad4e022f63c4197085047af9606a08a3df17badbb7bd3644dc7faeb"
+checksum = "a51c783163bdf4549820b80968d386c94ed45ed23819c93f59cca7ebd97fe0eb"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -350,9 +350,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crates-io"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217138863f33507d7a8edef10fc673c4911679ef7aeb9ff53ee7bb82dc7bf590"
+checksum = "b2d7714dc2b336c5a579a1a2aa2d41c7cd7a31ccb25e2ea908dba8934cfeb75a"
 dependencies = [
  "anyhow",
  "curl",

--- a/cargo-cyclonedx/Cargo.toml
+++ b/cargo-cyclonedx/Cargo.toml
@@ -22,7 +22,7 @@ lto = true
 
 [dependencies]
 anyhow = "1.0.55"
-cargo = "0.59.0"
+cargo = "0.60.0"
 cargo_metadata = "0.14.2"
 chrono = { version = "0.4.19", features = ["serde"] }
 clap = { version = "3.1.2", features = ["derive"] }

--- a/cargo-cyclonedx/src/metadata.rs
+++ b/cargo-cyclonedx/src/metadata.rs
@@ -151,11 +151,7 @@ fn could_be_application(pkg: &Package) -> bool {
 
 /// Is the `package` an application? This will tell us!
 fn is_an_application(pkg: &cargo_metadata::Package) -> bool {
-    let mut kinds = pkg
-        .targets
-        .iter()
-        .map(|target| target.clone().kind)
-        .flatten();
+    let mut kinds = pkg.targets.iter().flat_map(|target| target.clone().kind);
 
     kinds.any(|kind| kind == "bin")
 }

--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -25,9 +25,9 @@ impl NormalizedString {
     pub fn new(value: &str) -> Self {
         let value = value
             .replace("\r\n", " ")
-            .replace("\r", " ")
-            .replace("\n", " ")
-            .replace("\t", " ");
+            .replace('\r', " ")
+            .replace('\n', " ")
+            .replace('\t', " ");
         NormalizedString(value)
     }
 


### PR DESCRIPTION
This failed in CI with an unrelated clippy lint, so updating the code to meet
clippy's expectations.
Updating the CI behavior to only run for "push" events to the main branch. This
should still run for pushes to open PRs, using the "pull_request" event.