### PR TITLE
Lookup top level dependencies also from resolved dependency graph

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -385,10 +385,8 @@ fn top_level_dependencies(
         .flat_map(|m| {
             resolve
                 .deps(m.package_id())
-                .filter_map(move |r| match r.0 == m.package_id() {
-                    true => Some(r.1),
-                    false => None,
-                })
+                .filter(move |r| r.0 == m.package_id())
+                .map(|(_, dependency)| dependency)
         })
         .flatten()
         .filter(|d: &&Dependency| d.kind() == DepKind::Normal);


### PR DESCRIPTION
Instead of using the declared dependency, this change now uses to the resolved dependency graph to look up the top level dependencies.

The difference is, that a declared dependency may be overridden. And so the source no longer matches, which results in the dependency missing from the final SBOM.

Using the resolved dependency graph, overriding dependencies is covered as well.

This also aligns with the "all dependencies" approach, which also uses the resolved dependencies.

Closes #364