### PR TITLE
Remove vulnerabilities placeholder

### DIFF
--- a/cyclonedx-bom/src/specs/v1_3/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_3/bom.rs
@@ -39,10 +39,6 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use xml::{reader, writer::XmlEvent};
 
-// Placeholders for types defined in other versions of the spec
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-struct Vulnerabilities();
-
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Bom {
@@ -64,30 +60,7 @@ pub(crate) struct Bom {
     compositions: Option<Compositions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     properties: Option<Properties>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    vulnerabilities: Option<Vulnerabilities>,
 }
-
-/*
-impl From<models::bom::Bom> for Bom {
-    fn from(other: models::bom::Bom) -> Self {
-        Self {
-            bom_format: BomFormat::CycloneDX,
-            spec_version: SpecVersion::V1_3,
-            version: Some(other.version),
-            serial_number: convert_optional(other.serial_number),
-            metadata: convert_optional(other.metadata),
-            components: convert_optional(other.components),
-            services: convert_optional(other.services),
-            external_references: convert_optional(other.external_references),
-            dependencies: convert_optional(other.dependencies),
-            compositions: convert_optional(other.compositions),
-            properties: convert_optional(other.properties),
-            vulnerabilities: None,
-        }
-    }
-}
-*/
 
 impl TryFrom<models::bom::Bom> for Bom {
     type Error = BomError;
@@ -105,7 +78,6 @@ impl TryFrom<models::bom::Bom> for Bom {
             dependencies: convert_optional(other.dependencies),
             compositions: convert_optional(other.compositions),
             properties: convert_optional(other.properties),
-            vulnerabilities: None,
         })
     }
 }
@@ -341,7 +313,6 @@ impl FromXmlDocument for Bom {
             dependencies,
             compositions,
             properties,
-            vulnerabilities: None,
         })
     }
 }
@@ -399,7 +370,6 @@ pub(crate) mod test {
             dependencies: None,
             compositions: None,
             properties: None,
-            vulnerabilities: None,
         }
     }
 
@@ -416,7 +386,6 @@ pub(crate) mod test {
             dependencies: Some(example_dependencies()),
             compositions: Some(example_compositions()),
             properties: Some(example_properties()),
-            vulnerabilities: None,
         }
     }
 


### PR DESCRIPTION
The `Vulnerabilities` placeholder struct in version 1.3 is not created or used, therefore removing this property. Version 1.3 should not know about a field that is only present in other spec versions.