### PR TITLE
Add ability to output alternative file names for BOMs

### DIFF
--- a/cargo-cyclonedx/README.md
+++ b/cargo-cyclonedx/README.md
@@ -28,11 +28,21 @@ cargo cyclonedx
 
 This produces a `bom.xml` file adjacent to every `Cargo.toml` file that exists in the workspace.
 
-#### Common command-line options
+#### Command-line options
 
 * `--format` (`xml` or `json`): Defaults to XML output
 * `--all`: Include the transitive dependencies for the project rather than only the top-level dependencies
 * `--manifest-path`: where to find the `Cargo.toml` file if other than the default `cargo` location of the current directory
+* `--output-cdx`: Include `.cdx` in the filename as described in [the recognized file patterns](https://cyclonedx.org/specification/overview/#recognized-file-patterns)
+* `--output-pattern` (`bom` or `package`)
+  * `bom`: Outputs a prefix of `bom` for the filename
+  * `package`: Outputs a prefix using the `Cargo.toml` package name for the filename
+* `--output-prefix`: Outputs a custom prefix for the filename
+
+Notes:
+
+* `--output-cdx`, `--output-pattern`, and `--output-prefix` are a group of options. Passing any of them as arguments will override any `output_options` configurations in `Cargo.toml` files.
+* `--output-pattern` and `--output-prefix` cannot be passed as arguments at the same time.
 
 ### Manifest Configuration
 
@@ -46,6 +56,20 @@ Option                  | Values (*default)   | Description
 ----------------------- | ------------------- | --------------------------
 `included_dependencies` | `top-level`*, `all` | Either only direct (`top-level`) or including transitive (`all`) dependencies
 `format`                | `xml`*, `json`      | Output format for the SBOM
+`output_options`        | `<defined below>`   | A collection of options for file output
+
+#### Output Options
+
+Option    | Values (*default)   | Description
+--------- | ------------------- | --------------------------
+`cdx`     | `true` / `false`*   | Determines if `.cdx` is included in the filename as described in [the recognized file patterns](https://cyclonedx.org/specification/overview/#recognized-file-patterns)
+`pattern` | `bom`*, `package`   | `bom` outputs `bom`, while `package` outputs the `Cargo.toml` package name as the prefix
+`prefix`  | `<filename prefix>` | Outputs a custom value for the prefix
+
+Notes:
+
+* `output_options` values are merged as a single configuration, so a package-level configuration will override the whole workspace-level configuration.
+* `pattern` and `prefix` cannot be configured at the same time.
 
 #### Precedence
 
@@ -56,13 +80,13 @@ Configuration options will be merged and applied in the following order from low
 3. Package manifest metadata
 4. Command-line options
 
-
 #### Example Workspace Configuration
 
 ``` toml
 [workspace.metadata.cyclonedx]
 included_dependencies = "top-level"
 format = "xml"
+output_options = { cdx = false, prefix = "cyclonedx" }
 ```
 
 #### Example Package Configuration
@@ -73,6 +97,7 @@ You can also specify your configuration in using package metadata in your packag
 [package.metadata.cyclonedx]
 included_dependencies = "all"
 format = "json"
+output_options = { cdx = true, pattern = "package" }
 ```
 
 ## Copyright & License

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -52,6 +52,8 @@ impl Args {
         SbomConfig {
             format: self.format,
             included_dependencies,
+            // TODO - Make this real. None while I test TOML parsing
+            output_options: None,
         }
     }
 }

--- a/cargo-cyclonedx/src/lib.rs
+++ b/cargo-cyclonedx/src/lib.rs
@@ -28,6 +28,7 @@ pub mod generator;
 pub mod license;
 pub mod metadata;
 pub mod reference;
+pub mod toml;
 pub mod traits;
 
 pub use crate::{

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
     setup_logging(&args, &mut config)?;
 
     let manifest_path = locate_manifest(&args)?;
-    let cli_config = args.as_config();
+    let cli_config = args.as_config()?;
 
     let ws = Workspace::new(&manifest_path, &config)?;
 
@@ -77,9 +77,11 @@ fn main() -> anyhow::Result<()> {
     let boms = SbomGenerator::create_sboms(ws, &cli_config)?;
     log::trace!("SBOM generation finished");
 
+    log::trace!("SBOM output started");
     for bom in boms {
         bom.write_to_file()?;
     }
+    log::trace!("SBOM output finished");
 
     Ok(())
 }

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -1,0 +1,292 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use crate::config::{self, CdxExtension, PrefixError};
+use crate::config::{CustomPrefix, SbomConfig};
+use crate::format::Format;
+
+use serde::Deserialize;
+use std::convert::{TryFrom, TryInto};
+use std::str::FromStr;
+use thiserror::Error;
+
+pub fn config_from_toml(value: Option<&toml::Value>) -> Result<SbomConfig, ConfigError> {
+    if let Some(value) = value {
+        let wrapper: ConfigWrapper = value
+            .clone()
+            .try_into()
+            .map_err(|e| ConfigError::TomlError(format!("{}", e)))?;
+
+        wrapper.try_into()
+    } else {
+        log::trace!("No Toml provided using default");
+        Ok(SbomConfig::empty_config())
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct ConfigWrapper {
+    pub cyclonedx: Option<TomlConfig>,
+}
+
+impl TryFrom<ConfigWrapper> for SbomConfig {
+    type Error = ConfigError;
+
+    fn try_from(value: ConfigWrapper) -> Result<Self, Self::Error> {
+        if let Some(cyclonedx) = value.cyclonedx {
+            cyclonedx.try_into()
+        } else {
+            Ok(SbomConfig::empty_config())
+        }
+    }
+}
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct TomlConfig {
+    pub format: Option<Format>,
+    pub included_dependencies: Option<IncludedDependencies>,
+    pub output_options: Option<OutputOptions>,
+}
+
+impl TomlConfig {
+    pub fn empty_config() -> Self {
+        Self {
+            format: None,
+            included_dependencies: None,
+            output_options: None,
+        }
+    }
+}
+
+impl TryFrom<TomlConfig> for SbomConfig {
+    type Error = ConfigError;
+
+    fn try_from(value: TomlConfig) -> Result<Self, Self::Error> {
+        let output_options: Option<config::OutputOptions> = match value.output_options {
+            Some(options) => Some(options.try_into()?),
+            None => None,
+        };
+
+        Ok(Self {
+            format: value.format,
+            included_dependencies: value.included_dependencies.map(Into::into),
+            output_options,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+pub enum IncludedDependencies {
+    #[serde(rename(deserialize = "top-level"))]
+    TopLevelDependencies,
+    #[serde(rename(deserialize = "all"))]
+    AllDependencies,
+}
+
+impl Default for IncludedDependencies {
+    fn default() -> Self {
+        Self::TopLevelDependencies
+    }
+}
+
+impl FromStr for IncludedDependencies {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "all" => Ok(Self::AllDependencies),
+            "top-level" => Ok(Self::TopLevelDependencies),
+            _ => Err(format!("Expected all or top-level, got `{}`", s)),
+        }
+    }
+}
+
+impl From<IncludedDependencies> for config::IncludedDependencies {
+    fn from(val: IncludedDependencies) -> Self {
+        match val {
+            IncludedDependencies::TopLevelDependencies => Self::TopLevelDependencies,
+            IncludedDependencies::AllDependencies => Self::AllDependencies,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct OutputOptions {
+    #[serde(rename(deserialize = "cdx"))]
+    pub cdx_extension: Option<bool>,
+    #[serde(rename(deserialize = "pattern"))]
+    pub pattern: Option<Pattern>,
+    #[serde(rename(deserialize = "prefix"))]
+    pub prefix: Option<String>,
+}
+
+impl TryFrom<OutputOptions> for config::OutputOptions {
+    type Error = ConfigError;
+
+    fn try_from(value: OutputOptions) -> Result<Self, Self::Error> {
+        let cdx_extension = match value.cdx_extension {
+            Some(true) => CdxExtension::Included,
+            Some(false) => CdxExtension::NotIncluded,
+            None => CdxExtension::default(),
+        };
+
+        let prefix = match (value.pattern, value.prefix) {
+            (Some(pattern), None) => Ok(Some(config::Prefix::Pattern(pattern.into()))),
+            (None, Some(prefix)) => {
+                let prefix = CustomPrefix::new(prefix)?;
+                Ok(Some(config::Prefix::Custom(prefix)))
+            }
+            (None, None) => Ok(None),
+            _ => Err(ConfigError::ValidationError(
+                "OutputOptions can contain either prefix or pattern, got both".to_string(),
+            )),
+        }?;
+        Ok(Self {
+            cdx_extension,
+            prefix: prefix.unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[serde(rename_all(deserialize = "lowercase"))]
+pub enum Pattern {
+    Bom,
+    Package,
+}
+
+impl Default for Pattern {
+    fn default() -> Self {
+        Self::Bom
+    }
+}
+
+impl FromStr for Pattern {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "bom" => Ok(Self::Bom),
+            "package" => Ok(Self::Package),
+            _ => Err(format!("Expected bom or package, got `{}`", s)),
+        }
+    }
+}
+
+impl From<Pattern> for config::Pattern {
+    fn from(val: Pattern) -> Self {
+        match val {
+            Pattern::Bom => Self::Bom,
+            Pattern::Package => Self::Package,
+        }
+    }
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ConfigError {
+    #[error("Failed to deserialize configuration from Toml: {0}")]
+    TomlError(String),
+
+    #[error("Failed to validate configuration: {0}")]
+    ValidationError(String),
+
+    #[error("Invalid prefix from Toml")]
+    CustomPrefixError(#[from] PrefixError),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_should_deserialize_from_toml_value() {
+        let toml = r#"
+[cyclonedx]
+format = "json"
+included_dependencies = "top-level"
+output_options = { cdx = true, pattern = "bom", prefix = "tacos" }
+"#;
+
+        let actual: ConfigWrapper = toml::from_str(toml).expect("Failed to parse toml");
+
+        let expected = TomlConfig {
+            format: Some(Format::Json),
+            included_dependencies: Some(IncludedDependencies::TopLevelDependencies),
+            output_options: Some(OutputOptions {
+                cdx_extension: Some(true),
+                prefix: Some("tacos".to_string()),
+                pattern: Some(Pattern::Bom),
+            }),
+        };
+
+        assert_eq!(actual.cyclonedx, Some(expected));
+    }
+
+    #[test]
+    fn it_should_return_an_error_for_mutually_exclusive_options() {
+        let options = OutputOptions {
+            cdx_extension: Some(true),
+            pattern: Some(Pattern::Bom),
+            prefix: Some("tacos".to_string()),
+        };
+
+        let actual: Result<config::OutputOptions, ConfigError> = options.try_into();
+
+        let actual = actual
+            .expect_err("Should not have been able to convert with mutually exclusive options");
+
+        assert_eq!(
+            actual,
+            ConfigError::ValidationError(
+                "OutputOptions can contain either prefix or pattern, got both".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn it_should_convert_to_config_output_options() {
+        let options = OutputOptions {
+            cdx_extension: Some(true),
+            pattern: Some(Pattern::Bom),
+            prefix: None,
+        };
+
+        let actual: Result<config::OutputOptions, ConfigError> = options.try_into();
+
+        let actual = actual.expect("Should have been able to convert to config::OutputOptions");
+
+        let expected = config::OutputOptions {
+            cdx_extension: config::CdxExtension::Included,
+            prefix: config::Prefix::Pattern(config::Pattern::Bom),
+        };
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn it_should_ignore_other_packages_from_toml_value() {
+        let toml = r#"
+[notourpackage]
+format = "json"
+included_dependencies = "top-level"
+output_options = { cdx = true, pattern = "bom", prefix = "" }
+"#;
+
+        let actual: ConfigWrapper = toml::from_str(toml).expect("Failed to parse toml");
+
+        assert_eq!(actual.cyclonedx, None);
+    }
+}


### PR DESCRIPTION
- Fixes #104
- Add additional output options to CLI args and Toml config
- Adds ability to add .cdx to file extension, use predefined prefixes, or a custom prefix. 
- Refactored Toml parsing into a separate model. 
- Improved tracing output.