### PR TITLE
Fix spec compliance: use an actually unique `bom-ref`

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -164,7 +164,7 @@ fn create_component(package: &Package) -> Component {
         Classification::Library,
         &name,
         &version,
-        purl.clone().map(|p| p.to_string()),
+        Some(package.id.to_string()),
     );
 
     component.purl = purl;


### PR DESCRIPTION
**Depends on https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/496, please review that first!**

Fixes #502 by using the unique IDs helpfully supplied by `cargo metadata`. They look something like this: 
`resvg 0.36.0 (registry+https://github.com/rust-lang/crates.io-index)`

They may expose local filesystem paths if the dependency is pulled from the local filesystem. However, this does not disclose anything panic messages in the binary didn't leak already.

This is a prerequisite for writing the dependency tree.