### PR TITLE
Use thin instead of fat LTO for leaner release builds

### DIFF
--- a/cargo-cyclonedx/Cargo.toml
+++ b/cargo-cyclonedx/Cargo.toml
@@ -19,7 +19,7 @@ name = "cargo-cyclonedx"
 path = "src/main.rs"
 
 [profile.release]
-lto = true
+lto = "thin"
 
 [dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
Since `cargo install cargo-cyclonedx` is the recommended way of installing this crate, the resource consumption of release builds is quite important for the user experience. Hence this commit changes the LTO mode from "fat" to "thin" which significantly improves the build time by improving parallelism at a marginal cost of runtime performance.

As an example, I ran `/usr/bin/time cargo install cargo-cyclonedx` on consumer-grade notebook with and without the environment variable `CARGO_PROFILE_RELEASE_LTO` set to `thin`. This improves the build time from 1min50s to 1min, i.e. almost halves it.