### PR TITLE
Slience lax parsing "errors"

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -241,7 +241,7 @@ fn get_licenses(package: &Package) -> Option<Licenses> {
         match SpdxExpression::try_from(license.to_string()) {
             Ok(expression) => licenses.push(LicenseChoice::Expression(expression)),
             Err(err) => {
-                log::error!(
+                log::debug!(
                     "Package {} has an invalid license expression, trying lax parsing ({}): {}",
                     package.name(),
                     license,

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -123,7 +123,7 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir(tmp_dir.path())
         .arg("cyclonedx")
         .arg("--all")
-        .arg("--verbose");
+        .arg("-vv");
 
     cmd.assert()
         .success()


### PR DESCRIPTION
They are not, in fact, errors. Just a conversion from the Rust format to the more universal one.

Supersedes #363