### PR TITLE
Fixes #442 - top level dependencies feature fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -23,7 +23,6 @@ use crate::format::Format;
 use crate::toml::config_from_toml;
 use crate::toml::ConfigError;
 use cargo::core::dependency::DepKind;
-use cargo::core::Dependency;
 use cargo::core::Package;
 use cargo::core::PackageSet;
 use cargo::core::Resolve;
@@ -92,7 +91,7 @@ impl SbomGenerator {
                 if config.included_dependencies() == IncludedDependencies::AllDependencies {
                     all_dependencies(&members, &package_ids, &resolve)?
                 } else {
-                    top_level_dependencies(&members, &package_ids, &resolve)?
+                    top_level_dependencies(&member, &package_ids, &resolve)?
                 };
 
             let bom = create_bom(member, dependencies)?;
@@ -373,23 +372,17 @@ pub enum GeneratorError {
 }
 
 fn top_level_dependencies(
-    members: &[Package],
+    member: &Package,
     package_ids: &PackageSet<'_>,
     resolve: &Resolve,
 ) -> Result<BTreeSet<Package>, GeneratorError> {
     log::trace!("Adding top-level dependencies to SBOM");
     let mut dependencies = BTreeSet::new();
 
-    let all_dependencies = members
-        .iter()
-        .flat_map(|m| {
-            resolve
-                .deps(m.package_id())
-                .filter(move |r| r.0 == m.package_id())
-                .map(|(_, dependency)| dependency)
-        })
-        .flatten()
-        .filter(|d: &&Dependency| d.kind() == DepKind::Normal);
+    let all_dependencies =
+        resolve.deps(member.package_id())
+            .filter(move |r| r.0 != member.package_id())
+            .map(|(_, dependency)| dependency).flatten().filter(|d|d.kind() == DepKind::Normal);
 
     for dependency in all_dependencies {
         log::trace!("Dependency: {dependency:?}");
@@ -412,11 +405,6 @@ fn top_level_dependencies(
                 );
             }
         }
-    }
-
-    // Filter out our own workspace crates from dependency list
-    for member in members {
-        dependencies.remove(member);
     }
 
     Ok(dependencies)

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -91,7 +91,7 @@ impl SbomGenerator {
                 if config.included_dependencies() == IncludedDependencies::AllDependencies {
                     all_dependencies(&members, &package_ids, &resolve)?
                 } else {
-                    top_level_dependencies(&member, &package_ids, &resolve)?
+                    top_level_dependencies(member, &package_ids, &resolve)?
                 };
 
             let bom = create_bom(member, dependencies)?;
@@ -379,10 +379,11 @@ fn top_level_dependencies(
     log::trace!("Adding top-level dependencies to SBOM");
     let mut dependencies = BTreeSet::new();
 
-    let all_dependencies =
-        resolve.deps(member.package_id())
-            .filter(move |r| r.0 != member.package_id())
-            .map(|(_, dependency)| dependency).flatten().filter(|d|d.kind() == DepKind::Normal);
+    let all_dependencies = resolve
+        .deps(member.package_id())
+        .filter(move |r| r.0 != member.package_id())
+        .flat_map(|(_, dependency)| dependency)
+        .filter(|d| d.kind() == DepKind::Normal);
 
     for dependency in all_dependencies {
         log::trace!("Dependency: {dependency:?}");

--- a/cyclonedx-bom/src/xml.rs
+++ b/cyclonedx-bom/src/xml.rs
@@ -411,7 +411,7 @@ pub(crate) mod test {
         let initial_event = event_reader
             .next()
             .expect("Failed to read from the XML input");
-        let output: X = match initial_event {
+        let output = match initial_event {
             reader::XmlEvent::StartElement {
                 name, attributes, ..
             } => X::read_xml_element(&mut event_reader, &name, &attributes)

--- a/cyclonedx-bom/src/xml.rs
+++ b/cyclonedx-bom/src/xml.rs
@@ -400,7 +400,6 @@ pub(crate) mod test {
     pub(crate) fn read_element_from_string<X: FromXml>(string: impl AsRef<str>) -> X {
         let mut event_reader =
             EventReader::new_with_config(string.as_ref().as_bytes(), parser_config());
-        let output: X;
 
         let start_document = event_reader.next().expect("Expected to start the document");
 
@@ -412,15 +411,15 @@ pub(crate) mod test {
         let initial_event = event_reader
             .next()
             .expect("Failed to read from the XML input");
-        match initial_event {
+        let output: X = match initial_event {
             reader::XmlEvent::StartElement {
                 name, attributes, ..
             } => {
-                output = X::read_xml_element(&mut event_reader, &name, &attributes)
+                X::read_xml_element(&mut event_reader, &name, &attributes)
                     .expect("Failed to read the element from the string")
             }
             other => panic!("Expected to start an element, but got {:?}", other),
-        }
+        };
         let end_document = event_reader.next().expect("Expected to end the document");
 
         match end_document {

--- a/cyclonedx-bom/src/xml.rs
+++ b/cyclonedx-bom/src/xml.rs
@@ -414,10 +414,8 @@ pub(crate) mod test {
         let output: X = match initial_event {
             reader::XmlEvent::StartElement {
                 name, attributes, ..
-            } => {
-                X::read_xml_element(&mut event_reader, &name, &attributes)
-                    .expect("Failed to read the element from the string")
-            }
+            } => X::read_xml_element(&mut event_reader, &name, &attributes)
+                .expect("Failed to read the element from the string"),
             other => panic!("Expected to start an element, but got {:?}", other),
         };
         let end_document = event_reader.next().expect("Expected to end the document");


### PR DESCRIPTION
- top_level_dependencies will now only be run once per member, previously it would iterate over all members again
- it will now properly _exclude_ itself (this was a logic error)
- It will _not_ exclude other members as dependencies, those are valid dependencies

/fixes #442 