### PR TITLE
Offload toplevel dependency selection to `cargo metadata`

### DIFF
--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -46,7 +46,7 @@
 * SOFTWARE.
 */
 use cargo_cyclonedx::{
-    config::{SbomConfig, Target},
+    config::{IncludedDependencies, SbomConfig, Target},
     generator::SbomGenerator,
 };
 
@@ -152,6 +152,10 @@ fn get_metadata(
                 feature_configuration.features.clone(),
             ));
         }
+    }
+
+    if let Some(IncludedDependencies::TopLevelDependencies) = config.included_dependencies {
+        cmd.no_deps();
     }
 
     if let Some(Target::SingleTarget(target)) = config.target.as_ref() {


### PR DESCRIPTION
Use `cargo metadata --no-deps` when listing top-level dependencies only. 

(Instead of rolling our own custom logic for this which is invariably going to be buggy _somehow._)