### PR TITLE
Generate output per target, not per package

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -1,10 +1,7 @@
-use cargo_cyclonedx::{
-    config::SbomConfig,
-    format::Format,
-};
+use cargo_cyclonedx::config::IncludedDependencies;
+use cargo_cyclonedx::{config::SbomConfig, format::Format};
 use clap::{ArgGroup, Parser};
 use std::path;
-use cargo_cyclonedx::config::IncludedDependencies;
 
 #[derive(Parser, Debug)]
 #[clap(bin_name = "cargo")]

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -1,13 +1,10 @@
 use cargo_cyclonedx::{
-    config::{
-        CdxExtension, IncludedDependencies, OutputOptions,
-        PrefixError, SbomConfig,
-    },
+    config::SbomConfig,
     format::Format,
 };
 use clap::{ArgGroup, Parser};
 use std::path;
-use thiserror::Error;
+use cargo_cyclonedx::config::IncludedDependencies;
 
 #[derive(Parser, Debug)]
 #[clap(bin_name = "cargo")]
@@ -36,59 +33,26 @@ pub struct Args {
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 
-    /// List all dependencies instead of only top-level ones
+    /// List all dependencies instead of only top-level ones (default)
     #[clap(long = "all", short = 'a')]
     pub all: bool,
 
-    /// List only top-level dependencies (default)
+    /// List only top-level dependencies
     #[clap(name = "top-level", long = "top-level")]
     pub top_level: bool,
-
-    /// Prepend file extension with .cdx
-    #[clap(long = "output-cdx")]
-    pub output_cdx: bool,
-
-    /// Custom prefix string to use for the filename
-    #[clap(
-        name = "output-prefix",
-        long = "output-prefix",
-        value_name = "FILENAME_PREFIX"
-    )]
-    pub output_prefix: Option<String>,
 }
 
 impl Args {
-    pub fn as_config(&self) -> Result<SbomConfig, ArgsError> {
+    pub fn as_config(&self) -> SbomConfig {
         let included_dependencies = match (self.all, self.top_level) {
             (true, _) => Some(IncludedDependencies::AllDependencies),
             (_, true) => Some(IncludedDependencies::TopLevelDependencies),
             _ => None,
         };
 
-        let cdx_extension = match self.output_cdx {
-            true => Some(CdxExtension::Included),
-            false => None,
-        };
-
-        let output_options = match cdx_extension {
-            Some(cdx_extension) => Some(OutputOptions {
-                cdx_extension,
-            }),
-            _ => Some(OutputOptions {
-                cdx_extension: CdxExtension::default(),
-            }),
-        };
-
-        Ok(SbomConfig {
+        SbomConfig {
             format: self.format,
             included_dependencies,
-            output_options,
-        })
+        }
     }
-}
-
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum ArgsError {
-    #[error("Invalid prefix from CLI")]
-    CustomPrefixError(#[from] PrefixError),
 }

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
  */
 use crate::format::Format;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SbomConfig {
     pub format: Option<Format>,
     pub included_dependencies: Option<IncludedDependencies>,

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -25,7 +25,6 @@ use crate::format::Format;
 pub struct SbomConfig {
     pub format: Option<Format>,
     pub included_dependencies: Option<IncludedDependencies>,
-    pub output_options: Option<OutputOptions>,
 }
 
 impl SbomConfig {
@@ -33,7 +32,6 @@ impl SbomConfig {
         Self {
             format: None,
             included_dependencies: None,
-            output_options: None,
         }
     }
 
@@ -41,10 +39,6 @@ impl SbomConfig {
         SbomConfig {
             format: other.format.or(self.format),
             included_dependencies: other.included_dependencies.or(self.included_dependencies),
-            output_options: other
-                .output_options
-                .clone()
-                .or_else(|| self.output_options.clone()),
         }
     }
 
@@ -54,10 +48,6 @@ impl SbomConfig {
 
     pub fn included_dependencies(&self) -> IncludedDependencies {
         self.included_dependencies.unwrap_or_default()
-    }
-
-    pub fn output_options(&self) -> OutputOptions {
-        self.output_options.clone().unwrap_or_default()
     }
 }
 

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -75,17 +75,9 @@ impl FromStr for IncludedDependencies {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct OutputOptions {
     pub cdx_extension: CdxExtension,
-}
-
-impl Default for OutputOptions {
-    fn default() -> Self {
-        Self {
-            cdx_extension: CdxExtension::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -59,7 +59,7 @@ pub enum IncludedDependencies {
 
 impl Default for IncludedDependencies {
     fn default() -> Self {
-        Self::TopLevelDependencies
+        Self::AllDependencies
     }
 }
 

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -88,14 +88,12 @@ impl FromStr for IncludedDependencies {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputOptions {
     pub cdx_extension: CdxExtension,
-    pub prefix: Prefix,
 }
 
 impl Default for OutputOptions {
     fn default() -> Self {
         Self {
             cdx_extension: CdxExtension::default(),
-            prefix: Prefix::Pattern(Pattern::Bom),
         }
     }
 }
@@ -121,41 +119,6 @@ impl Default for CdxExtension {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Prefix {
-    Pattern(Pattern),
-    Custom(CustomPrefix),
-}
-
-impl Default for Prefix {
-    fn default() -> Self {
-        Self::Pattern(Pattern::default())
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Pattern {
-    Bom,
-    Package,
-}
-
-impl Default for Pattern {
-    fn default() -> Self {
-        Self::Bom
-    }
-}
-
-impl FromStr for Pattern {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "bom" => Ok(Self::Bom),
-            "package" => Ok(Self::Package),
-            _ => Err(format!("Expected bom or package, got `{}`", s)),
-        }
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CustomPrefix(String);

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -109,7 +109,6 @@ impl Default for CdxExtension {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CustomPrefix(String);
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -25,7 +25,7 @@ use cargo::core::Package;
 use cargo::core::PackageSet;
 use cargo::core::Resolve;
 use cargo::core::Workspace;
-use cargo::core::{Dependency, Target, TargetKind};
+use cargo::core::{Target, TargetKind};
 use cargo::ops;
 
 use cyclonedx_bom::external_models::normalized_string::NormalizedString;

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -101,10 +101,10 @@ impl SbomGenerator {
             // And if we only use the name of the package it means users will have to alter the metadata manually to get the correct name.
             for target in member.targets() {
                 log::trace!(
-                    "Processing Target: {}/{}/{:?}",
+                    "Processing Target: {}/{}/{}",
                     member.name(),
                     target.name(),
-                    target.description_named()
+                    target.kind().description()
                 );
 
                 // We only want to generate SBOMs for binaries and libraries (this matches all kinds of libraries for example cdylib, rlib etc.)
@@ -127,7 +127,7 @@ impl SbomGenerator {
                 let generated = GeneratedSbom {
                     bom,
                     manifest_path: member.manifest_path().to_path_buf(),
-                    package_name: member.name().to_string(),
+                    package_name: target.name().to_string(),
                     sbom_config: config.clone(),
                     target_kind: target.kind().clone(),
                 };

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -147,7 +147,7 @@ fn create_bom(
 
     let components: Vec<_> = dependencies
         .into_iter()
-        .map(|package| create_component(&package))
+        .map(|package| create_component(&package, ))
         .collect();
 
     bom.components = Some(Components(components));
@@ -159,8 +159,8 @@ fn create_bom(
     Ok(bom)
 }
 
-fn create_component(package: &Package) -> Component {
-    let name = package.name().to_owned().trim().to_string();
+fn create_component(package: &Package, target: &Target) -> Component {
+    let name = target.name().to_owned().trim().to_string();
     let version = package.version().to_string();
 
     let purl = match Purl::new("cargo", &name, &version) {
@@ -311,7 +311,7 @@ fn create_metadata(package: &Package, target: &Target) -> Result<Metadata, Gener
         metadata.authors = Some(authors);
     }
 
-    let mut component = create_component(package);
+    let mut component = create_component(package, target);
 
     component.component_type = get_classification(target);
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -146,7 +146,7 @@ fn create_bom(
     let mut bom = Bom::default();
 
     let components: Vec<_> = dependencies
-        .into_iter()
+        .iter()
         .map(|package| create_component(package, package.name().as_str()))
         .collect();
     bom.components = Some(Components(components));
@@ -160,7 +160,7 @@ fn create_bom(
 fn create_component(package: &Package, name: &str) -> Component {
     let version = package.version().to_string();
 
-    let purl = match Purl::new("cargo", &name, &version) {
+    let purl = match Purl::new("cargo", name, &version) {
         Ok(purl) => Some(purl),
         Err(e) => {
             log::error!("Package {} has an invalid Purl: {} ", package.name(), e);
@@ -170,7 +170,7 @@ fn create_component(package: &Package, name: &str) -> Component {
 
     let mut component = Component::new(
         Classification::Library,
-        &name,
+        name,
         &version,
         purl.clone().map(|p| p.to_string()),
     );

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -147,7 +147,7 @@ fn create_bom(
 
     let components: Vec<_> = dependencies
         .into_iter()
-        .map(|package| create_component(&package, ))
+        .map(|package| create_component(&package, target))
         .collect();
 
     bom.components = Some(Components(components));

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -94,7 +94,7 @@ impl SbomGenerator {
                 if config.included_dependencies() == IncludedDependencies::TopLevelDependencies {
                     top_level_dependencies(&members, &package_ids, &resolve)?
                 } else {
-                    all_dependencies(&members, &package_ids, &resolve)?
+                    all_dependencies(&package_ids, &resolve)?
                 };
 
             // A package (member) can contain multiple targets (e.g. a single library, one or more binaries, tests, ...)
@@ -449,7 +449,6 @@ fn top_level_dependencies(
 }
 
 fn all_dependencies(
-    members: &[Package],
     package_ids: &PackageSet<'_>,
     resolve: &Resolve,
 ) -> Result<BTreeSet<Package>, GeneratorError> {
@@ -460,10 +459,6 @@ fn all_dependencies(
         let package = package_ids
             .get_one(package_id)
             .map_err(|error| GeneratorError::PackageError { package_id, error })?;
-        if members.contains(package) {
-            // Skip listing our own packages in our workspace
-            continue;
-        }
         dependencies.insert(package.to_owned());
     }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -16,8 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use crate::config::IncludedDependencies;
-use crate::config::Pattern;
-use crate::config::Prefix;
 use crate::config::SbomConfig;
 use crate::format::Format;
 use crate::toml::config_from_toml;
@@ -513,14 +511,9 @@ impl GeneratedSbom {
 
     fn filename(&self) -> String {
         let output_options = self.sbom_config.output_options();
-        let prefix = match output_options.prefix {
-            Prefix::Pattern(Pattern::Bom) => "bom".to_string(),
-            Prefix::Pattern(Pattern::Package) => format!(
-                "{}-{}",
-                self.package_name.clone(),
-                self.target_kind.description()
-            ),
-            Prefix::Custom(c) => c.to_string(),
+        let prefix = match self.target_kind {
+            TargetKind::Lib(_) => format!("lib{}", self.package_name.clone()),
+            _ => self.package_name.clone(),
         };
 
         format!(

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -109,10 +109,7 @@ impl SbomGenerator {
                 );
 
                 // We only want to generate SBOMs for binaries and libraries (this matches all kinds of libraries, for example cdylib, rlib etc.)
-                if !matches!(
-                    target.kind(),
-                    TargetKind::Bin | TargetKind::Lib(_)
-                ) {
+                if !matches!(target.kind(), TargetKind::Bin | TargetKind::Lib(_)) {
                     log::trace!(
                         "Skipping target {}/{} as it is not a binary or lib target",
                         member.name(),
@@ -313,7 +310,6 @@ fn create_metadata(package: &Package, target: &Target) -> Result<Metadata, Gener
 
     let mut component = create_component(package, target.name());
 
-
     component.component_type = get_classification(target);
 
     metadata.component = Some(component);
@@ -502,11 +498,7 @@ impl GeneratedSbom {
             _ => self.package_name.clone(),
         };
 
-        format!(
-            "{}.cdx.{}",
-            prefix,
-            self.sbom_config.format()
-        )
+        format!("{}.cdx.{}", prefix, self.sbom_config.format())
     }
 }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -110,7 +110,7 @@ impl SbomGenerator {
                 // We only want to generate SBOMs for binaries and libraries (this matches all kinds of libraries for example cdylib, rlib etc.)
                 if !matches!(
                     target.kind(),
-                    TargetKind::Bin | TargetKind::Lib(_) | TargetK
+                    TargetKind::Bin | TargetKind::Lib(_)
                 ) {
                     log::trace!(
                         "Skipping target {}/{} as it is not a binary or lib target",

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -65,13 +65,13 @@ use cli::{Args, Opts};
 
 fn main() -> anyhow::Result<()> {
     let Opts::Bom(args) = Opts::parse();
-    let mut config = Config::default()?;
-    setup_logging(&args, &mut config)?;
+    let mut cargo_config = Config::default()?;
+    setup_logging(&args, &mut cargo_config)?;
 
     let manifest_path = locate_manifest(&args)?;
-    let cli_config = args.as_config()?;
+    let cli_config = args.as_config();
 
-    let ws = Workspace::new(&manifest_path, &config)?;
+    let ws = Workspace::new(&manifest_path, &cargo_config)?;
 
     log::trace!("SBOM generation started");
     let boms = SbomGenerator::create_sboms(ws, &cli_config)?;

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 use crate::config::{self, CdxExtension, PrefixError};
-use crate::config::{CustomPrefix, SbomConfig};
+use crate::config::{SbomConfig};
 use crate::format::Format;
 
 use serde::Deserialize;
@@ -143,20 +143,8 @@ impl TryFrom<OutputOptions> for config::OutputOptions {
             None => CdxExtension::default(),
         };
 
-        let prefix = match (value.pattern, value.prefix) {
-            (Some(pattern), None) => Ok(Some(config::Prefix::Pattern(pattern.into()))),
-            (None, Some(prefix)) => {
-                let prefix = CustomPrefix::new(prefix)?;
-                Ok(Some(config::Prefix::Custom(prefix)))
-            }
-            (None, None) => Ok(None),
-            _ => Err(ConfigError::ValidationError(
-                "OutputOptions can contain either prefix or pattern, got both".to_string(),
-            )),
-        }?;
         Ok(Self {
             cdx_extension,
-            prefix: prefix.unwrap_or_default(),
         })
     }
 }
@@ -182,15 +170,6 @@ impl FromStr for Pattern {
             "bom" => Ok(Self::Bom),
             "package" => Ok(Self::Package),
             _ => Err(format!("Expected bom or package, got `{}`", s)),
-        }
-    }
-}
-
-impl From<Pattern> for config::Pattern {
-    fn from(val: Pattern) -> Self {
-        match val {
-            Pattern::Bom => Self::Bom,
-            Pattern::Package => Self::Package,
         }
     }
 }

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -75,15 +75,9 @@ impl TryFrom<TomlConfig> for SbomConfig {
     type Error = ConfigError;
 
     fn try_from(value: TomlConfig) -> Result<Self, Self::Error> {
-        let output_options: Option<config::OutputOptions> = match value.output_options {
-            Some(options) => Some(options.try_into()?),
-            None => None,
-        };
-
         Ok(Self {
             format: value.format,
             included_dependencies: value.included_dependencies.map(Into::into),
-            output_options,
         })
     }
 }
@@ -215,27 +209,6 @@ output_options = { cdx = true, pattern = "bom", prefix = "tacos" }
     }
 
     #[test]
-    fn it_should_return_an_error_for_mutually_exclusive_options() {
-        let options = OutputOptions {
-            cdx_extension: Some(true),
-            pattern: Some(Pattern::Bom),
-            prefix: Some("tacos".to_string()),
-        };
-
-        let actual: Result<config::OutputOptions, ConfigError> = options.try_into();
-
-        let actual = actual
-            .expect_err("Should not have been able to convert with mutually exclusive options");
-
-        assert_eq!(
-            actual,
-            ConfigError::ValidationError(
-                "OutputOptions can contain either prefix or pattern, got both".to_string()
-            )
-        );
-    }
-
-    #[test]
     fn it_should_convert_to_config_output_options() {
         let options = OutputOptions {
             cdx_extension: Some(true),
@@ -249,7 +222,6 @@ output_options = { cdx = true, pattern = "bom", prefix = "tacos" }
 
         let expected = config::OutputOptions {
             cdx_extension: config::CdxExtension::Included,
-            prefix: config::Prefix::Pattern(config::Pattern::Bom),
         };
 
         assert_eq!(actual, expected);

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -15,8 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+use crate::config::SbomConfig;
 use crate::config::{self, CdxExtension, PrefixError};
-use crate::config::{SbomConfig};
 use crate::format::Format;
 
 use serde::Deserialize;
@@ -137,9 +137,7 @@ impl TryFrom<OutputOptions> for config::OutputOptions {
             None => CdxExtension::default(),
         };
 
-        Ok(Self {
-            cdx_extension,
-        })
+        Ok(Self { cdx_extension })
     }
 }
 

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -71,14 +71,14 @@ fn find_content_in_bom_files() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success().stdout("");
 
     tmp_dir
-        .child("bom.xml")
+        .child("pkg.cdx.xml")
         .assert(predicate::str::contains("<vendor>CycloneDX</vendor>"));
 
     cmd.arg("--format").arg("json");
     cmd.assert().success().stdout("");
 
     tmp_dir
-        .child("bom.json")
+        .child("pkg.cdx.json")
         .assert(predicate::str::contains(r#""vendor": "CycloneDX"#));
 
     tmp_dir.close()?;
@@ -123,13 +123,13 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir(tmp_dir.path())
         .arg("cyclonedx")
         .arg("--all")
-        .arg("--verbose");
+        .arg("-vvvvv");
 
     cmd.assert()
         .success()
         .stderr(predicate::str::contains(format!(
             "Outputting {}",
-            tmp_dir.path().join("bom.xml").display(),
+            tmp_dir.path().join("test.cdx.xml").display(),
         )))
         .stderr(predicate::str::contains(format!(
             "Package {} has an invalid license expression, trying lax parsing ({})",
@@ -156,15 +156,14 @@ fn bom_file_name_extension_is_prepended_with_cdx() -> Result<(), Box<dyn std::er
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
 
     cmd.current_dir(tmp_dir.path())
-        .arg("cyclonedx")
-        .arg("--output-cdx");
+        .arg("cyclonedx");
 
     cmd.assert().success().stdout("");
 
-    tmp_dir.child("bom.xml").assert(predicate::path::missing());
+    tmp_dir.child("pkg.xml").assert(predicate::path::missing());
 
     tmp_dir
-        .child("bom.cdx.xml")
+        .child("pkg.cdx.xml")
         .assert(predicate::path::exists());
 
     tmp_dir.close()?;

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -155,8 +155,7 @@ fn bom_file_name_extension_is_prepended_with_cdx() -> Result<(), Box<dyn std::er
 
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
 
-    cmd.current_dir(tmp_dir.path())
-        .arg("cyclonedx");
+    cmd.current_dir(tmp_dir.path()).arg("cyclonedx");
 
     cmd.assert().success().stdout("");
 


### PR DESCRIPTION
This changes the CLI interface of the tool. It removes `output-pattern` and `output-prefix` as the name of the file is now generated from the name and type of the target.

This is because a single package can have multiple targes, some of which can be applications, one can be a library.
The old implementation would all tag the same (`application` if any application target exists) and the name would be the one of the package but each target can have a different name, so the resulting SBOM cannot be mapped to the artifact that is generated.