### PR TITLE
Add function to parse JSON without version

### DIFF
--- a/cyclonedx-bom/src/errors.rs
+++ b/cyclonedx-bom/src/errors.rs
@@ -68,9 +68,6 @@ pub enum XmlWriteError {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum JsonReadError {
-    #[error("IO Error #{0}")]
-    IoError(#[from] std::io::Error),
-
     #[error("Failed to deserialize JSON: {error}")]
     JsonElementReadError {
         #[from]


### PR DESCRIPTION
This adds a new function `Bom::parse_from_json` to parse JSON content without specifying a version. The function expects the `specVersion` field to be present in the JSON input. Depending on its value the appropriate conversion is executed or an error returned. 