### PR TITLE
Add feature selection via CLI arguments

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -109,12 +109,14 @@ impl Args {
             None
         } else {
             let mut feature_list: Vec<String> = Vec::new();
-            // Features can be comma-separated for compatibility with Cargo,
+            // Features can be comma- or space-separated for compatibility with Cargo,
             // but only in command-line arguments.
             for comma_separated_features in &self.features {
                 // Feature names themselves never contain commas.
-                for feature in comma_separated_features.split(',') {
-                    feature_list.push(feature.to_owned());
+                for space_separated_features in comma_separated_features.split(',') {
+                    for feature in space_separated_features.split(' ') {
+                        feature_list.push(feature.to_owned());
+                    }
                 }
             }
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -157,3 +157,43 @@ pub enum ArgsError {
     #[error("Invalid prefix from CLI")]
     CustomPrefixError(#[from] PrefixError),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_features() {
+        let args = vec!["cyclonedx"];
+        let config = parse_to_config(&args);
+        assert!(config.features.is_none());
+
+        let args = vec!["cyclonedx", "--features=foo"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+
+        let args = vec!["cyclonedx", "--features=foo", "--features=bar"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+        assert!(contains_feature(&config, "bar"));
+
+        let args = vec!["cyclonedx", "--features=foo,bar baz"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+        assert!(contains_feature(&config, "bar"));
+        assert!(contains_feature(&config, "baz"));
+    }
+
+    fn parse_to_config(args: &[&str]) -> SbomConfig {
+        Args::parse_from(args.iter()).as_config().unwrap()
+    }
+
+    fn contains_feature(config: &SbomConfig, feature: &str) -> bool {
+        config
+            .features
+            .as_ref()
+            .unwrap()
+            .features
+            .contains(&feature.to_owned())
+    }
+}

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -104,29 +104,29 @@ impl Args {
 
         let features =
             if !self.all_features && !self.no_default_features && self.features.is_empty() {
-            None
-        } else {
-            let mut feature_list: Vec<String> = Vec::new();
-            // Features can be comma- or space-separated for compatibility with Cargo,
-            // but only in command-line arguments (not in config files),
-            // which is why this code lives here.
-            for comma_separated_features in &self.features {
-                // Feature names themselves never contain commas.
-                for space_separated_features in comma_separated_features.split(',') {
-                    for feature in space_separated_features.split(' ') {
-                        if !feature.is_empty() {
-                            feature_list.push(feature.to_owned());
+                None
+            } else {
+                let mut feature_list: Vec<String> = Vec::new();
+                // Features can be comma- or space-separated for compatibility with Cargo,
+                // but only in command-line arguments (not in config files),
+                // which is why this code lives here.
+                for comma_separated_features in &self.features {
+                    // Feature names themselves never contain commas.
+                    for space_separated_features in comma_separated_features.split(',') {
+                        for feature in space_separated_features.split(' ') {
+                            if !feature.is_empty() {
+                                feature_list.push(feature.to_owned());
+                            }
                         }
                     }
                 }
-            }
 
-            Some(Features {
-                all_features: self.all_features,
-                no_default_features: self.no_default_features,
-                features: feature_list,
-            })
-        };
+                Some(Features {
+                    all_features: self.all_features,
+                    no_default_features: self.no_default_features,
+                    features: feature_list,
+                })
+            };
 
         let output_options = match (cdx_extension, prefix) {
             (Some(cdx_extension), Some(prefix)) => Some(OutputOptions {

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -102,10 +102,8 @@ impl Args {
             false => None,
         };
 
-        let features = if self.all_features == false
-            && self.no_default_features == false
-            && self.features.is_empty()
-        {
+        let features =
+            if !self.all_features && !self.no_default_features && self.features.is_empty() {
             None
         } else {
             let mut feature_list: Vec<String> = Vec::new();

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -122,6 +122,7 @@ impl Args {
             format: self.format,
             included_dependencies,
             output_options,
+            features: None, // TODO
         })
     }
 }

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -115,7 +115,9 @@ impl Args {
                 // Feature names themselves never contain commas.
                 for space_separated_features in comma_separated_features.split(',') {
                     for feature in space_separated_features.split(' ') {
-                        feature_list.push(feature.to_owned());
+                        if !feature.is_empty() {
+                            feature_list.push(feature.to_owned());
+                        }
                     }
                 }
             }
@@ -182,6 +184,12 @@ mod tests {
         assert!(contains_feature(&config, "foo"));
         assert!(contains_feature(&config, "bar"));
         assert!(contains_feature(&config, "baz"));
+
+        let args = vec!["cyclonedx", "--features=foo, bar"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+        assert!(contains_feature(&config, "bar"));
+        assert!(!contains_feature(&config, ""));
     }
 
     fn parse_to_config(args: &[&str]) -> SbomConfig {

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,8 +37,8 @@ pub struct Args {
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 
-    // The feature selection flags are not mutually exclusive in Cargo,
-    // so we keep the same behavior here too.
+    // `--all-features`, `--no-default-features` and `--features`
+    // are not mutually exclusive in Cargo, so we keep the same behavior here too.
     /// Activate all available features
     #[clap(long = "all-features")]
     pub all_features: bool,

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -110,7 +110,8 @@ impl Args {
         } else {
             let mut feature_list: Vec<String> = Vec::new();
             // Features can be comma- or space-separated for compatibility with Cargo,
-            // but only in command-line arguments.
+            // but only in command-line arguments (not in config files),
+            // which is why this code lives here.
             for comma_separated_features in &self.features {
                 // Feature names themselves never contain commas.
                 for space_separated_features in comma_separated_features.split(',') {

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,6 +37,20 @@ pub struct Args {
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 
+    // The feature selection flags are not mutually exclusive in Cargo,
+    // so we keep the same behavior here too.
+    /// Activate all available features
+    #[clap(long = "all-features")]
+    pub all_features: bool,
+
+    /// Do not activate the `default` feature
+    #[clap(long = "no-default-features")]
+    pub no_default_features: bool,
+
+    /// Space or comma separated list of features to activate
+    #[clap(long = "features", short = 'F')]
+    pub features: Option<Vec<String>>,
+
     /// List all dependencies instead of only top-level ones
     #[clap(long = "all", short = 'a')]
     pub all: bool,

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -121,6 +121,13 @@ impl Default for CdxExtension {
     }
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Features {
+    pub all_features: bool,
+    pub no_default_features: bool,
+    pub features: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Prefix {
     Pattern(Pattern),

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -21,20 +21,17 @@ use thiserror::Error;
  */
 use crate::format::Format;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct SbomConfig {
     pub format: Option<Format>,
     pub included_dependencies: Option<IncludedDependencies>,
     pub output_options: Option<OutputOptions>,
+    pub features: Option<Features>,
 }
 
 impl SbomConfig {
     pub fn empty_config() -> Self {
-        Self {
-            format: None,
-            included_dependencies: None,
-            output_options: None,
-        }
+        Default::default()
     }
 
     pub fn merge(&self, other: &SbomConfig) -> SbomConfig {
@@ -45,6 +42,7 @@ impl SbomConfig {
                 .output_options
                 .clone()
                 .or_else(|| self.output_options.clone()),
+            features: other.features.clone().or_else(|| self.features.clone()),
         }
     }
 

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -103,6 +103,7 @@ impl TryFrom<TomlConfig> for SbomConfig {
             format: value.format,
             included_dependencies: value.included_dependencies.map(Into::into),
             output_options,
+            features: None, // TODO
         })
     }
 }

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -103,7 +103,7 @@ impl TryFrom<TomlConfig> for SbomConfig {
             format: value.format,
             included_dependencies: value.included_dependencies.map(Into::into),
             output_options,
-            features: None, // TODO
+            features: None, // Not possible to support on per-Cargo.toml basis
         })
     }
 }


### PR DESCRIPTION
Supports `--no-default-features`, `--all-features`,` --features=...` CLI arguments. They are fully compatible with Cargo itself, which is verified by the added tests.

This allows selecting the feature configuration that matches the way you build your binaries, so that the dependency list in the SBOM can actually correspond to the binary.

Fixes #508