### PR TITLE
Add support for `signature` field in 1.4

### DIFF
--- a/cyclonedx-bom/src/errors.rs
+++ b/cyclonedx-bom/src/errors.rs
@@ -98,6 +98,9 @@ pub enum XmlReadError {
         element: String,
     },
 
+    #[error("Invalid enum value '{value}' given in {element}")]
+    InvalidEnumVariant { value: String, element: String },
+
     #[error("Could not parse {value} as {data_type} on {element}")]
     InvalidParseError {
         value: String,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -35,6 +35,7 @@ use crate::models::external_reference::ExternalReferences;
 use crate::models::metadata::Metadata;
 use crate::models::property::Properties;
 use crate::models::service::{Service, Services};
+use crate::models::signature::Signature;
 use crate::models::vulnerability::Vulnerabilities;
 use crate::validation::{
     FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
@@ -85,7 +86,10 @@ pub struct Bom {
     pub dependencies: Option<Dependencies>,
     pub compositions: Option<Compositions>,
     pub properties: Option<Properties>,
+    /// Added in version 1.4
     pub vulnerabilities: Option<Vulnerabilities>,
+    /// Added in version 1.4
+    pub signature: Option<Signature>,
 }
 
 impl Bom {
@@ -214,6 +218,7 @@ impl Default for Bom {
             compositions: None,
             properties: None,
             vulnerabilities: None,
+            signature: None,
         }
     }
 }
@@ -617,6 +622,7 @@ mod test {
             compositions: None,
             properties: None,
             vulnerabilities: None,
+            signature: None,
         };
 
         let actual = bom
@@ -642,6 +648,7 @@ mod test {
             compositions: None,
             properties: None,
             vulnerabilities: None,
+            signature: None,
         };
 
         let actual = bom.validate().expect("Failed to validate bom");
@@ -701,6 +708,7 @@ mod test {
             }])),
             properties: None,
             vulnerabilities: None,
+            signature: None,
         };
 
         let actual = bom.validate().expect("Failed to validate bom");
@@ -841,6 +849,7 @@ mod test {
                 vulnerability_targets: None,
                 properties: None,
             }])),
+            signature: None,
         };
 
         let actual = bom
@@ -1001,6 +1010,7 @@ mod test {
             compositions: None,
             properties: None,
             vulnerabilities: None,
+            signature: None,
         }
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -702,6 +702,7 @@ mod test {
                 aggregate: AggregateType::Complete,
                 assemblies: Some(vec![BomReference("assembly".to_string())]),
                 dependencies: Some(vec![BomReference("dependencies".to_string())]),
+                signature: None,
             }])),
             properties: None,
             vulnerabilities: None,
@@ -823,6 +824,7 @@ mod test {
                 aggregate: AggregateType::UnknownAggregateType("unknown".to_string()),
                 assemblies: None,
                 dependencies: None,
+                signature: None,
             }])),
             properties: Some(Properties(vec![Property {
                 name: "name".to_string(),

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -805,6 +805,7 @@ mod test {
                 external_references: None,
                 properties: None,
                 services: None,
+                signature: None,
             }])),
             external_references: Some(ExternalReferences(vec![ExternalReference {
                 external_reference_type: ExternalReferenceType::UnknownExternalReferenceType(

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -791,6 +791,7 @@ mod test {
                 properties: None,
                 components: None,
                 evidence: None,
+                signature: None,
             }])),
             services: Some(Services(vec![Service {
                 bom_ref: None,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -109,10 +109,7 @@ impl Bom {
                 SpecVersion::V1_4 => Ok(crate::specs::v1_4::bom::Bom::deserialize(json)?.into()),
             }
         } else {
-            return Err(BomError::UnsupportedSpecVersion(
-                "No field 'specVersion' found".to_string(),
-            )
-            .into());
+            Err(BomError::UnsupportedSpecVersion("No field 'specVersion' found".to_string()).into())
         }
     }
 

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -36,6 +36,8 @@ use crate::{
     validation::{Validate, ValidationContext, ValidationError, ValidationResult},
 };
 
+use super::signature::Signature;
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Component {
     pub component_type: Classification,
@@ -61,6 +63,8 @@ pub struct Component {
     pub properties: Option<Properties>,
     pub components: Option<Components>,
     pub evidence: Option<ComponentEvidence>,
+    /// Added in version 1.4
+    pub signature: Option<Signature>,
 }
 
 impl Component {
@@ -94,6 +98,7 @@ impl Component {
             properties: None,
             components: None,
             evidence: None,
+            signature: None,
         }
     }
 }
@@ -608,6 +613,7 @@ mod test {
             hash::{Hash, HashAlgorithm, HashValue},
             license::LicenseChoice,
             property::Property,
+            signature::Algorithm,
         },
         validation::ValidationPathComponent,
     };
@@ -691,6 +697,10 @@ mod test {
                     "MIT".to_string(),
                 ))])),
                 copyright: Some(CopyrightTexts(vec![Copyright("copyright".to_string())])),
+            }),
+            signature: Some(Signature {
+                algorithm: Algorithm::HS512,
+                value: "abcdefgh".to_string(),
             }),
         }])
         .validate_with_context(ValidationContext::default())
@@ -779,6 +789,10 @@ mod test {
                     "invalid license".to_string(),
                 ))])),
                 copyright: Some(CopyrightTexts(vec![Copyright("copyright".to_string())])),
+            }),
+            signature: Some(Signature {
+                algorithm: Algorithm::HS512,
+                value: "abcdefgh".to_string(),
             }),
         }])
         .validate_with_context(ValidationContext::default())
@@ -1194,6 +1208,7 @@ mod test {
             properties: None,
             components: None,
             evidence: None,
+            signature: None,
         }
     }
 }

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -21,11 +21,14 @@ use crate::validation::{
     ValidationResult,
 };
 
+use super::signature::Signature;
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct Composition {
     pub aggregate: AggregateType,
     pub assemblies: Option<Vec<BomReference>>,
     pub dependencies: Option<Vec<BomReference>>,
+    pub signature: Option<Signature>,
 }
 
 impl Validate for Composition {
@@ -131,6 +134,8 @@ pub struct BomReference(pub(crate) String);
 
 #[cfg(test)]
 mod test {
+    use crate::models::signature::Algorithm;
+
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -140,6 +145,10 @@ mod test {
             aggregate: AggregateType::Complete,
             assemblies: Some(vec![BomReference("reference".to_string())]),
             dependencies: Some(vec![BomReference("reference".to_string())]),
+            signature: Some(Signature {
+                algorithm: Algorithm::HS512,
+                value: "abcdefgh".to_string(),
+            }),
         }])
         .validate()
         .expect("Error while validating");
@@ -153,6 +162,10 @@ mod test {
             aggregate: AggregateType::UnknownAggregateType("unknown aggregate type".to_string()),
             assemblies: Some(vec![BomReference("reference".to_string())]),
             dependencies: Some(vec![BomReference("reference".to_string())]),
+            signature: Some(Signature {
+                algorithm: Algorithm::HS512,
+                value: "abcdefgh".to_string(),
+            }),
         }])
         .validate()
         .expect("Error while validating");

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -191,6 +191,7 @@ mod test {
                 properties: None,
                 components: None,
                 evidence: None,
+                signature: None,
             }),
             manufacture: Some(OrganizationalEntity {
                 name: Some(NormalizedString::new("name")),
@@ -255,6 +256,7 @@ mod test {
                 properties: None,
                 components: None,
                 evidence: None,
+                signature: None,
             }),
             manufacture: Some(OrganizationalEntity {
                 name: Some(NormalizedString("invalid\tname".to_string())),

--- a/cyclonedx-bom/src/models/mod.rs
+++ b/cyclonedx-bom/src/models/mod.rs
@@ -30,6 +30,7 @@ pub mod metadata;
 pub mod organization;
 pub mod property;
 pub mod service;
+pub mod signature;
 pub mod tool;
 pub mod vulnerability;
 pub mod vulnerability_analysis;

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -26,6 +26,8 @@ use crate::validation::{
     ValidationResult,
 };
 
+use super::signature::Signature;
+
 /// Represents a service as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#service-definition)
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_service)
@@ -45,6 +47,8 @@ pub struct Service {
     pub external_references: Option<ExternalReferences>,
     pub properties: Option<Properties>,
     pub services: Option<Services>,
+    /// Added in version 1.4
+    pub signature: Option<Signature>,
 }
 
 impl Service {
@@ -70,6 +74,7 @@ impl Service {
             external_references: None,
             properties: None,
             services: None,
+            signature: None,
         }
     }
 }
@@ -284,6 +289,7 @@ mod test {
             external_reference::{ExternalReference, ExternalReferenceType},
             license::LicenseChoice,
             property::Property,
+            signature::Algorithm,
         },
     };
 
@@ -324,6 +330,10 @@ mod test {
                 value: NormalizedString::new("value"),
             }])),
             services: Some(Services(vec![])),
+            signature: Some(Signature {
+                algorithm: Algorithm::HS512,
+                value: "abcdefgh".to_string(),
+            }),
         }])
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");
@@ -381,7 +391,12 @@ mod test {
                 external_references: None,
                 properties: None,
                 services: None,
+                signature: None,
             }])),
+            signature: Some(Signature {
+                algorithm: Algorithm::HS512,
+                value: "abcdefgh".to_string(),
+            }),
         }])
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");

--- a/cyclonedx-bom/src/models/signature.rs
+++ b/cyclonedx-bom/src/models/signature.rs
@@ -1,0 +1,115 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::str::FromStr;
+
+/// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
+#[derive(Debug, PartialEq, Eq)]
+pub struct Signature {
+    /// Signature algorithm.
+    pub algorithm: Algorithm,
+    /// The signature data.
+    pub value: String,
+}
+
+/*
+/// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
+#[derive(Debug, PartialEq, Eq)]
+pub enum Signature {
+    /// Multiple signatures
+    Signers(Vec<Signer>),
+    /// A single signature chain
+    Chain(Signer),
+    /// A single signature
+    Signature(Signer),
+}
+
+/// For now the [`Signer`] struct only holds algorithm and value
+#[derive(Debug, PartialEq, Eq)]
+pub struct Signer {
+    /// Signature algorithm.
+    pub algorithm: Algorithm,
+    /// The signature data.
+    pub value: String,
+}
+*/
+
+/// Supported signature algorithms.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Algorithm {
+    RS256,
+    RS384,
+    RS512,
+    PS256,
+    PS384,
+    PS512,
+    ES256,
+    ES384,
+    ES512,
+    Ed25519,
+    Ed448,
+    HS256,
+    HS384,
+    HS512,
+}
+
+impl FromStr for Algorithm {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RS256" => Ok(Algorithm::RS256),
+            "RS384" => Ok(Algorithm::RS384),
+            "RS512" => Ok(Algorithm::RS512),
+            "PS256" => Ok(Algorithm::PS256),
+            "PS384" => Ok(Algorithm::PS384),
+            "PS512" => Ok(Algorithm::PS512),
+            "ES256" => Ok(Algorithm::ES256),
+            "ES384" => Ok(Algorithm::ES384),
+            "ES512" => Ok(Algorithm::ES512),
+            "Ed25519" => Ok(Algorithm::Ed25519),
+            "Ed448" => Ok(Algorithm::Ed448),
+            "HS256" => Ok(Algorithm::HS256),
+            "HS384" => Ok(Algorithm::HS384),
+            "HS512" => Ok(Algorithm::HS512),
+            _ => Err(format!("Invalid algorithm '{}' found", s)),
+        }
+    }
+}
+
+impl ToString for Algorithm {
+    fn to_string(&self) -> String {
+        let s = match self {
+            Algorithm::RS256 => "RS256",
+            Algorithm::RS384 => "RS384",
+            Algorithm::RS512 => "RS512",
+            Algorithm::PS256 => "PS256",
+            Algorithm::PS384 => "PS384",
+            Algorithm::PS512 => "PS512",
+            Algorithm::ES256 => "ES256",
+            Algorithm::ES384 => "ES384",
+            Algorithm::ES512 => "ES512",
+            Algorithm::Ed25519 => "Ed25519",
+            Algorithm::Ed448 => "Ed448",
+            Algorithm::HS256 => "HS256",
+            Algorithm::HS384 => "HS384",
+            Algorithm::HS512 => "HS512",
+        };
+        s.to_string()
+    }
+}

--- a/cyclonedx-bom/src/specs/v1_3/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_3/bom.rs
@@ -123,6 +123,7 @@ impl From<Bom> for models::bom::Bom {
             compositions: convert_optional(other.compositions),
             properties: convert_optional(other.properties),
             vulnerabilities: None,
+            signature: None,
         }
     }
 }
@@ -431,6 +432,7 @@ pub(crate) mod test {
             compositions: Some(corresponding_compositions()),
             properties: Some(corresponding_properties()),
             vulnerabilities: None,
+            signature: None,
         }
     }
 

--- a/cyclonedx-bom/src/specs/v1_3/component.rs
+++ b/cyclonedx-bom/src/specs/v1_3/component.rs
@@ -225,6 +225,7 @@ impl From<Component> for models::component::Component {
             properties: convert_optional(other.properties),
             components: convert_optional(other.components),
             evidence: convert_optional(other.evidence),
+            signature: None, // Not supported in 1.3
         }
     }
 }
@@ -1256,6 +1257,7 @@ pub(crate) mod test {
             properties: Some(corresponding_properties()),
             components: Some(corresponding_empty_components()),
             evidence: Some(corresponding_evidence()),
+            signature: None,
         }
     }
 

--- a/cyclonedx-bom/src/specs/v1_3/composition.rs
+++ b/cyclonedx-bom/src/specs/v1_3/composition.rs
@@ -106,6 +106,7 @@ impl From<Composition> for models::composition::Composition {
             aggregate: models::composition::AggregateType::new_unchecked(other.aggregate),
             assemblies: convert_optional_vec(other.assemblies),
             dependencies: convert_optional_vec(other.dependencies),
+            signature: None,
         }
     }
 }
@@ -311,6 +312,7 @@ pub(crate) mod test {
             dependencies: Some(vec![models::composition::BomReference(
                 "dependency".to_string(),
             )]),
+            signature: None,
         }
     }
 

--- a/cyclonedx-bom/src/specs/v1_3/service.rs
+++ b/cyclonedx-bom/src/specs/v1_3/service.rs
@@ -160,6 +160,7 @@ impl From<Service> for models::service::Service {
             external_references: convert_optional(other.external_references),
             properties: convert_optional(other.properties),
             services: convert_optional(other.services),
+            signature: None,
         }
     }
 }
@@ -540,6 +541,7 @@ pub(crate) mod test {
             external_references: Some(corresponding_external_references()),
             properties: Some(corresponding_properties()),
             services: Some(models::service::Services(vec![])),
+            signature: None,
         }
     }
 

--- a/cyclonedx-bom/src/specs/v1_4/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_4/bom.rs
@@ -815,6 +815,10 @@ pub(crate) mod test {
       <dependencies>
         <dependency ref="dependency" />
       </dependencies>
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </composition>
   </compositions>
   <properties>

--- a/cyclonedx-bom/src/specs/v1_4/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_4/bom.rs
@@ -786,6 +786,10 @@ pub(crate) mod test {
         <property name="name">value</property>
       </properties>
       <services />
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </service>
   </services>
   <externalReferences>

--- a/cyclonedx-bom/src/specs/v1_4/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_4/bom.rs
@@ -613,6 +613,10 @@ pub(crate) mod test {
           <text><![CDATA[copyright]]></text>
         </copyright>
       </evidence>
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </component>
     <manufacture>
       <name>name</name>
@@ -737,6 +741,10 @@ pub(crate) mod test {
           <text><![CDATA[copyright]]></text>
         </copyright>
       </evidence>
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </component>
   </components>
   <services>

--- a/cyclonedx-bom/src/specs/v1_4/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_4/bom.rs
@@ -29,7 +29,7 @@ use crate::{
     specs::v1_4::{
         component::Components, composition::Compositions, dependency::Dependencies,
         external_reference::ExternalReferences, metadata::Metadata, property::Properties,
-        service::Services, vulnerability::Vulnerabilities,
+        service::Services, signature::Signature, vulnerability::Vulnerabilities,
     },
     xml::ToXml,
 };
@@ -59,6 +59,8 @@ pub(crate) struct Bom {
     properties: Option<Properties>,
     #[serde(skip_serializing_if = "Option::is_none")]
     vulnerabilities: Option<Vulnerabilities>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    signature: Option<Signature>,
 }
 
 impl From<models::bom::Bom> for Bom {
@@ -76,6 +78,7 @@ impl From<models::bom::Bom> for Bom {
             compositions: convert_optional(other.compositions),
             properties: convert_optional(other.properties),
             vulnerabilities: convert_optional(other.vulnerabilities),
+            signature: convert_optional(other.signature),
         }
     }
 }
@@ -93,6 +96,7 @@ impl From<Bom> for models::bom::Bom {
             compositions: convert_optional(other.compositions),
             properties: convert_optional(other.properties),
             vulnerabilities: convert_optional(other.vulnerabilities),
+            signature: convert_optional(other.signature),
         }
     }
 }
@@ -170,6 +174,7 @@ const DEPENDENCIES_TAG: &str = "dependencies";
 const COMPOSITIONS_TAG: &str = "compositions";
 const PROPERTIES_TAG: &str = "properties";
 const VULNERABILITIES_TAG: &str = "vulnerabilities";
+const SIGNATURE_TAG: &str = "signature";
 
 impl FromXmlDocument for Bom {
     fn read_xml_document<R: std::io::Read>(
@@ -218,6 +223,7 @@ impl FromXmlDocument for Bom {
         let mut compositions: Option<Compositions> = None;
         let mut properties: Option<Properties> = None;
         let mut vulnerabilities: Option<Vulnerabilities> = None;
+        let mut signature: Option<Signature> = None;
 
         let mut got_end_tag = false;
         while !got_end_tag {
@@ -295,6 +301,15 @@ impl FromXmlDocument for Bom {
                         &attributes,
                     )?)
                 }
+                reader::XmlEvent::StartElement {
+                    name, attributes, ..
+                } if name.local_name == SIGNATURE_TAG => {
+                    signature = Some(Signature::read_xml_element(
+                        event_reader,
+                        &name,
+                        &attributes,
+                    )?)
+                }
 
                 // lax validation of any elements from a different schema
                 reader::XmlEvent::StartElement { name, .. } => {
@@ -327,6 +342,7 @@ impl FromXmlDocument for Bom {
             compositions,
             properties,
             vulnerabilities,
+            signature,
         })
     }
 }
@@ -367,6 +383,7 @@ pub(crate) mod test {
             metadata::test::{corresponding_metadata, example_metadata},
             property::test::{corresponding_properties, example_properties},
             service::test::{corresponding_services, example_services},
+            signature::test::{corresponding_signature, example_signature},
         },
         xml::test::{read_document_from_string, write_element_to_string},
     };
@@ -387,6 +404,7 @@ pub(crate) mod test {
             compositions: None,
             properties: None,
             vulnerabilities: None,
+            signature: None,
         }
     }
 
@@ -404,6 +422,7 @@ pub(crate) mod test {
             compositions: Some(example_compositions()),
             properties: Some(example_properties()),
             vulnerabilities: Some(example_vulnerabilities()),
+            signature: Some(example_signature()),
         }
     }
 
@@ -419,6 +438,7 @@ pub(crate) mod test {
             compositions: Some(corresponding_compositions()),
             properties: Some(corresponding_properties()),
             vulnerabilities: Some(corresponding_vulnerabilities()),
+            signature: Some(corresponding_signature()),
         }
     }
 
@@ -892,6 +912,10 @@ pub(crate) mod test {
       </properties>
     </vulnerability>
   </vulnerabilities>
+  <signature>
+    <algorithm>HS512</algorithm>
+    <value>1234567890</value>
+  </signature>
   <example:laxValidation>
     <example:innerElement id="test" />
   </example:laxValidation>

--- a/cyclonedx-bom/src/specs/v1_4/metadata.rs
+++ b/cyclonedx-bom/src/specs/v1_4/metadata.rs
@@ -439,6 +439,10 @@ pub(crate) mod test {
         <text><![CDATA[copyright]]></text>
       </copyright>
     </evidence>
+    <signature>
+      <algorithm>HS512</algorithm>
+      <value>1234567890</value>
+    </signature>
   </component>
   <manufacture>
     <name>name</name>

--- a/cyclonedx-bom/src/specs/v1_4/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_4/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod metadata;
 pub(crate) mod organization;
 pub(crate) mod property;
 pub(crate) mod service;
+pub(crate) mod signature;
 pub(crate) mod tool;
 pub(crate) mod vulnerability;
 pub(crate) mod vulnerability_analysis;

--- a/cyclonedx-bom/src/specs/v1_4/signature.rs
+++ b/cyclonedx-bom/src/specs/v1_4/signature.rs
@@ -1,0 +1,283 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use xml::reader;
+
+use crate::{
+    errors::XmlReadError,
+    models,
+    xml::{read_simple_tag, to_xml_read_error, unexpected_element_error, FromXml},
+};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Signature {
+    pub algorithm: Algorithm,
+    pub value: String,
+}
+
+impl From<models::signature::Signature> for Signature {
+    fn from(other: models::signature::Signature) -> Self {
+        Signature {
+            algorithm: other.algorithm.into(),
+            value: other.value,
+        }
+    }
+}
+
+impl From<Signature> for models::signature::Signature {
+    fn from(other: Signature) -> Self {
+        models::signature::Signature {
+            algorithm: other.algorithm.into(),
+            value: other.value,
+        }
+    }
+}
+
+/// Supported signature algorithms.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub enum Algorithm {
+    RS256,
+    RS384,
+    RS512,
+    PS256,
+    PS384,
+    PS512,
+    ES256,
+    ES384,
+    ES512,
+    Ed25519,
+    Ed448,
+    HS256,
+    HS384,
+    HS512,
+}
+
+impl FromStr for Algorithm {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "RS256" => Ok(Algorithm::RS256),
+            "RS384" => Ok(Algorithm::RS384),
+            "RS512" => Ok(Algorithm::RS512),
+            "PS256" => Ok(Algorithm::PS256),
+            "PS384" => Ok(Algorithm::PS384),
+            "PS512" => Ok(Algorithm::PS512),
+            "ES256" => Ok(Algorithm::ES256),
+            "ES384" => Ok(Algorithm::ES384),
+            "ES512" => Ok(Algorithm::ES512),
+            "Ed25519" => Ok(Algorithm::Ed25519),
+            "Ed448" => Ok(Algorithm::Ed448),
+            "HS256" => Ok(Algorithm::HS256),
+            "HS384" => Ok(Algorithm::HS384),
+            "HS512" => Ok(Algorithm::HS512),
+            _ => Err(format!("Invalid algorithm '{}' found", s)),
+        }
+    }
+}
+
+impl ToString for Algorithm {
+    fn to_string(&self) -> String {
+        let s = match self {
+            Algorithm::RS256 => "RS256",
+            Algorithm::RS384 => "RS384",
+            Algorithm::RS512 => "RS512",
+            Algorithm::PS256 => "PS256",
+            Algorithm::PS384 => "PS384",
+            Algorithm::PS512 => "PS512",
+            Algorithm::ES256 => "ES256",
+            Algorithm::ES384 => "ES384",
+            Algorithm::ES512 => "ES512",
+            Algorithm::Ed25519 => "Ed25519",
+            Algorithm::Ed448 => "Ed448",
+            Algorithm::HS256 => "HS256",
+            Algorithm::HS384 => "HS384",
+            Algorithm::HS512 => "HS512",
+        };
+        s.to_string()
+    }
+}
+
+impl From<models::signature::Algorithm> for Algorithm {
+    fn from(other: models::signature::Algorithm) -> Self {
+        other
+            .to_string()
+            .parse::<Algorithm>()
+            .expect("Failed to convert algorithm")
+    }
+}
+
+impl From<Algorithm> for models::signature::Algorithm {
+    fn from(other: Algorithm) -> Self {
+        other
+            .to_string()
+            .parse::<models::signature::Algorithm>()
+            .expect("Failed to convert algorithm")
+    }
+}
+
+const SIGNATURE_TAG: &str = "signature";
+const ALGORITHM_TAG: &str = "algorithm";
+const VALUE_TAG: &str = "value";
+
+impl FromXml for Signature {
+    fn read_xml_element<R: std::io::prelude::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        _attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, crate::errors::XmlReadError>
+    where
+        Self: Sized,
+    {
+        let mut algorithm: Option<String> = None;
+        let mut value: Option<String> = None;
+
+        let mut got_end_tag = false;
+        while !got_end_tag {
+            let next_element = event_reader
+                .next()
+                .map_err(to_xml_read_error(SIGNATURE_TAG))?;
+
+            match next_element {
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == ALGORITHM_TAG => {
+                    algorithm = Some(read_simple_tag(event_reader, &name)?);
+                }
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == VALUE_TAG => {
+                    value = Some(read_simple_tag(event_reader, &name)?);
+                }
+                reader::XmlEvent::EndElement { name } if &name == element_name => {
+                    got_end_tag = true;
+                }
+                unexpected => return Err(unexpected_element_error(element_name, unexpected)),
+            }
+        }
+
+        // get required attributesInvalidEnumVariant
+        let algorithm = algorithm.ok_or_else(|| XmlReadError::RequiredDataMissing {
+            required_field: ALGORITHM_TAG.to_string(),
+            element: SIGNATURE_TAG.to_string(),
+        })?;
+        let value = value.ok_or_else(|| XmlReadError::RequiredDataMissing {
+            required_field: VALUE_TAG.to_string(),
+            element: SIGNATURE_TAG.to_string(),
+        })?;
+
+        let algorithm =
+            algorithm
+                .parse::<Algorithm>()
+                .map_err(|_| XmlReadError::InvalidEnumVariant {
+                    value: algorithm.to_string(),
+                    element: ALGORITHM_TAG.to_string(),
+                })?;
+
+        Ok(Self { algorithm, value })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use xml::{name::OwnedName, EventReader, ParserConfig};
+
+    use crate::{
+        models,
+        xml::{test::read_element_from_string, FromXml},
+    };
+
+    use super::{Algorithm, Signature};
+
+    pub(crate) fn example_signature() -> Signature {
+        Signature {
+            algorithm: Algorithm::HS512,
+            value: "1234567890".to_string(),
+        }
+    }
+
+    pub(crate) fn corresponding_signature() -> models::signature::Signature {
+        models::signature::Signature {
+            algorithm: models::signature::Algorithm::HS512,
+            value: "1234567890".to_string(),
+        }
+    }
+
+    #[track_caller]
+    fn assert_valid_signature(input: &str, expected: Signature) {
+        let actual: Signature = read_element_from_string(input);
+        assert_eq!(actual, expected);
+    }
+
+    #[track_caller]
+    fn assert_invalid_signature(input: &str) {
+        let reader = input.to_string();
+        let config = ParserConfig::default().trim_whitespace(true);
+        let mut event_reader = EventReader::new_with_config(reader.as_bytes(), config);
+
+        let element_name = OwnedName::local("signature");
+        let actual = Signature::read_xml_element(&mut event_reader, &element_name, &[]);
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn it_should_read_valid_signature() {
+        let input = r#"
+<signature>
+    <algorithm>RS512</algorithm>
+    <value>abcdefghijklmnopqrstuvwxyz</value>
+</signature>
+"#;
+        let expected = Signature {
+            algorithm: Algorithm::RS512,
+            value: "abcdefghijklmnopqrstuvwxyz".to_string(),
+        };
+        assert_valid_signature(input, expected);
+    }
+
+    #[test]
+    fn it_shoud_fail_with_missing_value() {
+        let input = r#"
+<signature>
+    <algorithm><RS512/algorithm>
+</signature>
+"#;
+        assert_invalid_signature(input);
+    }
+
+    #[test]
+    fn it_should_fail_with_missing_algorithm() {
+        let input = r#"
+<signature>
+    <value>abcdefghijklmnopqrstuvwxyz</value>
+</signature>
+"#;
+        assert_invalid_signature(input);
+    }
+
+    #[test]
+    fn it_should_fail_with_invalid_algorithm() {
+        let input = r#"
+<signature>
+    <algorithm><ABCD/algorithm>
+    <value>abcdefghijklmnopqrstuvwxyz</value>
+</signature>
+"#;
+        assert_invalid_signature(input);
+    }
+}

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
@@ -441,7 +441,11 @@ expression: actual
       ],
       "dependencies": [
         "dependency"
-      ]
+      ],
+      "signature": {
+        "algorithm": "HS512",
+        "value": "1234567890"
+      }
     }
   ],
   "properties": [

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/v1_4/bom.rs
+assertion_line: 460
 expression: actual
 ---
 {
@@ -404,7 +405,11 @@ expression: actual
           "value": "value"
         }
       ],
-      "services": []
+      "services": [],
+      "signature": {
+        "algorithm": "HS512",
+        "value": "1234567890"
+      }
     }
   ],
   "externalReferences": [

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
@@ -551,5 +551,9 @@ expression: actual
         }
       ]
     }
-  ]
+  ],
+  "signature": {
+    "algorithm": "HS512",
+    "value": "1234567890"
+  }
 }

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_json.snap
@@ -163,6 +163,10 @@ expression: actual
             "text": "copyright"
           }
         ]
+      },
+      "signature": {
+        "algorithm": "HS512",
+        "value": "1234567890"
       }
     },
     "manufacture": {
@@ -338,6 +342,10 @@ expression: actual
             "text": "copyright"
           }
         ]
+      },
+      "signature": {
+        "algorithm": "HS512",
+        "value": "1234567890"
       }
     }
   ],

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -323,6 +323,10 @@ expression: xml_output
       <dependencies>
         <dependency ref="dependency" />
       </dependencies>
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </composition>
   </compositions>
   <properties>

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/v1_4/bom.rs
+assertion_line: 466
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -293,6 +294,10 @@ expression: xml_output
         <property name="name">value</property>
       </properties>
       <services />
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </service>
   </services>
   <externalReferences>

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__bom__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,6 +1,5 @@
 ---
 source: cyclonedx-bom/src/specs/v1_4/bom.rs
-assertion_line: 444
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -121,6 +120,10 @@ expression: xml_output
           <text><![CDATA[copyright]]></text>
         </copyright>
       </evidence>
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </component>
     <manufacture>
       <name>name</name>
@@ -245,6 +248,10 @@ expression: xml_output
           <text><![CDATA[copyright]]></text>
         </copyright>
       </evidence>
+      <signature>
+        <algorithm>HS512</algorithm>
+        <value>1234567890</value>
+      </signature>
     </component>
   </components>
   <services>

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__component__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__component__test__it_should_write_xml_full.snap
@@ -101,5 +101,9 @@ expression: xml_output
         <text><![CDATA[copyright]]></text>
       </copyright>
     </evidence>
+    <signature>
+      <algorithm>HS512</algorithm>
+      <value>1234567890</value>
+    </signature>
   </component>
 </components>

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__composition__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__composition__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/v1_4/composition.rs
+assertion_line: 347
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -12,5 +13,9 @@ expression: xml_output
     <dependencies>
       <dependency ref="dependency" />
     </dependencies>
+    <signature>
+      <algorithm>HS512</algorithm>
+      <value>1234567890</value>
+    </signature>
   </composition>
 </compositions>

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__metadata__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__metadata__test__it_should_write_xml_full.snap
@@ -119,6 +119,10 @@ expression: xml_output
         <text><![CDATA[copyright]]></text>
       </copyright>
     </evidence>
+    <signature>
+      <algorithm>HS512</algorithm>
+      <value>1234567890</value>
+    </signature>
   </component>
   <manufacture>
     <name>name</name>

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__service__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__service__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/v1_4/service.rs
+assertion_line: 603
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -42,5 +43,9 @@ expression: xml_output
       <property name="name">value</property>
     </properties>
     <services />
+    <signature>
+      <algorithm>HS512</algorithm>
+      <value>1234567890</value>
+    </signature>
   </service>
 </services>

--- a/cyclonedx-bom/src/specs/v1_4/vulnerability_target.rs
+++ b/cyclonedx-bom/src/specs/v1_4/vulnerability_target.rs
@@ -356,6 +356,7 @@ impl FromXml for Version {
     }
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 enum VersionRange {

--- a/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
@@ -1,7 +1,7 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_4.rs
 expression: bom_output
-input_file: cyclonedx-bom/tests/data/1.4/valid-signatures-1.4.json
+input_file: cyclonedx-bom/tests/spec/1.4/valid-signatures-1.4.json
 ---
 {
   "bomFormat": "CycloneDX",
@@ -47,5 +47,9 @@ input_file: cyclonedx-bom/tests/data/1.4/valid-signatures-1.4.json
         "5366293e-0740-4dcf-b1d0-0c1fc26e4981"
       ]
     }
-  ]
+  ],
+  "signature": {
+    "algorithm": "ES256",
+    "value": "m4pMbQQVV61TlP4Og7a75SeY8lh00LkkUDXZ4PIhXsR512MPRgZmusFYorJlYq9wM3P9n9gM3T8BTg9XdFdQkQ"
+  }
 }

--- a/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_4.rs
+assertion_line: 54
 expression: bom_output
 input_file: cyclonedx-bom/tests/spec/1.4/valid-signatures-1.4.json
 ---
@@ -37,7 +38,11 @@ input_file: cyclonedx-bom/tests/spec/1.4/valid-signatures-1.4.json
           "flow": "inbound",
           "classification": "PII"
         }
-      ]
+      ],
+      "signature": {
+        "algorithm": "ES256",
+        "value": "6A77T3RBTAuVpZOgFFFfOvGOQ1hqMbfSQ91VucRM1RIP6QqX9kEF1Pi1_vCl37qpVzK51kIyppgUF_i9s999XA"
+      }
     }
   ],
   "compositions": [

--- a/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
@@ -54,7 +54,11 @@ input_file: cyclonedx-bom/tests/spec/1.4/valid-signatures-1.4.json
       ],
       "dependencies": [
         "5366293e-0740-4dcf-b1d0-0c1fc26e4981"
-      ]
+      ],
+      "signature": {
+        "algorithm": "ES256",
+        "value": "lm6wx-elyBTbNMKNF8riooZhvrm6f5j8JpvgP9JtVv50dd7sXQLH7PqJcn9fmKV8eoF8cszPllEsQQhEQOM4hA"
+      }
     }
   ],
   "signature": {

--- a/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-signatures-1.4.json.snap
@@ -13,7 +13,11 @@ input_file: cyclonedx-bom/tests/spec/1.4/valid-signatures-1.4.json
       "type": "application",
       "bom-ref": "5366293e-0740-4dcf-b1d0-0c1fc26e4981",
       "name": "amce app",
-      "version": "1.0"
+      "version": "1.0",
+      "signature": {
+        "algorithm": "ES256",
+        "value": "tqITqIm0gUMWXIjqDgwqzqPw1CwTUKRewZQ5YpX3VwFMWV68NJgX4npU91cSwSC-MRlx1QfOYwSQkeU26VpXSg"
+      }
     }
   ],
   "services": [


### PR DESCRIPTION
This PR adds support for the [signature](https://cyclonedx.org/docs/1.4/json/#signature) field. The signature field can appear in three different versions, for now only the flat [`Signature` option](https://cyclonedx.org/docs/1.4/json/#tab-pane_signature_oneOf_i2) is implemented with required fields `algorithm` & `value` to get started. Support for the other versions can follow later, the internal Signature struct would need to change to support multiple options (by using an enum) but unfortunately have not found a good way to do that at this point.

The `signature` field needs to be added to the following nodes in the spec: `components`, `services` & `compositions`. The validation of the provided algorithm needs to move out from the parse logic.

* add `Signature` & `Algorithm` types with serialization / deserialization logic for JSON and XML
* add `signature` field to `Bom` & `Component` (metadata) structs, is ignored in version 1.3 (set to `None`)
* adjust samples / snapshots to include new signature field
* update tests
* add comments to signal which fields are new in version 1.4