### PR TITLE
Add spec version type

### DIFF
--- a/cyclonedx-bom/src/errors.rs
+++ b/cyclonedx-bom/src/errors.rs
@@ -27,6 +27,9 @@ pub enum BomError {
 
     #[error("Failed to serialize BOM to v1.3: {0}")]
     BomV13SerializationError(String),
+
+    #[error("Unsupported Spec Version '{0}'")]
+    UnsupportedSpecVersion(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -63,10 +66,18 @@ pub enum XmlWriteError {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum JsonReadError {
+    #[error("IO Error #{0}")]
+    IoError(#[from] std::io::Error),
+
     #[error("Failed to deserialize JSON: {error}")]
     JsonElementReadError {
         #[from]
         error: serde_json::Error,
+    },
+    #[error("Invalid input format found: {error}")]
+    BomError {
+        #[from]
+        error: BomError,
     },
 }
 

--- a/cyclonedx-bom/src/errors.rs
+++ b/cyclonedx-bom/src/errors.rs
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::models::bom::SpecVersion;
+
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum BomError {
@@ -25,8 +27,8 @@ pub enum BomError {
     #[error("Failed to serialize BOM to XML: {0}")]
     XmlSerializationError(String),
 
-    #[error("Failed to serialize BOM to v1.3: {0}")]
-    BomV13SerializationError(String),
+    #[error("Failed to serialize BOM with version {0:?}: {1}")]
+    BomSerializationError(SpecVersion, String),
 
     #[error("Unsupported Spec Version '{0}'")]
     UnsupportedSpecVersion(String),

--- a/cyclonedx-bom/src/specs/v1_3/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_3/bom.rs
@@ -17,6 +17,7 @@
  */
 
 use crate::errors::BomError;
+use crate::models::bom::SpecVersion;
 use crate::{
     models::{self},
     utilities::{convert_optional, try_convert_optional},
@@ -46,7 +47,7 @@ struct Vulnerabilities();
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Bom {
     bom_format: BomFormat,
-    spec_version: String,
+    spec_version: SpecVersion,
     version: Option<u32>,
     serial_number: Option<UrnUuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -72,7 +73,7 @@ impl From<models::bom::Bom> for Bom {
     fn from(other: models::bom::Bom) -> Self {
         Self {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.3".to_string(),
+            spec_version: SpecVersion::V1_3,
             version: Some(other.version),
             serial_number: convert_optional(other.serial_number),
             metadata: convert_optional(other.metadata),
@@ -94,7 +95,7 @@ impl TryFrom<models::bom::Bom> for Bom {
     fn try_from(other: models::bom::Bom) -> Result<Self, Self::Error> {
         Ok(Self {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.3".to_string(),
+            spec_version: SpecVersion::V1_3,
             version: Some(other.version),
             serial_number: convert_optional(other.serial_number),
             metadata: try_convert_optional(other.metadata)?,
@@ -329,7 +330,7 @@ impl FromXmlDocument for Bom {
             })?;
         Ok(Self {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.3".to_string(),
+            spec_version: SpecVersion::V1_3,
             version,
             serial_number,
             metadata,
@@ -387,7 +388,7 @@ pub(crate) mod test {
     pub(crate) fn minimal_bom_example() -> Bom {
         Bom {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.3".to_string(),
+            spec_version: SpecVersion::V1_3,
             version: Some(1),
             serial_number: Some(UrnUuid("fake-uuid".to_string())),
             metadata: None,
@@ -404,7 +405,7 @@ pub(crate) mod test {
     pub(crate) fn full_bom_example() -> Bom {
         Bom {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.3".to_string(),
+            spec_version: SpecVersion::V1_3,
             version: Some(1),
             serial_number: Some(UrnUuid("fake-uuid".to_string())),
             metadata: Some(example_metadata()),

--- a/cyclonedx-bom/src/specs/v1_4/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_4/bom.rs
@@ -17,7 +17,7 @@
  */
 
 use crate::{
-    models::{self},
+    models::{self, bom::SpecVersion},
     utilities::convert_optional,
     xml::{
         expected_namespace_or_error, optional_attribute, read_lax_validation_tag,
@@ -40,7 +40,7 @@ use xml::{reader, writer::XmlEvent};
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Bom {
     bom_format: BomFormat,
-    spec_version: String,
+    spec_version: SpecVersion,
     version: Option<u32>,
     serial_number: Option<UrnUuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -65,7 +65,7 @@ impl From<models::bom::Bom> for Bom {
     fn from(other: models::bom::Bom) -> Self {
         Self {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.4".to_string(),
+            spec_version: SpecVersion::V1_4,
             version: Some(other.version),
             serial_number: convert_optional(other.serial_number),
             metadata: convert_optional(other.metadata),
@@ -316,7 +316,7 @@ impl FromXmlDocument for Bom {
             })?;
         Ok(Self {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.4".to_string(),
+            spec_version: SpecVersion::V1_4,
             version,
             serial_number,
             metadata,
@@ -376,7 +376,7 @@ pub(crate) mod test {
     pub(crate) fn minimal_bom_example() -> Bom {
         Bom {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.4".to_string(),
+            spec_version: SpecVersion::V1_4,
             version: Some(1),
             serial_number: Some(UrnUuid("fake-uuid".to_string())),
             metadata: None,
@@ -393,7 +393,7 @@ pub(crate) mod test {
     pub(crate) fn full_bom_example() -> Bom {
         Bom {
             bom_format: BomFormat::CycloneDX,
-            spec_version: "1.4".to_string(),
+            spec_version: SpecVersion::V1_4,
             version: Some(1),
             serial_number: Some(UrnUuid("fake-uuid".to_string())),
             metadata: Some(example_metadata()),


### PR DESCRIPTION
This PR refactors handling of the spec version by adding the `SpecVersion` enum type to indicate all supported versions. Currently it contains variants for specification 1.3 and 1.4. With this change it should be easier to check for supported spec versions, instead of using a stringified version type.

* refactor `BomV13SerializationError` variant to contain `SpecVersion` within a more generalized `BomSerializationError`
* add test to check this particular error is raised in the Bom conversion