### PR TITLE
Initial Library Documentation

### DIFF
--- a/cyclonedx-bom/README.md
+++ b/cyclonedx-bom/README.md
@@ -12,6 +12,12 @@ The [CycloneDX](https://cyclonedx.org/) library provides JSON and XML serializat
 
 CycloneDX is a lightweight SBOM specification that is easily created, human and machine readable, and simple to parse.
 
+The library is intended to enable developers to:
+
+- Construct SBOM documents that conform the CycloneDX specification
+- Parse and validate JSON and XML SBOM documents
+- Perform modifications to BOM documents (e.g. merging multiple BOMs using a variety of algorithms)
+
 ## Usage
 
 ### Read and validate an SBOM

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -19,11 +19,19 @@
 #![deny(clippy::all)]
 #![deny(warnings)]
 
-//! The [CycloneDX](https://cyclonedx.org/) library provides JSON and XML serialization and derserialization of Software Bill-of-Materials (SBOM) files.
+//! The `cyclonedx-bom` library provides JSON and XML serialization and derserialization of Software Bill-of-Materials (SBOM) files.
 //!
-//! CycloneDX is a lightweight SBOM specification that is easily created, human and machine readable, and simple to parse.
+//! [CycloneDX](https://cyclonedx.org/) is a lightweight SBOM specification that is easily created, human and machine readable, and simple to parse.
+//!
+//! The library is intended to enable developers to:
+//!
+//! - Construct SBOM documents that conform the CycloneDX specification
+//! - Parse and validate JSON and XML SBOM documents
+//! - Perform modifications to BOM documents (e.g. merging multiple BOMs using a variety of algorithms)
 //!
 //! ## Read and validate an SBOM
+//!
+//! Given an input implements [std::io::Read], parse the value into a [`Bom`](crate::models::bom::Bom) and then use the [`Validate`](crate::validation::Validate) trait to ensure that it is a valid BOM.
 //!
 //! ```rust
 //! use cyclonedx_bom::models::bom::Bom;
@@ -42,6 +50,8 @@
 //! ```
 //!
 //! ## Create and output an SBOM
+//!
+//! Given an output implements [std::io::Write], output the [`Bom`](crate::models::bom::Bom) as JSON.
 //!
 //! ```rust
 //! use cyclonedx_bom::external_models::normalized_string::NormalizedString;

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -19,6 +19,76 @@
 #![deny(clippy::all)]
 #![deny(warnings)]
 
+//! The [CycloneDX](https://cyclonedx.org/) library provides JSON and XML serialization and derserialization of Software Bill-of-Materials (SBOM) files.
+//!
+//! CycloneDX is a lightweight SBOM specification that is easily created, human and machine readable, and simple to parse.
+//!
+//! ## Read and validate an SBOM
+//!
+//! ```rust
+//! use cyclonedx_bom::models::bom::Bom;
+//! use cyclonedx_bom::validation::{Validate, ValidationResult};
+//!
+//! let bom_json = r#"{
+//!   "bomFormat": "CycloneDX",
+//!   "specVersion": "1.3",
+//!   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+//!   "version": 1
+//! }"#;
+//! let bom = Bom::parse_from_json_v1_3(bom_json.as_bytes()).expect("Failed to parse BOM");
+//!
+//! let validation_result = bom.validate().expect("Failed to validate BOM");
+//! assert_eq!(validation_result, ValidationResult::Passed);
+//! ```
+//!
+//! ## Create and output an SBOM
+//!
+//! ```rust
+//! use cyclonedx_bom::external_models::normalized_string::NormalizedString;
+//! use cyclonedx_bom::models::{
+//!     bom::{Bom, UrnUuid},
+//!     metadata::Metadata,
+//!     tool::{Tool, Tools},
+//! };
+//!
+//! let bom = Bom {
+//!     serial_number: Some(
+//!         UrnUuid::new("urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79".to_string())
+//!             .expect("Failed to create UrnUuid"),
+//!     ),
+//!     metadata: Some(Metadata {
+//!         tools: Some(Tools(vec![Tool {
+//!             name: Some(NormalizedString::new("my_tool")),
+//!             ..Tool::default()
+//!         }])),
+//!         ..Metadata::default()
+//!     }),
+//!     ..Bom::default()
+//! };
+//!
+//! let mut output = Vec::<u8>::new();
+//!
+//! bom.output_as_json_v1_3(&mut output)
+//!     .expect("Failed to write BOM");
+//! let output = String::from_utf8(output).expect("Failed to read output as a string");
+//! assert_eq!(
+//!     output,
+//!     r#"{
+//!   "bomFormat": "CycloneDX",
+//!   "specVersion": "1.3",
+//!   "version": 1,
+//!   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+//!   "metadata": {
+//!     "tools": [
+//!       {
+//!         "name": "my_tool"
+//!       }
+//!     ]
+//!   }
+//! }"#
+//! );
+//! ```
+
 pub mod errors;
 pub mod external_models;
 pub mod models;

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -49,6 +49,7 @@ pub struct Bom {
 }
 
 impl Bom {
+    /// Parse the input as a JSON document conforming to [version 1.3 of the specification](https://cyclonedx.org/docs/1.3/json/)
     pub fn parse_from_json_v1_3<R: std::io::Read>(
         mut reader: R,
     ) -> Result<Self, crate::errors::JsonReadError> {
@@ -56,6 +57,7 @@ impl Bom {
         Ok(bom.into())
     }
 
+    /// Parse the input as an XML document conforming to [version 1.3 of the specification](https://cyclonedx.org/docs/1.3/xml/)
     pub fn parse_from_xml_v1_3<R: std::io::Read>(
         reader: R,
     ) -> Result<Self, crate::errors::XmlReadError> {
@@ -65,6 +67,7 @@ impl Bom {
         Ok(bom.into())
     }
 
+    /// Output as a JSON document conforming to [version 1.3 of the specification](https://cyclonedx.org/docs/1.3/json/)
     pub fn output_as_json_v1_3<W: std::io::Write>(
         self,
         writer: &mut W,
@@ -73,7 +76,7 @@ impl Bom {
         serde_json::to_writer_pretty(writer, &bom)?;
         Ok(())
     }
-
+    /// Output as an XML document conforming to [version 1.3 of the specification](https://cyclonedx.org/docs/1.3/xml/)
     pub fn output_as_xml_v1_3<W: std::io::Write>(
         self,
         writer: &mut W,
@@ -87,6 +90,7 @@ impl Bom {
 }
 
 impl Default for Bom {
+    /// Construct a BOM with a default `version` of `1` and `serial_number` with a random UUID
     fn default() -> Self {
         Self {
             version: 1,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -428,12 +428,12 @@ impl Validate for UrnUuid {
                     context,
                 }],
             }),
-            Err(e) => Err(e.clone().into()),
+            Err(e) => Err(e.into()),
         }
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum UrnUuidError {
     InvalidUrnUuid(String),
 }

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -26,7 +26,7 @@ use crate::validation::{
     Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct Metadata {
     pub timestamp: Option<DateTime>,
     pub tools: Option<Tools>,

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -22,7 +22,7 @@ use crate::validation::{
     Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct Tool {
     pub vendor: Option<NormalizedString>,
     pub name: Option<NormalizedString>,


### PR DESCRIPTION
Start documenting the `cyclonedx-bom` library

- Initial examples for the `README.md` and `lib.rs` files
- Tweak the ergonomics of `UrnUuid` to enable construction from a `Uuid` or a `String`
- Add a few `Default` implementations where it makes sense