### PR TITLE
Add improved handling for invalid SPDX expressions

### DIFF
--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -65,6 +65,16 @@ pub struct License {
     pub url: Option<Uri>,
 }
 
+impl License {
+    pub fn named_license(license: &str) -> Self {
+        Self {
+            license_identifier: LicenseIdentifier::Name(NormalizedString::new(license)),
+            text: None,
+            url: None,
+        }
+    }
+}
+
 impl Validate for License {
     fn validate_with_context(
         &self,


### PR DESCRIPTION
Resolves #238 

- Falls back to lax parsing if the SPDX expression fails strict parsing
- Lax parsing is only successful if it can convert to a valid SPDX expression
- Falls back to a named license if lax parsing fails