### PR TITLE
Attack of the clones

### DIFF
--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -40,7 +40,7 @@ use crate::validation::{
 ///
 /// assert_eq!(date_time.to_string(), timestamp);
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DateTime(pub(crate) String);
 
 impl DateTime {

--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -25,7 +25,7 @@ use std::ops::Deref;
 /// A string that does not contain carriage return, line feed, or tab characters
 ///
 /// Defined via the [XML schema](https://www.w3.org/TR/xmlschema-2/#normalizedString)
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NormalizedString(pub(crate) String);
 
 impl NormalizedString {

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -36,7 +36,7 @@ use crate::validation::{FailureReason, Validate, ValidationResult};
 /// assert_eq!(spdx_identifier.to_string(), identifier);
 /// # Ok::<(), SpdxIdentifierError>(())
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpdxIdentifier(pub(crate) String);
 
 impl SpdxIdentifier {
@@ -119,7 +119,7 @@ pub enum SpdxIdentifierError {
 /// assert_eq!(spdx_expression.to_string(), expression);
 /// # Ok::<(), SpdxExpressionError>(())
 /// ```
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SpdxExpression(pub(crate) String);
 
 impl SpdxExpression {

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -24,7 +24,7 @@ use crate::validation::{
 /// Represents an advisory, a notification of a threat to a component, service, or system.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_advisoryType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Advisory {
     pub title: Option<NormalizedString>,
     pub url: Uri,
@@ -68,7 +68,7 @@ impl Validate for Advisory {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Advisories(pub Vec<Advisory>);
 
 impl Validate for Advisories {

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -23,7 +23,7 @@ use crate::{
     validation::{FailureReason, Validate, ValidationContext, ValidationError, ValidationResult},
 };
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AttachedText {
     pub(crate) content_type: Option<NormalizedString>,
     pub(crate) encoding: Option<Encoding>,
@@ -86,7 +86,7 @@ impl Validate for AttachedText {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Encoding {
     Base64,
     #[doc(hidden)]

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -75,7 +75,7 @@ impl ToString for SpecVersion {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Bom {
     pub version: u32,
     pub serial_number: Option<UrnUuid>,
@@ -510,7 +510,7 @@ fn validate_services(
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UrnUuid(pub(crate) String);
 
 impl UrnUuid {
@@ -558,7 +558,7 @@ impl Validate for UrnUuid {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum UrnUuidError {
     InvalidUrnUuid(String),
 }

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use super::attached_text::AttachedText;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Commit {
     pub uid: Option<NormalizedString>,
     pub url: Option<Uri>,
@@ -78,7 +78,7 @@ impl Validate for Commit {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Commits(pub Vec<Commit>);
 
 impl Validate for Commits {
@@ -100,7 +100,7 @@ impl Validate for Commits {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Diff {
     pub text: Option<AttachedText>,
     pub url: Option<Uri>,
@@ -131,7 +131,7 @@ impl Validate for Diff {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IdentifiableAction {
     pub timestamp: Option<DateTime>,
     pub name: Option<NormalizedString>,
@@ -170,7 +170,7 @@ impl Validate for IdentifiableAction {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Issue {
     pub issue_type: IssueClassification,
     pub id: Option<NormalizedString>,
@@ -234,7 +234,7 @@ impl Validate for Issue {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IssueClassification {
     Defect,
     Enhancement,
@@ -283,7 +283,7 @@ impl Validate for IssueClassification {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Patch {
     pub patch_type: PatchClassification,
     pub diff: Option<Diff>,
@@ -326,7 +326,7 @@ impl Validate for Patch {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Patches(pub Vec<Patch>);
 
 impl Validate for Patches {
@@ -347,7 +347,7 @@ impl Validate for Patches {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PatchClassification {
     Unofficial,
     Monkey,
@@ -399,7 +399,7 @@ impl Validate for PatchClassification {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Source {
     pub name: Option<NormalizedString>,
     pub url: Option<Uri>,

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -38,7 +38,7 @@ use crate::{
 
 use super::signature::Signature;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Component {
     pub component_type: Classification,
     pub mime_type: Option<MimeType>,
@@ -243,7 +243,7 @@ impl Validate for Component {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Components(pub Vec<Component>);
 
 impl Validate for Components {
@@ -264,7 +264,7 @@ impl Validate for Components {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Classification {
     Application,
     Framework,
@@ -328,7 +328,7 @@ impl Validate for Classification {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Scope {
     Required,
     Optional,
@@ -377,7 +377,7 @@ impl Validate for Scope {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MimeType(pub(crate) String);
 
 impl Validate for MimeType {
@@ -406,7 +406,7 @@ impl Validate for MimeType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Swid {
     pub tag_id: String,
     pub name: String,
@@ -442,7 +442,7 @@ impl Validate for Swid {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cpe(pub(crate) String);
 
 impl FromStr for Cpe {
@@ -484,7 +484,7 @@ impl Validate for Cpe {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ComponentEvidence {
     pub licenses: Option<Licenses>,
     pub copyright: Option<CopyrightTexts>,
@@ -516,7 +516,7 @@ impl Validate for ComponentEvidence {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Pedigree {
     pub ancestors: Option<Components>,
     pub descendants: Option<Components>,
@@ -569,7 +569,7 @@ impl Validate for Pedigree {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Copyright(pub String);
 
 impl Validate for Copyright {
@@ -581,7 +581,7 @@ impl Validate for Copyright {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CopyrightTexts(pub(crate) Vec<Copyright>);
 
 impl Validate for CopyrightTexts {

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -23,7 +23,7 @@ use crate::validation::{
 
 use super::signature::Signature;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Composition {
     pub aggregate: AggregateType,
     pub assemblies: Option<Vec<BomReference>>,
@@ -49,7 +49,7 @@ impl Validate for Composition {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Compositions(pub Vec<Composition>);
 
 impl Validate for Compositions {
@@ -71,7 +71,7 @@ impl Validate for Compositions {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AggregateType {
     Complete,
     Incomplete,
@@ -129,7 +129,7 @@ impl Validate for AggregateType {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BomReference(pub(crate) String);
 
 #[cfg(test)]

--- a/cyclonedx-bom/src/models/dependency.rs
+++ b/cyclonedx-bom/src/models/dependency.rs
@@ -16,10 +16,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Dependencies(pub Vec<Dependency>);
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Dependency {
     pub dependency_ref: String,
     pub dependencies: Vec<String>,

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -26,7 +26,7 @@ use crate::validation::{
 /// Represents a way to document systems, sites, and information that may be relevant but which are not included with the BOM.
 ///
 /// Please see the [CycloneDX use case](https://cyclonedx.org/use-cases/#external-references) for more information and examples.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExternalReference {
     pub external_reference_type: ExternalReferenceType,
     pub url: Uri,
@@ -86,7 +86,7 @@ impl Validate for ExternalReference {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExternalReferences(pub Vec<ExternalReference>);
 
 impl Validate for ExternalReferences {
@@ -108,7 +108,7 @@ impl Validate for ExternalReferences {
 }
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_externalReferenceType).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExternalReferenceType {
     Vcs,
     IssueTracker,

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -27,7 +27,7 @@ use crate::validation::{
 /// Represents the hash of the component
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Hash {
     pub alg: HashAlgorithm,
     pub content: HashValue,
@@ -54,7 +54,7 @@ impl Validate for Hash {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Hashes(pub Vec<Hash>);
 
 impl Validate for Hashes {
@@ -80,7 +80,7 @@ impl Validate for Hashes {
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashAlg)
 #[allow(non_camel_case_types)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum HashAlgorithm {
     MD5,
     SHA1,
@@ -157,7 +157,7 @@ impl Validate for HashAlgorithm {
 }
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashValue)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HashValue(pub String);
 
 impl Validate for HashValue {

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -32,7 +32,7 @@ use crate::validation::{
 /// Represents whether a license is a named license or an SPDX license expression
 ///
 /// As defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_licenseChoiceType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LicenseChoice {
     License(License),
     Expression(SpdxExpression),
@@ -81,7 +81,7 @@ impl Validate for LicenseChoice {
 /// Represents a license with identifier, text, and url
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_licenseType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct License {
     pub license_identifier: LicenseIdentifier,
     pub text: Option<AttachedText>,
@@ -153,7 +153,7 @@ impl Validate for License {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Licenses(pub Vec<LicenseChoice>);
 
 impl Validate for Licenses {
@@ -175,7 +175,7 @@ impl Validate for Licenses {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LicenseIdentifier {
     /// An SPDX license identifier from the list on the [SPDX website](https://spdx.org/licenses/).
     SpdxId(SpdxIdentifier),

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -31,7 +31,7 @@ use crate::validation::{
 /// Represents additional information about a BOM
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_metadata)
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Metadata {
     pub timestamp: Option<DateTime>,
     pub tools: Option<Tools>,

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -26,7 +26,7 @@ use crate::{
 /// Represents the contact information for an organization
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_organizationalContact)
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct OrganizationalContact {
     pub name: Option<NormalizedString>,
     pub email: Option<NormalizedString>,
@@ -85,7 +85,7 @@ impl Validate for OrganizationalContact {
 /// Represents an organization with name, url, and contact information
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_organizationalEntity)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OrganizationalEntity {
     pub name: Option<NormalizedString>,
     pub url: Option<Vec<Uri>>,

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_propertyType). Please see the
 /// [CycloneDX use case](https://cyclonedx.org/use-cases/#properties--name-value-store) for more information and examples.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Properties(pub Vec<Property>);
 
 impl Validate for Properties {
@@ -53,7 +53,7 @@ impl Validate for Properties {
 /// Represents an individual property with a name and value
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_propertyType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Property {
     pub name: String,
     pub value: NormalizedString,

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -31,7 +31,7 @@ use super::signature::Signature;
 /// Represents a service as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#service-definition)
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_service)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Service {
     pub bom_ref: Option<String>,
     pub provider: Option<OrganizationalEntity>,
@@ -171,7 +171,7 @@ impl Validate for Service {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Services(pub Vec<Service>);
 
 impl Validate for Services {
@@ -195,7 +195,7 @@ impl Validate for Services {
 /// Represents the data classification and data flow
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_dataClassificationType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DataClassification {
     pub flow: DataFlowType,
     pub classification: NormalizedString,
@@ -229,7 +229,7 @@ impl Validate for DataClassification {
 /// Represents the flow direction of the data
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_dataFlowType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DataFlowType {
     Inbound,
     Outbound,

--- a/cyclonedx-bom/src/models/signature.rs
+++ b/cyclonedx-bom/src/models/signature.rs
@@ -19,7 +19,7 @@
 use std::str::FromStr;
 
 /// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Signature {
     /// Signature algorithm.
     pub algorithm: Algorithm,
@@ -29,7 +29,7 @@ pub struct Signature {
 
 /*
 /// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Signature {
     /// Multiple signatures
     Signers(Vec<Signer>),
@@ -40,7 +40,7 @@ pub enum Signature {
 }
 
 /// For now the [`Signer`] struct only holds algorithm and value
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Signer {
     /// Signature algorithm.
     pub algorithm: Algorithm,
@@ -50,7 +50,7 @@ pub struct Signer {
 */
 
 /// Supported signature algorithms.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Algorithm {
     RS256,
     RS384,

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -25,7 +25,7 @@ use crate::validation::{
 /// Represents the tool used to create the BOM
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_toolType)
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Tool {
     pub vendor: Option<NormalizedString>,
     pub name: Option<NormalizedString>,
@@ -87,7 +87,7 @@ impl Validate for Tool {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Tools(pub Vec<Tool>);
 
 impl Validate for Tools {

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -33,7 +33,7 @@ use crate::validation::{
 /// Represents a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilitiesType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Vulnerability {
     pub bom_ref: Option<String>,
     pub id: Option<NormalizedString>,
@@ -183,7 +183,7 @@ impl Validate for Vulnerability {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Vulnerabilities(pub Vec<Vulnerability>);
 
 impl Validate for Vulnerabilities {

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -24,7 +24,7 @@ use crate::validation::{
 /// Represents a vulnerability's analysis as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilityType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityAnalysis {
     pub state: Option<ImpactAnalysisState>,
     pub justification: Option<ImpactAnalysisJustification>,
@@ -100,7 +100,7 @@ impl Validate for VulnerabilityAnalysis {
 /// Specifies a vulnerability's state according to impact analysis.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisStateType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ImpactAnalysisState {
     Resolved,
     ResolvedWithPedigree,
@@ -161,7 +161,7 @@ impl ToString for ImpactAnalysisState {
 /// Justifies the vulnerability's state according to impact analysis.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisJustificationType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ImpactAnalysisJustification {
     CodeNotPresent,
     CodeNotReachable,
@@ -237,7 +237,7 @@ impl ToString for ImpactAnalysisJustification {
 /// Provides a response to the vulnerability according to impact analysis.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisResponsesType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ImpactAnalysisResponse {
     CanNotFix,
     WillNotFix,

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -22,7 +22,7 @@ use crate::validation::{
 };
 
 /// Provides credits to organizations or individuals who contributed to a vulnerability.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityCredits {
     pub organizations: Option<Vec<OrganizationalEntity>>,
     pub individuals: Option<Vec<OrganizationalContact>>,

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -28,7 +28,7 @@ use crate::validation::{
 /// Represents a vulnerability's rating as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_ratingType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityRating {
     pub vulnerability_source: Option<VulnerabilitySource>,
     pub score: Option<Score>,
@@ -95,7 +95,7 @@ impl Validate for VulnerabilityRating {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 
 impl Validate for VulnerabilityRatings {
@@ -123,7 +123,7 @@ impl Validate for VulnerabilityRatings {
 /// convert a f32 into i32 because OWASP's scoring method uses up to three decimal places.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_ratingType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Score(OrderedFloat<f32>);
 
 impl Score {
@@ -155,7 +155,7 @@ impl From<Score> for f32 {
 /// Specifies a vulnerability's severity adopted by the analysis method.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_severityType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Severity {
     Critical,
     High,
@@ -219,7 +219,7 @@ impl ToString for Severity {
 /// Specifies the risk scoring method or standard used.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_scoreSourceType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ScoreMethod {
     CVSSv2,
     CVSSv3,

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -26,7 +26,7 @@ use crate::validation::{
 /// to correlate vulnerabilities across multiple sources of vulnerability intelligence.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilityType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityReference {
     pub id: NormalizedString,
     pub vulnerability_source: VulnerabilitySource,
@@ -78,7 +78,7 @@ impl Validate for VulnerabilityReference {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 
 impl Validate for VulnerabilityReferences {

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -22,7 +22,7 @@ use crate::validation::{Validate, ValidationContext, ValidationError, Validation
 /// Defines a source related to the vulnerability, e.g. who published or calculated the severity or risk rating the vulnerability.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilitySourceType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilitySource {
     pub name: Option<NormalizedString>,
     pub url: Option<Uri>,

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -28,7 +28,7 @@ use crate::validation::{
 /// Defines how a component or service is affected by a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilityType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityTarget {
     pub bom_ref: String,
     pub versions: Option<Versions>,
@@ -69,7 +69,7 @@ impl Validate for VulnerabilityTarget {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityTargets(pub Vec<VulnerabilityTarget>);
 
 impl Validate for VulnerabilityTargets {
@@ -90,7 +90,7 @@ impl Validate for VulnerabilityTargets {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Versions(pub Vec<Version>);
 
 impl Validate for Versions {
@@ -111,7 +111,7 @@ impl Validate for Versions {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Version {
     pub version_range: VersionRange,
     pub status: Status,
@@ -161,7 +161,7 @@ impl Validate for Version {
 ///
 /// Defined via the [PURL specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst)
 /// Spec for version ranges still work in progress [PURL version-range-spec](https://github.com/package-url/purl-spec/blob/version-range-spec/VERSION-RANGE-SPEC.rst)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum VersionRange {
     Version(NormalizedString),
     Range(NormalizedString),
@@ -218,7 +218,7 @@ fn matches_purl_version_range_regex(value: &str) -> Result<bool, regex::Error> {
 /// Specifies if a vulnerability affects a component or service.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisAffectedStatusType)
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Status {
     Affected,
     Unaffected,

--- a/cyclonedx-bom/src/validation.rs
+++ b/cyclonedx-bom/src/validation.rs
@@ -65,7 +65,7 @@ pub enum ValidationPathComponent {
     },
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ValidationResult {
     Passed,
     Failed { reasons: Vec<FailureReason> },


### PR DESCRIPTION
Derive `Clone` on `cyclonedx-bom` structs.

This is required for serializing the same document multiple times (with alterations), because serialization takes ownership of a struct and converts it to the appropriate format, which means the original struct is lost.

This in turn unblocks emitting a separate SBOM file for each binary.