### PR TITLE
Upgrade Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
  "bytesize",
  "cargo-platform",
  "cargo-util",
- "clap",
+ "clap 3.2.22",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -157,7 +157,7 @@ version = "0.3.7"
 dependencies = [
  "anyhow",
  "cargo",
- "clap",
+ "clap 4.0.10",
  "cyclonedx-bom",
  "env_logger",
  "log",
@@ -223,20 +223,33 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.2.18"
+name = "clap"
+version = "4.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "3b1a0a4208c6c483b952ad35c6eed505fc13b46f08f631b81e828084a9318d74"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db342ce9fda24fb191e2ed4e102055a4d381c1086a06630174cd8da8d5d917ce"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -250,6 +263,15 @@ name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]

--- a/cargo-cyclonedx/Cargo.toml
+++ b/cargo-cyclonedx/Cargo.toml
@@ -24,7 +24,7 @@ lto = true
 [dependencies]
 anyhow = "1.0.65"
 cargo = "0.65.0"
-clap = { version = "3.2.22", features = ["derive"] }
+clap = { version = "4.0.10", features = ["derive"] }
 cyclonedx-bom = { version = "0.3.5", path = "../cyclonedx-bom" }
 env_logger = "0.9.1"
 log = "0.4.17"

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -22,7 +22,7 @@ pub enum Opts {
 #[clap(group(ArgGroup::new("prefix-or-pattern-group").required(false).args(&["output-prefix", "output-pattern"])))]
 pub struct Args {
     /// Path to Cargo.toml
-    #[clap(long = "manifest-path", value_name = "PATH", parse(from_os_str))]
+    #[clap(long = "manifest-path", value_name = "PATH")]
     pub manifest_path: Option<path::PathBuf>,
 
     /// Output BOM format: json, xml
@@ -30,8 +30,8 @@ pub struct Args {
     pub format: Option<Format>,
 
     /// Use verbose output (-vv very verbose/build.rs output)
-    #[clap(long = "verbose", short = 'v', parse(from_occurrences))]
-    pub verbose: u32,
+    #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
+    pub verbose: u8,
 
     /// No output printed to stdout
     #[clap(long = "quiet", short = 'q')]
@@ -42,7 +42,7 @@ pub struct Args {
     pub all: bool,
 
     /// List only top-level dependencies (default)
-    #[clap(long = "top-level")]
+    #[clap(name = "top-level", long = "top-level")]
     pub top_level: bool,
 
     /// Prepend file extension with .cdx
@@ -50,11 +50,19 @@ pub struct Args {
     pub output_cdx: bool,
 
     /// Prefix patterns to use for the filename: bom, package
-    #[clap(long = "output-pattern", value_name = "PATTERN")]
+    #[clap(
+        name = "output-pattern",
+        long = "output-pattern",
+        value_name = "PATTERN"
+    )]
     pub output_pattern: Option<Pattern>,
 
     /// Custom prefix string to use for the filename
-    #[clap(long = "output-prefix", value_name = "FILENAME_PREFIX")]
+    #[clap(
+        name = "output-prefix",
+        long = "output-prefix",
+        value_name = "FILENAME_PREFIX"
+    )]
     pub output_prefix: Option<String>,
 }
 

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -110,7 +110,7 @@ fn setup_logging(args: &Args, config: &mut Config) -> anyhow::Result<()> {
 
     // configure logging level of cargo to match what was passed via CLI
     config.configure(
-        args.verbose,
+        args.verbose as u32,
         args.quiet,
         None,
         false,


### PR DESCRIPTION
- Use name to reference flags with dashes
- Switch the verbose to be a u8
- OS string parsing works by default now without needing to be parsed