### PR TITLE
Makes a log statement more useful and less verbose

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -263,7 +263,12 @@ impl SbomGenerator {
                 .map(|opts| opts.mode)
                 .unwrap_or_default();
 
-            log::debug!("License parser mode: {:?}", parse_mode);
+            log::trace!(
+                "Using license parser mode [{:?}] for package [{}@{}]",
+                parse_mode,
+                package.name,
+                package.version
+            );
 
             let result = match parse_mode {
                 ParseMode::Strict => SpdxExpression::try_from(license.to_string()),


### PR DESCRIPTION
The original would just print the same line dozens of times (once for each dependency) without any additional context.
That made it not very useful, I didn't catch that during the initial review of #363 

I switched from `debug` to `trace` but I have no strong opinion and can change it back again as well.

@ctron Any opinions?