### PR TITLE
Add cache to speed up builds

### DIFF
--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: 'cargo-cyclonedx release type (major, minor, patch)'
+        description: "cargo-cyclonedx release type (major, minor, patch)"
         required: true
-        default: 'patch'
+        default: "patch"
 
 jobs:
   deploy:
@@ -20,6 +20,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Cargo bump
         run: |
           cargo install cargo-edit

--- a/.github/workflows/deploy_cyclonedx_bom.yml
+++ b/.github/workflows/deploy_cyclonedx_bom.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       releaseType:
-        description: 'cyclonedx-bom release type (major, minor, patch)'
+        description: "cyclonedx-bom release type (major, minor, patch)"
         required: true
-        default: 'patch'
+        default: "patch"
 
 jobs:
   deploy:
@@ -20,6 +20,9 @@ jobs:
         with:
           toolchain: stable
           override: true
+
+      - uses: Swatinem/rust-cache@v2
+
       - name: Cargo bump
         run: |
           cargo install cargo-edit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,39 +4,41 @@ on:
   pull_request:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
-
   lint:
     name: Linting & Coding Standards
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust Toolchain
-      run: |
-        rustup update
-        rustup component add clippy
-    - name: Lint
-      run: |
-        cargo fmt -- --check
-        cargo clippy --all-targets
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Lint
+        run: |
+          cargo fmt -- --check
+          cargo clippy --all-targets
 
   dependencies:
     name: Check Dependencies
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust Toolchain
-      run: |
-        rustup update
-        rustup install nightly
-        cargo install cargo-udeps
-    - name: Check for unused dependencies
-      run: |
-        cargo +nightly udeps
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        run: |
+          rustup update
+          rustup install nightly
+          cargo install cargo-udeps
+      - name: Check for unused dependencies
+        run: |
+          cargo +nightly udeps
 
   test:
     name: Test Suite Runs - ${{ matrix.test-arm }}
@@ -47,29 +49,29 @@ jobs:
       matrix:
         include:
           - # test with the current stable version
-            test-arm: 'Stable'
-            rust-version: 'stable'
+            test-arm: "Stable"
+            rust-version: "stable"
             continue-on-error: false
           - # test with the MSRV version
-            test-arm: 'Minimum Supported Rust Version'
-            rust-version: '1.70.0'
+            test-arm: "Minimum Supported Rust Version"
+            rust-version: "1.70.0"
             continue-on-error: false
           - # test with the current nightly version (allowed to fail)
-            test-arm: 'Nightly'
-            rust-version: 'nightly'
+            test-arm: "Nightly"
+            rust-version: "nightly"
             continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust Toolchain
-      run: |
-        rustup update
-        rustup install ${{ matrix.rust-version }}
-    - name: Build
-      run: cargo +${{ matrix.rust-version }} build --verbose
-      continue-on-error: ${{ matrix.continue-on-error }}
-    - name: Execute tests
-      run: cargo +${{ matrix.rust-version }} test --verbose
-      continue-on-error: ${{ matrix.continue-on-error }}
-    - name: Run CLI
-      run: cargo +${{ matrix.rust-version }} run -- cyclonedx
+      - uses: actions/checkout@v3
+      - name: Install Rust Toolchain
+        run: |
+          rustup update
+          rustup install ${{ matrix.rust-version }}
+      - name: Build
+        run: cargo +${{ matrix.rust-version }} build --verbose
+        continue-on-error: ${{ matrix.continue-on-error }}
+      - name: Execute tests
+        run: cargo +${{ matrix.rust-version }} test --verbose
+        continue-on-error: ${{ matrix.continue-on-error }}
+      - name: Run CLI
+        run: cargo +${{ matrix.rust-version }} run -- cyclonedx


### PR DESCRIPTION
As mentioned in https://github.com/CycloneDX/cyclonedx-rust-cargo/issues/474#issuecomment-1751069739 , here is a PR that the only thing it does is adding the more popular rust-cache action.

It will cache all necessary packages on the first successful action run, the speed up increases will be immediately seen on a second run after that.