### PR TITLE
Use buffered I/O when writing for much higher performance

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -50,8 +50,8 @@ use regex::Regex;
 
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
-use std::io::BufWriter;
 use std::fs::File;
+use std::io::BufWriter;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -52,6 +52,7 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::BufWriter;
+use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -498,7 +499,7 @@ impl GeneratedSbom {
     pub fn write_to_file(self) -> Result<(), SbomWriterError> {
         let path = self.manifest_path.with_file_name(self.filename());
         log::info!("Outputting {}", path.display());
-        let file = File::create(path).map_err(SbomWriterError::FileCreateError)?;
+        let file = File::create(path)?;
         let mut writer = BufWriter::new(file);
         match self.sbom_config.format() {
             Format::Json => {
@@ -512,6 +513,9 @@ impl GeneratedSbom {
                     .map_err(SbomWriterError::XmlWriteError)?;
             }
         }
+
+        // Flush the writer explicitly to catch and report any I/O errors
+        writer.flush()?;
 
         Ok(())
     }
@@ -535,8 +539,8 @@ impl GeneratedSbom {
 
 #[derive(Error, Debug)]
 pub enum SbomWriterError {
-    #[error("Error creating file")]
-    FileCreateError(#[source] std::io::Error),
+    #[error("I/O error")]
+    IoError(#[source] std::io::Error),
 
     #[error("Error writing JSON file")]
     JsonWriteError(#[source] cyclonedx_bom::errors::JsonWriteError),
@@ -546,6 +550,12 @@ pub enum SbomWriterError {
 
     #[error("Error serializing to XML")]
     SerializeXmlError(#[source] std::io::Error),
+}
+
+impl From<std::io::Error> for SbomWriterError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IoError(value)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The tool is currently bottlenecked by writing to files one byte at a time.

Use buffered I/O for dramatically higher performance. Drastically cuts the execution time for the entire tool.