### PR TITLE
Record binary targets of the toplevel package in the SBOM

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -174,6 +174,7 @@ impl SbomGenerator {
     fn create_toplevel_component(&self, package: &Package) -> Component {
         let mut top_component = self.create_component(package);
         let mut subcomponents: Vec<Component> = Vec::new();
+        let mut subcomp_count: u32 = 0;
         for bin_target in &package.targets {
             // Ignore tests, benches, examples and build scripts.
             // They are not part of the final build artifacts, which is what we are after.
@@ -191,11 +192,17 @@ impl SbomGenerator {
                         }
                     };
                     if let Some(cdx_type) = cdx_type {
+                        let bom_ref = format!(
+                            "{} bin-target-{}",
+                            top_component.bom_ref.as_ref().unwrap(),
+                            subcomp_count
+                        );
+                        subcomp_count += 1;
                         subcomponents.push(Component::new(
                             cdx_type,
                             &bin_target.name,
                             &package.version.to_string(),
-                            None,
+                            Some(bom_ref),
                         ));
                     }
                 }

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -169,6 +169,42 @@ impl SbomGenerator {
         component
     }
 
+    /// Same as [Self::create_component] but also includes information
+    /// on binaries and libraries comprising it as subcomponents
+    fn create_toplevel_component(&self, package: &Package) -> Component {
+        let mut top_component = self.create_component(package);
+        let mut subcomponents: Vec<Component> = Vec::new();
+        for bin_target in &package.targets {
+            // Ignore tests, benches, examples and build scripts.
+            // They are not part of the final build artifacts, which is what we are after.
+            if !contains_any(
+                bin_target.kind.iter().map(|s| s.as_str()),
+                &["example", "test", "bench", "custom-build"],
+            ) {
+                for kind in bin_target.kind.iter() {
+                    let cdx_type = match kind.as_str() {
+                        "bin" => Some(Classification::Application),
+                        "lib" => Some(Classification::Library),
+                        other_kind => {
+                            log::error!("Unknown target kind: {}", other_kind);
+                            None
+                        }
+                    };
+                    if let Some(cdx_type) = cdx_type {
+                        subcomponents.push(Component::new(
+                            cdx_type,
+                            &bin_target.name,
+                            &package.version.to_string(),
+                            None,
+                        ));
+                    }
+                }
+            }
+        }
+        top_component.components = Some(Components(subcomponents));
+        top_component
+    }
+
     fn get_classification(pkg: &Package) -> Classification {
         // FIXME: this is almost certainly wrong
         if pkg.targets.iter().any(|tgt| tgt.is_bin()) {
@@ -301,7 +337,7 @@ impl SbomGenerator {
             metadata.authors = Some(authors);
         }
 
-        let mut component = self.create_component(package);
+        let mut component = self.create_toplevel_component(package);
 
         component.component_type = Self::get_classification(package);
 
@@ -503,6 +539,17 @@ fn non_dev_dependencies(input: &[NodeDep]) -> impl Iterator<Item = &NodeDep> {
             .iter()
             .any(|dep| dep.kind != DependencyKind::Development)
     })
+}
+
+fn contains_any<T: Eq>(mut haystack: impl Iterator<Item = T>, needles: &[T]) -> bool {
+    // This could be done more efficiently with the `memchr` crate,
+    // but the slices we need to run this on are so short that it doesn't matter
+    for needle in needles {
+        if haystack.any(|elem| &elem == needle) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Contains a generated SBOM and context used in its generation


### PR DESCRIPTION
The spec has a dedicated field for this sort of thing, so we just use it: https://cyclonedx.org/docs/1.5/json/#metadata_component_components

It should be possible to add source paths such as `src/main.rs`, `src/bin/some-binary.rs`, `src/lib.rs` to the PURL too, but that depends on the PURL PR (#523) and I didn't want to block this PR on the PURL one, so that will come in a follow-up PR.

There is not much else we can include: the [cargo-metadata `Target`](https://docs.rs/cargo_metadata/latest/cargo_metadata/struct.Target.html) has almost no overlap with the CycloneDX `component`.

Supersedes #441