### PR TITLE
Add public interfaces

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -17,6 +17,7 @@
  */
 
 use std::collections::HashSet;
+use std::fmt;
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -406,6 +407,12 @@ impl UrnUuid {
 
     pub fn generate() -> Self {
         Self::from(uuid::Uuid::new_v4())
+    }
+}
+
+impl fmt::Display for UrnUuid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -16,6 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::convert::TryFrom;
+
+use crate::external_models::spdx::SpdxIdentifierError;
 use crate::external_models::{
     normalized_string::NormalizedString,
     spdx::{SpdxExpression, SpdxIdentifier},
@@ -84,6 +87,22 @@ impl License {
             text: None,
             url: None,
         }
+    }
+
+    /// Constructs a `License` with an SPDX license identifier
+    /// ```
+    /// use cyclonedx_bom::models::license::License;
+    ///
+    /// let license = License::license_id("LGPL-3.0-or-later");
+    /// ```
+    pub fn license_id(license: &str) -> Result<Self, SpdxIdentifierError> {
+        Ok(Self {
+            license_identifier: LicenseIdentifier::SpdxId(SpdxIdentifier::try_from(
+                license.to_owned(),
+            )?),
+            text: None,
+            url: None,
+        })
     }
 }
 

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -29,7 +29,7 @@ use crate::{
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_propertyType). Please see the
 /// [CycloneDX use case](https://cyclonedx.org/use-cases/#properties--name-value-store) for more information and examples.
 #[derive(Debug, PartialEq, Eq)]
-pub struct Properties(pub(crate) Vec<Property>);
+pub struct Properties(pub Vec<Property>);
 
 impl Validate for Properties {
     fn validate_with_context(


### PR DESCRIPTION
Thank you for making the [cyclonedx-bom](https://github.com/nikstur/cyclonedx-rust-cargo/tree/main/cyclonedx-bom) crate reusable!

I'm working on creating a SBOM tool for Nix (as in NixOS) and I am using your crate to convert the Nix internal representaton into a valid CycloneDX SBOM. However, I am missing a few public interfaces. I thought it would be nice to upstream them, since they surely will be useful for others too (e.g. #227).

If there is anything you want to change or approach differently please let me know!