### PR TITLE
Implement multiple variants of Signature field

### DIFF
--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -698,10 +698,7 @@ mod test {
                 ))])),
                 copyright: Some(CopyrightTexts(vec![Copyright("copyright".to_string())])),
             }),
-            signature: Some(Signature {
-                algorithm: Algorithm::HS512,
-                value: "abcdefgh".to_string(),
-            }),
+            signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");
@@ -790,10 +787,7 @@ mod test {
                 ))])),
                 copyright: Some(CopyrightTexts(vec![Copyright("copyright".to_string())])),
             }),
-            signature: Some(Signature {
-                algorithm: Algorithm::HS512,
-                value: "abcdefgh".to_string(),
-            }),
+            signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -145,10 +145,7 @@ mod test {
             aggregate: AggregateType::Complete,
             assemblies: Some(vec![BomReference("reference".to_string())]),
             dependencies: Some(vec![BomReference("reference".to_string())]),
-            signature: Some(Signature {
-                algorithm: Algorithm::HS512,
-                value: "abcdefgh".to_string(),
-            }),
+            signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate()
         .expect("Error while validating");
@@ -162,10 +159,7 @@ mod test {
             aggregate: AggregateType::UnknownAggregateType("unknown aggregate type".to_string()),
             assemblies: Some(vec![BomReference("reference".to_string())]),
             dependencies: Some(vec![BomReference("reference".to_string())]),
-            signature: Some(Signature {
-                algorithm: Algorithm::HS512,
-                value: "abcdefgh".to_string(),
-            }),
+            signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate()
         .expect("Error while validating");

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -330,10 +330,7 @@ mod test {
                 value: NormalizedString::new("value"),
             }])),
             services: Some(Services(vec![])),
-            signature: Some(Signature {
-                algorithm: Algorithm::HS512,
-                value: "abcdefgh".to_string(),
-            }),
+            signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");
@@ -393,10 +390,7 @@ mod test {
                 services: None,
                 signature: None,
             }])),
-            signature: Some(Signature {
-                algorithm: Algorithm::HS512,
-                value: "abcdefgh".to_string(),
-            }),
+            signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate_with_context(ValidationContext::default())
         .expect("Error while validating");

--- a/cyclonedx-bom/src/models/signature.rs
+++ b/cyclonedx-bom/src/models/signature.rs
@@ -20,23 +20,13 @@ use std::str::FromStr;
 
 /// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Signature {
-    /// Signature algorithm.
-    pub algorithm: Algorithm,
-    /// The signature data.
-    pub value: String,
-}
-
-/*
-/// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Signature {
     /// Multiple signatures
     Signers(Vec<Signer>),
-    /// A single signature chain
-    Chain(Signer),
+    /// A signature chain consisting of multiple signatures
+    Chain(Vec<Signer>),
     /// A single signature
-    Signature(Signer),
+    Single(Signer),
 }
 
 /// For now the [`Signer`] struct only holds algorithm and value
@@ -47,10 +37,48 @@ pub struct Signer {
     /// The signature data.
     pub value: String,
 }
-*/
+
+impl Signer {
+    pub fn new(algorithm: Algorithm, value: &str) -> Self {
+        Self {
+            algorithm,
+            value: value.to_string(),
+        }
+    }
+}
+
+impl Signature {
+    /// Creates a single signature.
+    pub fn single(algorithm: Algorithm, value: &str) -> Self {
+        Self::Single(Signer {
+            algorithm,
+            value: value.to_string(),
+        })
+    }
+
+    /// Creates a chain of multiple signatures
+    pub fn chain(chain: &[(Algorithm, &str)]) -> Self {
+        Self::Chain(
+            chain
+                .iter()
+                .map(|(algorithm, value)| Signer::new(*algorithm, value))
+                .collect(),
+        )
+    }
+
+    /// Creates a list of multiple signatures.
+    pub fn signers(signers: &[(Algorithm, &str)]) -> Self {
+        Self::Signers(
+            signers
+                .iter()
+                .map(|(algorithm, value)| Signer::new(*algorithm, value))
+                .collect(),
+        )
+    }
+}
 
 /// Supported signature algorithms.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Algorithm {
     RS256,
     RS384,

--- a/cyclonedx-bom/src/xml.rs
+++ b/cyclonedx-bom/src/xml.rs
@@ -5,7 +5,7 @@ use xml::{
     name::OwnedName,
     namespace::{Namespace, NS_NO_PREFIX},
     reader::{self},
-    writer::{self, EventWriter},
+    writer::{self, EventWriter, XmlEvent},
     EventReader,
 };
 
@@ -55,6 +55,26 @@ pub(crate) fn write_simple_tag<W: Write>(
         .write(writer::XmlEvent::end_element())
         .map_err(to_xml_write_error(tag))?;
     Ok(())
+}
+
+/// Writes a simple start tag of the form `<tag>` without attributes.
+pub(crate) fn write_start_tag<W: Write>(
+    writer: &mut EventWriter<W>,
+    tag: &str,
+) -> Result<(), XmlWriteError> {
+    writer
+        .write(XmlEvent::start_element(tag))
+        .map_err(to_xml_write_error(tag))
+}
+
+/// Writes the closing tag of the form `</tag>`
+pub(crate) fn write_close_tag<W: Write>(
+    writer: &mut EventWriter<W>,
+    tag: &str,
+) -> Result<(), XmlWriteError> {
+    writer
+        .write(XmlEvent::end_element())
+        .map_err(to_xml_write_error(tag))
 }
 
 pub(crate) fn to_xml_write_error(


### PR DESCRIPTION
Instead of removing previous signature related structs (which were commented out) this PR implements de-/serialization of the signature field given in the [JSON spec](https://cyclonedx.org/docs/1.4/json/#tab-pane_signature_oneOf_i0), based on the [JSON Signature Format](https://cyberphone.github.io/doc/security/jsf.html). Most of the changes are due to the updated XML parse / write functions.

* implement de-/serialization logic for signature
* add helper functions to write opening / closing XML tags
* expand signature tests to check the different variants or missing fields
* add create functions for `Signature` & refactor code

This relates to #588.