### PR TITLE
Allow selecting the target with `--target=<TRIPLE>` or `--all-targets`

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -52,8 +52,13 @@ pub struct Args {
     #[clap(long = "features", short = 'F')]
     pub features: Vec<String>,
 
-    /// The target to generate the SBOM for, e.g. x86_64-unknown-linux-gnu
-    #[clap(long = "target")]
+    /// The target to generate the SBOM for, or 'all' for all targets.
+    #[clap(
+        long = "target",
+        long_help = "The target to generate the SBOM for, e.g. 'x86_64-unknown-linux-gnu'.
+Use 'all' to include dependencies for all possible targets.
+Defaults to the host target, as printed by 'rustc -vV'"
+    )]
     pub target: Option<String>,
 
     /// Include the dependencies from all possible target platforms in the SBOM

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -109,12 +109,14 @@ impl Args {
             None
         } else {
             let mut feature_list: Vec<String> = Vec::new();
-            // Features can be comma-separated for compatibility with Cargo,
+            // Features can be comma- or space-separated for compatibility with Cargo,
             // but only in command-line arguments.
             for comma_separated_features in &self.features {
                 // Feature names themselves never contain commas.
-                for feature in comma_separated_features.split(',') {
-                    feature_list.push(feature.to_owned());
+                for space_separated_features in comma_separated_features.split(',') {
+                    for feature in space_separated_features.split(' ') {
+                        feature_list.push(feature.to_owned());
+                    }
                 }
             }
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -157,3 +157,43 @@ pub enum ArgsError {
     #[error("Invalid prefix from CLI")]
     CustomPrefixError(#[from] PrefixError),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_features() {
+        let args = vec!["cyclonedx"];
+        let config = parse_to_config(&args);
+        assert!(config.features.is_none());
+
+        let args = vec!["cyclonedx", "--features=foo"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+
+        let args = vec!["cyclonedx", "--features=foo", "--features=bar"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+        assert!(contains_feature(&config, "bar"));
+
+        let args = vec!["cyclonedx", "--features=foo,bar baz"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+        assert!(contains_feature(&config, "bar"));
+        assert!(contains_feature(&config, "baz"));
+    }
+
+    fn parse_to_config(args: &[&str]) -> SbomConfig {
+        Args::parse_from(args.iter()).as_config().unwrap()
+    }
+
+    fn contains_feature(config: &SbomConfig, feature: &str) -> bool {
+        config
+            .features
+            .as_ref()
+            .unwrap()
+            .features
+            .contains(&feature.to_owned())
+    }
+}

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -140,16 +140,10 @@ impl Args {
         };
 
         let target = Some(if self.all_targets {
-            Target {
-                all_targets: true,
-                target: None,
-            }
+            Target::AllTargets
         } else {
-            let target = Some(self.target.clone().unwrap_or_else(host_platform));
-            Target {
-                all_targets: false,
-                target,
-            }
+            let target = self.target.clone().unwrap_or_else(host_platform);
+            Target::SingleTarget(target)
         });
 
         let output_options = match (cdx_extension, prefix) {

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -51,6 +51,15 @@ pub struct Args {
     #[clap(long = "features", short = 'F')]
     pub features: Vec<String>,
 
+    /// The target to generate the SBOM for, e.g. x86_64-unknown-linux-gnu
+    #[clap(long = "target")]
+    pub target: String,
+
+    /// Include the dependencies from all possible platforms in the SBOM
+    #[clap(long = "all-platforms")]
+    #[clap(conflicts_with = "target")]
+    pub all_platforms: bool,
+
     /// List all dependencies instead of only top-level ones
     #[clap(long = "all", short = 'a')]
     pub all: bool,

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -61,11 +61,6 @@ Defaults to the host target, as printed by 'rustc -vV'"
     )]
     pub target: Option<String>,
 
-    /// Include the dependencies from all possible target platforms in the SBOM
-    #[clap(long = "all-targets")]
-    #[clap(conflicts_with = "target")]
-    pub all_targets: bool,
-
     /// List all dependencies instead of only top-level ones
     #[clap(long = "all", short = 'a')]
     pub all: bool,
@@ -142,11 +137,11 @@ impl Args {
                 })
             };
 
-        let target = Some(if self.all_targets {
+        let target_string = self.target.clone().unwrap_or_else(host_platform);
+        let target = Some(if &target_string == "all" {
             Target::AllTargets
         } else {
-            let target = self.target.clone().unwrap_or_else(host_platform);
-            Target::SingleTarget(target)
+            Target::SingleTarget(target_string)
         });
 
         let output_options = match (cdx_extension, prefix) {

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -122,6 +122,7 @@ impl Args {
             format: self.format,
             included_dependencies,
             output_options,
+            features: None, // TODO
         })
     }
 }

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -55,10 +55,10 @@ pub struct Args {
     #[clap(long = "target")]
     pub target: String,
 
-    /// Include the dependencies from all possible platforms in the SBOM
-    #[clap(long = "all-platforms")]
+    /// Include the dependencies from all possible target platforms in the SBOM
+    #[clap(long = "all-targets")]
     #[clap(conflicts_with = "target")]
-    pub all_platforms: bool,
+    pub all_targets: bool,
 
     /// List all dependencies instead of only top-level ones
     #[clap(long = "all", short = 'a')]

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -115,7 +115,9 @@ impl Args {
                 // Feature names themselves never contain commas.
                 for space_separated_features in comma_separated_features.split(',') {
                     for feature in space_separated_features.split(' ') {
-                        feature_list.push(feature.to_owned());
+                        if !feature.is_empty() {
+                            feature_list.push(feature.to_owned());
+                        }
                     }
                 }
             }
@@ -182,6 +184,12 @@ mod tests {
         assert!(contains_feature(&config, "foo"));
         assert!(contains_feature(&config, "bar"));
         assert!(contains_feature(&config, "baz"));
+
+        let args = vec!["cyclonedx", "--features=foo, bar"];
+        let config = parse_to_config(&args);
+        assert!(contains_feature(&config, "foo"));
+        assert!(contains_feature(&config, "bar"));
+        assert!(!contains_feature(&config, ""));
     }
 
     fn parse_to_config(args: &[&str]) -> SbomConfig {

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,6 +37,20 @@ pub struct Args {
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 
+    // The feature selection flags are not mutually exclusive in Cargo,
+    // so we keep the same behavior here too.
+    /// Activate all available features
+    #[clap(long = "all-features")]
+    pub all_features: bool,
+
+    /// Do not activate the `default` feature
+    #[clap(long = "no-default-features")]
+    pub no_default_features: bool,
+
+    /// Space or comma separated list of features to activate
+    #[clap(long = "features", short = 'F')]
+    pub features: Option<Vec<String>>,
+
     /// List all dependencies instead of only top-level ones
     #[clap(long = "all", short = 'a')]
     pub all: bool,

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -121,6 +121,13 @@ impl Default for CdxExtension {
     }
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Features {
+    pub all_features: bool,
+    pub no_default_features: bool,
+    pub features: Vec<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Prefix {
     Pattern(Pattern),

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -126,6 +126,12 @@ pub struct Features {
     pub features: Vec<String>,
 }
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Target {
+    pub all_targets: bool,
+    pub target: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Prefix {
     Pattern(Pattern),

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -27,6 +27,7 @@ pub struct SbomConfig {
     pub included_dependencies: Option<IncludedDependencies>,
     pub output_options: Option<OutputOptions>,
     pub features: Option<Features>,
+    pub target: Option<Target>,
 }
 
 impl SbomConfig {
@@ -43,6 +44,7 @@ impl SbomConfig {
                 .clone()
                 .or_else(|| self.output_options.clone()),
             features: other.features.clone().or_else(|| self.features.clone()),
+            target: other.target.clone().or_else(|| self.target.clone()),
         }
     }
 

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -35,6 +35,7 @@ impl SbomConfig {
         Default::default()
     }
 
+    /// The config passed as an argument takes priority over `Self`
     pub fn merge(&self, other: &SbomConfig) -> SbomConfig {
         SbomConfig {
             format: other.format.or(self.format),

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -21,20 +21,17 @@ use thiserror::Error;
  */
 use crate::format::Format;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct SbomConfig {
     pub format: Option<Format>,
     pub included_dependencies: Option<IncludedDependencies>,
     pub output_options: Option<OutputOptions>,
+    pub features: Option<Features>,
 }
 
 impl SbomConfig {
     pub fn empty_config() -> Self {
-        Self {
-            format: None,
-            included_dependencies: None,
-            output_options: None,
-        }
+        Default::default()
     }
 
     pub fn merge(&self, other: &SbomConfig) -> SbomConfig {
@@ -45,6 +42,7 @@ impl SbomConfig {
                 .output_options
                 .clone()
                 .or_else(|| self.output_options.clone()),
+            features: other.features.clone().or_else(|| self.features.clone()),
         }
     }
 

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -130,9 +130,10 @@ pub struct Features {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Target {
-    pub all_targets: bool,
-    pub target: Option<String>,
+pub enum Target {
+    #[default]
+    AllTargets,
+    SingleTarget(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/cargo-cyclonedx/src/lib.rs
+++ b/cargo-cyclonedx/src/lib.rs
@@ -19,6 +19,7 @@
 pub mod config;
 pub mod format;
 pub mod generator;
+pub mod platform;
 pub mod toml;
 
 pub use crate::generator::*;

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -45,7 +45,10 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-use cargo_cyclonedx::{config::SbomConfig, generator::SbomGenerator};
+use cargo_cyclonedx::{
+    config::{SbomConfig, Target},
+    generator::SbomGenerator,
+};
 use std::{
     io::{self},
     path::{Path, PathBuf},
@@ -148,6 +151,10 @@ fn get_metadata(
                 feature_configuration.features.clone(),
             ));
         }
+    }
+
+    if let Some(Target::SingleTarget(target)) = config.target.as_ref() {
+        cmd.other_options(vec!["--filter-platform".to_owned(), target.to_owned()]);
     }
 
     Ok(cmd.exec()?)

--- a/cargo-cyclonedx/src/platform.rs
+++ b/cargo-cyclonedx/src/platform.rs
@@ -1,0 +1,30 @@
+use std::{
+    ffi::{OsStr, OsString},
+    io::BufRead,
+    process::Command,
+};
+
+/// Returns the host target triple, e.g. `x86_64-unknown-linux-gnu`
+pub fn host_platform() -> String {
+    rustc_host_target_triple(&rustc_location())
+}
+
+pub fn rustc_location() -> OsString {
+    // Honor the environment variable used by Cargo to locate `rustc`:
+    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
+    std::env::var_os("RUSTC").unwrap_or("rustc".into())
+}
+
+/// Returns the default target triple for the rustc we're running
+pub fn rustc_host_target_triple(rustc_path: &OsStr) -> String {
+    Command::new(rustc_path)
+        .arg("-vV")
+        .output()
+        .expect("Failed to invoke rustc! Is it in your $PATH?")
+        .stdout
+        .lines()
+        .map(|l| l.unwrap())
+        .find(|l| l.starts_with("host: "))
+        .map(|l| l[6..].to_string())
+        .expect("Failed to parse rustc output to determine the current platform. Please report this bug!")
+}

--- a/cargo-cyclonedx/src/platform.rs
+++ b/cargo-cyclonedx/src/platform.rs
@@ -17,6 +17,7 @@ pub fn rustc_location() -> OsString {
 
 /// Returns the default target triple for the rustc we're running
 pub fn rustc_host_target_triple(rustc_path: &OsStr) -> String {
+    // While this feels somewhat insane, this is how `cargo` determines the host platform
     Command::new(rustc_path)
         .arg("-vV")
         .output()

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -103,6 +103,7 @@ impl TryFrom<TomlConfig> for SbomConfig {
             format: value.format,
             included_dependencies: value.included_dependencies.map(Into::into),
             output_options,
+            features: None, // TODO
         })
     }
 }

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -103,7 +103,7 @@ impl TryFrom<TomlConfig> for SbomConfig {
             format: value.format,
             included_dependencies: value.included_dependencies.map(Into::into),
             output_options,
-            features: None, // TODO
+            features: None, // Not possible to support on per-Cargo.toml basis
         })
     }
 }

--- a/cargo-cyclonedx/src/toml.rs
+++ b/cargo-cyclonedx/src/toml.rs
@@ -104,6 +104,7 @@ impl TryFrom<TomlConfig> for SbomConfig {
             included_dependencies: value.included_dependencies.map(Into::into),
             output_options,
             features: None, // Not possible to support on per-Cargo.toml basis
+            target: None,   // Ditto
         })
     }
 }


### PR DESCRIPTION
**Depends on  #512, please review that first.**

`cargo cyclonedx` now defaults to the host platform, producing a SBOM for the binary you would get with `cargo build --release`.

"Cross-compilation" of the SBOM is natively supported with `--target=<TRIPLE>`, same flag as for `cargo build`.

The old behavior that includes packages from all targets, even the packages only used on that one funky unikernel, is still available via `--all-targets`.

Fixes #500