### PR TITLE
Update proc_macro2 and fix new clippy lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,9 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/cyclonedx-bom/src/xml.rs
+++ b/cyclonedx-bom/src/xml.rs
@@ -400,7 +400,6 @@ pub(crate) mod test {
     pub(crate) fn read_element_from_string<X: FromXml>(string: impl AsRef<str>) -> X {
         let mut event_reader =
             EventReader::new_with_config(string.as_ref().as_bytes(), parser_config());
-        let output: X;
 
         let start_document = event_reader.next().expect("Expected to start the document");
 
@@ -412,15 +411,13 @@ pub(crate) mod test {
         let initial_event = event_reader
             .next()
             .expect("Failed to read from the XML input");
-        match initial_event {
+        let output = match initial_event {
             reader::XmlEvent::StartElement {
                 name, attributes, ..
-            } => {
-                output = X::read_xml_element(&mut event_reader, &name, &attributes)
-                    .expect("Failed to read the element from the string")
-            }
+            } => X::read_xml_element(&mut event_reader, &name, &attributes)
+                .expect("Failed to read the element from the string"),
             other => panic!("Expected to start an element, but got {:?}", other),
-        }
+        };
         let end_document = event_reader.next().expect("Expected to end the document");
 
         match end_document {


### PR DESCRIPTION
This issue breaks the build as of a Rust nightly version in June: https://github.com/rust-lang/rust/issues/113152

In addition this Clippy lint also breaks the build: https://rust-lang.github.io/rust-clippy/master/index.html#/needless_late_init
I'm not sure what was changed there because it apparently existed for a long time already.

This PR fixes both issues and makes the build pass again.