### PR TITLE
`cyclonedx-bom`: Don't break on newer compilers

### DIFF
--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -16,9 +16,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#![deny(clippy::all)]
-#![deny(warnings)]
-
 //! The `cyclonedx-bom` library provides JSON and XML serialization and derserialization of Software
 //! Bill-of-Materials (SBOM) files.
 //!


### PR DESCRIPTION
Remove ![deny(warnings)] so that cyclonedx-bom doesn't fail to build in production just because a newer compiler added a new lint