### PR TITLE
Fix clippy warning - 2nd try

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -140,7 +140,7 @@ fn create_bom(package: &PackageId, dependencies: &PackageMap) -> Result<Bom, Gen
     let components: Vec<_> = dependencies
         .values()
         .filter(|p| &p.id != package)
-        .map(|package| create_component(package))
+        .map(create_component)
         .collect();
 
     bom.components = Some(Components(components));


### PR DESCRIPTION
In https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/507 I fixed one clippy warning only to replace it with the next one. 
This gets rid of all of them.