### PR TITLE
Rename variant to match enum type

### DIFF
--- a/cyclonedx-bom/src/errors.rs
+++ b/cyclonedx-bom/src/errors.rs
@@ -64,7 +64,7 @@ pub enum XmlWriteError {
 #[non_exhaustive]
 pub enum JsonReadError {
     #[error("Failed to deserialize JSON: {error}")]
-    JsonElementWriteError {
+    JsonElementReadError {
         #[from]
         error: serde_json::Error,
     },


### PR DESCRIPTION
This is to match the variant with its enum type name.