### PR TITLE
Default to listing all dependencies, not just top-level ones

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -63,11 +63,11 @@ Defaults to the host target, as printed by 'rustc -vV'"
     )]
     pub target: Option<String>,
 
-    /// List all dependencies instead of only top-level ones
+    /// List all dependencies instead of only top-level ones (default)
     #[clap(long = "all", short = 'a')]
     pub all: bool,
 
-    /// List only top-level dependencies (default)
+    /// List only top-level dependencies
     #[clap(name = "top-level", long = "top-level", conflicts_with = "all")]
     pub top_level: bool,
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -68,7 +68,7 @@ Defaults to the host target, as printed by 'rustc -vV'"
     pub all: bool,
 
     /// List only top-level dependencies (default)
-    #[clap(name = "top-level", long = "top-level")]
+    #[clap(name = "top-level", long = "top-level", conflicts_with = "all")]
     pub top_level: bool,
 
     /// Prepend file extension with .cdx

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use std::collections::HashSet;
+use std::default;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -72,16 +73,11 @@ impl SbomConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum IncludedDependencies {
     TopLevelDependencies,
+    #[default]
     AllDependencies,
-}
-
-impl Default for IncludedDependencies {
-    fn default() -> Self {
-        Self::TopLevelDependencies
-    }
 }
 
 impl FromStr for IncludedDependencies {

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -1,6 +1,5 @@
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::default;
 use std::str::FromStr;
 use thiserror::Error;
 


### PR DESCRIPTION
1. Default to listing all dependencies, not just top-level ones. Now that the platform filtering is implemented, this will match the components that go into the final binary.
2. Make `--all` and `--top-level` flags incompatible with each other, because passing both makes no sense