### PR TITLE
Fix dev-dependencies being included in the dependency tree

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -44,6 +44,7 @@ use cyclonedx_bom::models::metadata::MetadataError;
 use cyclonedx_bom::models::organization::OrganizationalContact;
 use cyclonedx_bom::models::tool::{Tool, Tools};
 use cyclonedx_bom::validation::Validate;
+use cyclonedx_bom::validation::ValidationResult;
 use once_cell::sync::Lazy;
 use regex::Regex;
 
@@ -91,7 +92,12 @@ impl SbomGenerator {
             };
             let bom = generator.create_bom(member, &dependencies, &resolve)?;
 
-            log::debug!("Bom validation: {:?}", &bom.validate());
+            if cfg!(debug_assertions) {
+                let result = bom.validate().unwrap();
+                if let ValidationResult::Failed { reasons } = result {
+                    panic!("The generated SBOM failed validation: {:?}", &reasons);
+                }
+            }
 
             let generated = GeneratedSbom {
                 bom,

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -80,7 +80,7 @@ impl SbomGenerator {
         for member in members.iter() {
             log::trace!("Processing the package {}", member);
 
-            let (dependencies, _resolve) =
+            let (dependencies, pruned_resolve) =
                 if config.included_dependencies() == IncludedDependencies::AllDependencies {
                     all_dependencies(member, &packages, &resolve)
                 } else {
@@ -90,7 +90,7 @@ impl SbomGenerator {
             let generator = SbomGenerator {
                 config: config.clone(),
             };
-            let bom = generator.create_bom(member, &dependencies, &resolve)?;
+            let bom = generator.create_bom(member, &dependencies, &pruned_resolve)?;
 
             if cfg!(debug_assertions) {
                 let result = bom.validate().unwrap();


### PR DESCRIPTION
1. Make validation failure of the generated SBOM panic when debug assertions are enabled (as opposed to having it only log the issue with `log_level=debug`)
2. Only run potentially quadratic validation when debug assertions are enabled
3. Fix the issue that caused dev-dependencies to be included in the SBOM and validation to fail