### PR TITLE
Refactor `Validate` trait to simplify return type

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -99,7 +99,7 @@ impl SbomGenerator {
             let bom = generator.create_bom(member, &dependencies, &pruned_resolve)?;
 
             if cfg!(debug_assertions) {
-                let result = bom.validate().unwrap();
+                let result = bom.validate();
                 if let ValidationResult::Failed { reasons } = result {
                     panic!("The generated SBOM failed validation: {:?}", &reasons);
                 }

--- a/cargo-cyclonedx/src/purl.rs
+++ b/cargo-cyclonedx/src/purl.rs
@@ -82,7 +82,7 @@ fn to_purl_subpath(path: &Utf8Path) -> String {
 
 fn assert_validation_passes(purl: &CdxPurl) {
     use cyclonedx_bom::validation::{Validate, ValidationResult};
-    assert_eq!(purl.validate().unwrap(), ValidationResult::Passed);
+    assert_eq!(purl.validate(), ValidationResult::Passed);
 }
 
 #[cfg(test)]

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -75,7 +75,6 @@ fn find_content_in_bom_files() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-#[ignore]
 fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
     let tmp_dir = make_temp_rust_project()?;
 

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -21,7 +21,7 @@ use std::convert::TryFrom;
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};
 
-use crate::validation::{FailureReason, Validate, ValidationContext, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
 
 /// For the purposes of CycloneDX SBOM documents, `DateTime` is a ISO8601 formatted timestamp
 ///
@@ -68,12 +68,7 @@ impl Validate for DateTime {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match OffsetDateTime::parse(&self.0.to_string(), &Iso8601::DEFAULT) {
             Ok(_) => ValidationResult::Passed,
-            Err(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "DateTime does not conform to ISO 8601".to_string(),
-                    context,
-                }],
-            },
+            Err(_) => ValidationResult::failure("DateTime does not conform to ISO 8601", context),
         }
     }
 }
@@ -96,7 +91,6 @@ pub enum DateTimeError {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::validation::FailureReason;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -112,12 +106,10 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "DateTime does not conform to ISO 8601".to_string(),
-                    context: ValidationContext::default()
-                }]
-            }
+            ValidationResult::failure(
+                "DateTime does not conform to ISO 8601",
+                ValidationContext::default()
+            )
         )
     }
 }

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -21,9 +21,7 @@ use std::convert::TryFrom;
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};
 
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationResult,
-};
+use crate::validation::{FailureReason, Validate, ValidationContext, ValidationResult};
 
 /// For the purposes of CycloneDX SBOM documents, `DateTime` is a ISO8601 formatted timestamp
 ///
@@ -67,18 +65,15 @@ impl TryFrom<String> for DateTime {
 }
 
 impl Validate for DateTime {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match OffsetDateTime::parse(&self.0.to_string(), &Iso8601::DEFAULT) {
-            Ok(_) => Ok(ValidationResult::Passed),
-            Err(_) => Ok(ValidationResult::Failed {
+            Ok(_) => ValidationResult::Passed,
+            Err(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "DateTime does not conform to ISO 8601".to_string(),
                     context,
                 }],
-            }),
+            },
         }
     }
 }
@@ -106,18 +101,14 @@ mod test {
 
     #[test]
     fn valid_datetimes_should_pass_validation() {
-        let validation_result = DateTime("1969-06-28T01:20:00.00-04:00".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = DateTime("1969-06-28T01:20:00.00-04:00".to_string()).validate();
 
         assert_eq!(validation_result, ValidationResult::Passed)
     }
 
     #[test]
     fn invalid_datetimes_should_fail_validation() {
-        let validation_result = DateTime("invalid date".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = DateTime("invalid date".to_string()).validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -85,7 +85,6 @@ impl Validate for NormalizedString {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::validation::FailureReason;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -117,13 +116,10 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                        .to_string(),
-                    context: ValidationContext::default()
-                }]
-            }
+            ValidationResult::failure(
+                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n",
+                ValidationContext::default()
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -16,9 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
 use std::fmt::Display;
 use std::ops::Deref;
 
@@ -68,25 +66,19 @@ impl Display for NormalizedString {
 }
 
 impl Validate for NormalizedString {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         if self.0.contains("\r\n")
             || self.0.contains('\r')
             || self.0.contains('\n')
             || self.0.contains('\t')
         {
-            return Ok(ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                        .to_string(),
-                    context,
-                }],
-            });
+            return ValidationResult::failure(
+                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n",
+                context,
+            );
         }
 
-        Ok(ValidationResult::Passed)
+        ValidationResult::Passed
     }
 }
 
@@ -114,18 +106,14 @@ mod test {
 
     #[test]
     fn it_should_pass_validation() {
-        let validation_result = NormalizedString("no_whitespace".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = NormalizedString("no_whitespace".to_string()).validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
 
     #[test]
     fn it_should_fail_validation() {
-        let validation_result = NormalizedString("spaces and\ttabs".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = NormalizedString("spaces and\ttabs".to_string()).validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -84,15 +84,15 @@ impl Validate for SpdxIdentifier {
     fn validate_with_context(
         &self,
         context: crate::validation::ValidationContext,
-    ) -> Result<ValidationResult, crate::validation::ValidationError> {
+    ) -> ValidationResult {
         match Self::try_from(self.0.clone()) {
-            Ok(_) => Ok(ValidationResult::Passed),
-            Err(_) => Ok(ValidationResult::Failed {
+            Ok(_) => ValidationResult::Passed,
+            Err(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "SPDX identifier is not valid".to_string(),
                     context,
                 }],
-            }),
+            },
         }
     }
 }
@@ -184,15 +184,15 @@ impl Validate for SpdxExpression {
     fn validate_with_context(
         &self,
         context: crate::validation::ValidationContext,
-    ) -> Result<crate::validation::ValidationResult, crate::validation::ValidationError> {
+    ) -> ValidationResult {
         match SpdxExpression::try_from(self.0.clone()) {
-            Ok(_) => Ok(ValidationResult::Passed),
-            Err(_) => Ok(ValidationResult::Failed {
+            Ok(_) => ValidationResult::Passed,
+            Err(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "SPDX expression is not valid".to_string(),
                     context,
                 }],
-            }),
+            },
         }
     }
 }
@@ -257,18 +257,14 @@ mod test {
 
     #[test]
     fn valid_spdx_identifiers_should_pass_validation() {
-        let validation_result = SpdxIdentifier("MIT".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = SpdxIdentifier("MIT".to_string()).validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
 
     #[test]
     fn invalid_spdx_identifiers_should_fail_validation() {
-        let validation_result = SpdxIdentifier("MIT OR Apache-2.0".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = SpdxIdentifier("MIT OR Apache-2.0".to_string()).validate();
 
         assert_eq!(
             validation_result,
@@ -307,18 +303,14 @@ mod test {
 
     #[test]
     fn valid_spdx_expressions_should_pass_validation() {
-        let validation_result = SpdxExpression("MIT OR Apache-2.0".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = SpdxExpression("MIT OR Apache-2.0".to_string()).validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
 
     #[test]
     fn invalid_spdx_expressions_should_fail_validation() {
-        let validation_result = SpdxExpression("not a real license".to_string())
-            .validate_with_context(ValidationContext::default())
-            .expect("Error while validating");
+        let validation_result = SpdxExpression("not a real license".to_string()).validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -21,7 +21,7 @@ use std::convert::TryFrom;
 use spdx::{Expression, ParseMode};
 use thiserror::Error;
 
-use crate::validation::{FailureReason, Validate, ValidationResult};
+use crate::validation::{Validate, ValidationResult};
 
 /// An identifier for a single, specific license
 ///
@@ -87,12 +87,7 @@ impl Validate for SpdxIdentifier {
     ) -> ValidationResult {
         match Self::try_from(self.0.clone()) {
             Ok(_) => ValidationResult::Passed,
-            Err(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "SPDX identifier is not valid".to_string(),
-                    context,
-                }],
-            },
+            Err(_) => ValidationResult::failure("SPDX identifier is not valid", context),
         }
     }
 }
@@ -187,12 +182,7 @@ impl Validate for SpdxExpression {
     ) -> ValidationResult {
         match SpdxExpression::try_from(self.0.clone()) {
             Ok(_) => ValidationResult::Passed,
-            Err(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "SPDX expression is not valid".to_string(),
-                    context,
-                }],
-            },
+            Err(_) => ValidationResult::failure("SPDX expression is not valid", context),
         }
     }
 }
@@ -208,7 +198,7 @@ pub enum SpdxExpressionError {
 
 #[cfg(test)]
 mod test {
-    use crate::validation::{FailureReason, ValidationContext, ValidationResult};
+    use crate::validation::{ValidationContext, ValidationResult};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -268,12 +258,7 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "SPDX identifier is not valid".to_string(),
-                    context: ValidationContext::default()
-                }]
-            }
+            ValidationResult::failure("SPDX identifier is not valid", ValidationContext::default()),
         );
     }
 
@@ -314,12 +299,7 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "SPDX expression is not valid".to_string(),
-                    context: ValidationContext::default()
-                }]
-            }
+            ValidationResult::failure("SPDX expression is not valid", ValidationContext::default())
         );
     }
 }

--- a/cyclonedx-bom/src/external_models/uri.rs
+++ b/cyclonedx-bom/src/external_models/uri.rs
@@ -105,8 +105,6 @@ pub enum UriError {
 mod test {
     use pretty_assertions::assert_eq;
 
-    use crate::validation::FailureReason;
-
     use super::*;
 
     #[test]
@@ -122,13 +120,10 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Purl does not conform to Package URL spec: missing scheme"
-                        .to_string(),
-                    context: ValidationContext::default()
-                }]
-            }
+            ValidationResult::failure(
+                "Purl does not conform to Package URL spec: missing scheme",
+                ValidationContext::default()
+            ),
         );
     }
 
@@ -145,12 +140,10 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Uri does not conform to RFC 3986".to_string(),
-                    context: ValidationContext::default()
-                }]
-            }
+            ValidationResult::failure(
+                "Uri does not conform to RFC 3986",
+                ValidationContext::default()
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -46,7 +46,7 @@
 //! }"#;
 //! let bom = Bom::parse_from_json_v1_3(bom_json.as_bytes()).expect("Failed to parse BOM");
 //!
-//! let validation_result = bom.validate().expect("Failed to validate BOM");
+//! let validation_result = bom.validate();
 //! assert_eq!(validation_result, ValidationResult::Passed);
 //! ```
 //!

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -49,12 +49,12 @@ impl Validate for Advisory {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(title) = &self.title {
-            let context = context.extend_context_with_struct_field("Advisory", "title");
+            let context = context.with_struct("Advisory", "title");
 
             results.push(title.validate_with_context(context));
         }
 
-        let url_context = context.extend_context_with_struct_field("Advisory", "url");
+        let url_context = context.with_struct("Advisory", "url");
         results.push(self.url.validate_with_context(url_context));
 
         results

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -17,9 +17,7 @@
  */
 
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// Represents an advisory, a notification of a threat to a component, service, or system.
 ///
@@ -47,24 +45,21 @@ impl Advisory {
 }
 
 impl Validate for Advisory {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(title) = &self.title {
             let context = context.extend_context_with_struct_field("Advisory", "title");
 
-            results.push(title.validate_with_context(context)?);
+            results.push(title.validate_with_context(context));
         }
 
         let url_context = context.extend_context_with_struct_field("Advisory", "url");
-        results.push(self.url.validate_with_context(url_context)?);
+        results.push(self.url.validate_with_context(url_context));
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -72,20 +67,17 @@ impl Validate for Advisory {
 pub struct Advisories(pub Vec<Advisory>);
 
 impl Validate for Advisories {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, advisory) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(advisory.validate_with_context(context)?);
+            results.push(advisory.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -105,8 +97,7 @@ mod test {
             title: Some(NormalizedString::new("title")),
             url: Uri("https://example.com".to_string()),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -117,8 +108,7 @@ mod test {
             title: Some(NormalizedString("invalid\ttitle".to_string())),
             url: Uri("invalid url".to_string()),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -17,7 +17,7 @@
  */
 
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
-use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
 
 /// Represents an advisory, a notification of a threat to a component, service, or system.
 ///
@@ -71,7 +71,7 @@ impl Validate for Advisories {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, advisory) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
+            let context = context.with_index(index);
             results.push(advisory.validate_with_context(context));
         }
 
@@ -114,28 +114,18 @@ mod test {
             validation_result,
             ValidationResult::Failed {
                 reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Advisory".to_string(),
-                                field_name: "title".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Advisory".to_string(),
-                                field_name: "url".to_string()
-                            }
-                        ])
-                    },
+                    FailureReason::new(
+                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n",
+                        ValidationContext::new()
+                            .with_index(0)
+                            .with_struct("Advisory", "title")
+                    ),
+                    FailureReason::new(
+                        "Uri does not conform to RFC 3986",
+                        ValidationContext::new()
+                            .with_index(0)
+                            .with_struct("Advisory", "url")
+                    )
                 ]
             }
         );

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -20,7 +20,7 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 
 use crate::{
     external_models::normalized_string::NormalizedString,
-    validation::{FailureReason, Validate, ValidationContext, ValidationError, ValidationResult},
+    validation::{FailureReason, Validate, ValidationContext, ValidationResult},
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -45,16 +45,13 @@ impl AttachedText {
 }
 
 impl Validate for AttachedText {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(content_type) = &self.content_type {
             let context = context.extend_context_with_struct_field("AttachedText", "content_type");
 
-            results.push(content_type.validate_with_context(context)?);
+            results.push(content_type.validate_with_context(context));
         }
 
         if let Some(encoding) = &self.encoding {
@@ -75,14 +72,14 @@ impl Validate for AttachedText {
                     let context =
                         context.extend_context_with_struct_field("AttachedText", "encoding");
 
-                    results.push(encoding.validate_with_context(context)?);
+                    results.push(encoding.validate_with_context(context));
                 }
             }
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -112,18 +109,15 @@ impl Encoding {
 }
 
 impl Validate for Encoding {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            Encoding::UnknownEncoding(_) => Ok(ValidationResult::Failed {
+            Encoding::UnknownEncoding(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown encoding".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -158,8 +152,7 @@ mod test {
             encoding: Some(Encoding::Base64),
             content: "dGhpcyB0ZXh0IGlzIHBsYWlu".to_string(),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -171,8 +164,7 @@ mod test {
             encoding: Some(Encoding::Base64),
             content: "not base64 encoded".to_string(),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -206,8 +198,7 @@ mod test {
             encoding: Some(Encoding::UnknownEncoding("unknown".to_string())),
             content: "not base64 encoded".to_string(),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -230,8 +221,7 @@ mod test {
             encoding: None,
             content: "not base64 encoded".to_string(),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -49,7 +49,7 @@ impl Validate for AttachedText {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(content_type) = &self.content_type {
-            let context = context.extend_context_with_struct_field("AttachedText", "content_type");
+            let context = context.with_struct("AttachedText", "content_type");
 
             results.push(content_type.validate_with_context(context));
         }
@@ -58,8 +58,7 @@ impl Validate for AttachedText {
             match (encoding, STANDARD.decode(self.content.clone())) {
                 (Encoding::Base64, Ok(_)) => results.push(ValidationResult::Passed),
                 (Encoding::Base64, Err(_)) => {
-                    let context =
-                        context.extend_context_with_struct_field("AttachedText", "content");
+                    let context = context.with_struct("AttachedText", "content");
 
                     results.push(ValidationResult::Failed {
                         reasons: vec![FailureReason {
@@ -69,8 +68,7 @@ impl Validate for AttachedText {
                     })
                 }
                 (Encoding::UnknownEncoding(_), _) => {
-                    let context =
-                        context.extend_context_with_struct_field("AttachedText", "encoding");
+                    let context = context.with_struct("AttachedText", "encoding");
 
                     results.push(encoding.validate_with_context(context));
                 }
@@ -124,7 +122,7 @@ impl Validate for Encoding {
 
 #[cfg(test)]
 mod test {
-    use crate::{models::attached_text::Encoding, validation::ValidationPathComponent};
+    use crate::models::attached_text::Encoding;
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -174,17 +172,12 @@ mod test {
                         message:
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
                                 .to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "AttachedText".to_string(),
-                            field_name: "content_type".to_string()
-                        }])
+                        context: ValidationContext::new()
+                            .with_struct("AttachedText", "content_type")
                     },
                     FailureReason {
                         message: "Content is not Base64 encoded".to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "AttachedText".to_string(),
-                            field_name: "content".to_string()
-                        }])
+                        context: ValidationContext::new().with_struct("AttachedText", "content")
                     }
                 ]
             }
@@ -202,16 +195,11 @@ mod test {
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Unknown encoding".to_string(),
-                    context: ValidationContext(vec![ValidationPathComponent::Struct {
-                        struct_name: "AttachedText".to_string(),
-                        field_name: "encoding".to_string()
-                    }])
-                }]
-            }
-        );
+            ValidationResult::failure(
+                "Unknown encoding",
+                ValidationContext::new().with_struct("AttachedText", "encoding")
+            )
+        )
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -226,15 +226,15 @@ impl Validate for Bom {
         let mut bom_refs_context = BomReferencesContext::default();
 
         if let Some(serial_number) = &self.serial_number {
-            let context = context.extend_context_with_struct_field("Bom", "serial_number");
+            let context = context.with_struct("Bom", "serial_number");
 
             results.push(serial_number.validate_with_context(context));
         }
 
         if let Some(metadata) = &self.metadata {
-            let context = context.extend_context_with_struct_field("Bom", "metadata");
+            let context = context.with_struct("Bom", "metadata");
             let component_bom_ref_context =
-                context.extend_context_with_struct_field("Metadata", "component");
+                context.with_struct("Metadata", "component");
 
             results.push(metadata.validate_with_context(context));
 
@@ -249,7 +249,7 @@ impl Validate for Bom {
         }
 
         if let Some(components) = &self.components {
-            let context = context.extend_context_with_struct_field("Bom", "components");
+            let context = context.with_struct("Bom", "components");
             let component_bom_ref_context = context.clone();
 
             results.push(components.validate_with_context(context));
@@ -264,7 +264,7 @@ impl Validate for Bom {
         }
 
         if let Some(services) = &self.services {
-            let context = context.extend_context_with_struct_field("Bom", "services");
+            let context = context.with_struct("Bom", "services");
             let service_bom_ref_context = context.clone();
 
             results.push(services.validate_with_context(context));
@@ -279,13 +279,13 @@ impl Validate for Bom {
         }
 
         if let Some(external_references) = &self.external_references {
-            let context = context.extend_context_with_struct_field("Bom", "external_references");
+            let context = context.with_struct("Bom", "external_references");
 
             results.push(external_references.validate_with_context(context));
         }
 
         if let Some(dependencies) = &self.dependencies {
-            let context = context.extend_context_with_struct_field("Bom", "dependencies");
+            let context = context.with_struct("Bom", "dependencies");
 
             for (dependency_index, dependency) in dependencies.0.iter().enumerate() {
                 let context = context.extend_context(vec![ValidationPathComponent::Array {
@@ -293,7 +293,7 @@ impl Validate for Bom {
                 }]);
                 if !bom_refs_context.contains(&dependency.dependency_ref) {
                     let dependency_context =
-                        context.extend_context_with_struct_field("Dependency", "dependency_ref");
+                        context.with_struct("Dependency", "dependency_ref");
 
                     results.push(ValidationResult::Failed {
                         reasons: vec![FailureReason {
@@ -330,7 +330,7 @@ impl Validate for Bom {
         }
 
         if let Some(compositions) = &self.compositions {
-            let context = context.extend_context_with_struct_field("Bom", "compositions");
+            let context = context.with_struct("Bom", "compositions");
             let compositions_context = context.clone();
 
             results.push(compositions.validate_with_context(context));
@@ -343,7 +343,7 @@ impl Validate for Bom {
 
                 if let Some(assemblies) = &composition.assemblies {
                     let compositions_context = compositions_context
-                        .extend_context_with_struct_field("Composition", "assemblies");
+                        .with_struct("Composition", "assemblies");
                     for (assembly_index, BomReference(assembly)) in assemblies.iter().enumerate() {
                         if !bom_refs_context.contains(assembly) {
                             let compositions_context = compositions_context.extend_context(vec![
@@ -364,7 +364,7 @@ impl Validate for Bom {
 
                 if let Some(dependencies) = &composition.dependencies {
                     let compositions_context = compositions_context
-                        .extend_context_with_struct_field("Composition", "dependencies");
+                        .with_struct("Composition", "dependencies");
                     for (dependency_index, BomReference(dependency)) in
                         dependencies.iter().enumerate()
                     {
@@ -388,13 +388,13 @@ impl Validate for Bom {
         }
 
         if let Some(properties) = &self.properties {
-            let context = context.extend_context_with_struct_field("Bom", "properties");
+            let context = context.with_struct("Bom", "properties");
 
             results.push(properties.validate_with_context(context));
         }
 
         if let Some(vulnerabilities) = &self.vulnerabilities {
-            let context = context.extend_context_with_struct_field("Bom", "vulnerabilities");
+            let context = context.with_struct("Bom", "vulnerabilities");
             results.push(vulnerabilities.validate_with_context(context));
         }
 
@@ -432,7 +432,7 @@ fn validate_component_bom_refs(
 ) {
     if let Some(bom_ref) = &component.bom_ref {
         if bom_refs.contains(bom_ref) {
-            let context = context.extend_context_with_struct_field("Component", "bom_ref");
+            let context = context.with_struct("Component", "bom_ref");
             results.push(ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: format!(r#"Bom ref "{bom_ref}" is not unique"#),
@@ -444,7 +444,7 @@ fn validate_component_bom_refs(
     }
 
     if let Some(components) = &component.components {
-        let context = context.extend_context_with_struct_field("Component", "components");
+        let context = context.with_struct("Component", "components");
         validate_components(components, bom_refs, &context, results);
     }
 }
@@ -473,7 +473,7 @@ fn validate_service_bom_refs(
 ) {
     if let Some(bom_ref) = &service.bom_ref {
         if bom_refs.contains(bom_ref) {
-            let context = context.extend_context_with_struct_field("Service", "bom_ref");
+            let context = context.with_struct("Service", "bom_ref");
             results.push(ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: format!(r#"Bom ref "{bom_ref}" is not unique"#),
@@ -485,7 +485,7 @@ fn validate_service_bom_refs(
     }
 
     if let Some(services) = &service.services {
-        let context = context.extend_context_with_struct_field("Service", "services");
+        let context = context.with_struct("Service", "services");
         validate_services(services, bom_refs, &context, results);
     }
 }

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -19,8 +19,7 @@
 use crate::{
     external_models::{date_time::DateTime, normalized_string::NormalizedString, uri::Uri},
     validation::{
-        FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-        ValidationResult,
+        FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
     },
 };
 
@@ -36,45 +35,42 @@ pub struct Commit {
 }
 
 impl Validate for Commit {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(uid) = &self.uid {
             let context = context.extend_context_with_struct_field("Commit", "uid");
 
-            results.push(uid.validate_with_context(context)?);
+            results.push(uid.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
             let context = context.extend_context_with_struct_field("Commit", "url");
 
-            results.push(url.validate_with_context(context)?);
+            results.push(url.validate_with_context(context));
         }
 
         if let Some(author) = &self.author {
             let context = context.extend_context_with_struct_field("Commit", "author");
 
-            results.push(author.validate_with_context(context)?);
+            results.push(author.validate_with_context(context));
         }
 
         if let Some(committer) = &self.committer {
             let context = context.extend_context_with_struct_field("Commit", "committer");
 
-            results.push(committer.validate_with_context(context)?);
+            results.push(committer.validate_with_context(context));
         }
 
         if let Some(message) = &self.message {
             let context = context.extend_context_with_struct_field("Commit", "message");
 
-            results.push(message.validate_with_context(context)?);
+            results.push(message.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -82,21 +78,18 @@ impl Validate for Commit {
 pub struct Commits(pub Vec<Commit>);
 
 impl Validate for Commits {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, commit) in self.0.iter().enumerate() {
             let commit_context =
                 context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(commit.validate_with_context(commit_context)?);
+            results.push(commit.validate_with_context(commit_context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -107,27 +100,24 @@ pub struct Diff {
 }
 
 impl Validate for Diff {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(text) = &self.text {
             let context = context.extend_context_with_struct_field("Diff", "text");
 
-            results.push(text.validate_with_context(context)?);
+            results.push(text.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
             let context = context.extend_context_with_struct_field("Diff", "url");
 
-            results.push(url.validate_with_context(context)?);
+            results.push(url.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -139,34 +129,31 @@ pub struct IdentifiableAction {
 }
 
 impl Validate for IdentifiableAction {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {
             let context =
                 context.extend_context_with_struct_field("IdentifiableAction", "timestamp");
 
-            results.push(timestamp.validate_with_context(context)?);
+            results.push(timestamp.validate_with_context(context));
         }
 
         if let Some(name) = &self.name {
             let context = context.extend_context_with_struct_field("IdentifiableAction", "name");
 
-            results.push(name.validate_with_context(context)?);
+            results.push(name.validate_with_context(context));
         }
 
         if let Some(email) = &self.email {
             let context = context.extend_context_with_struct_field("IdentifiableAction", "email");
 
-            results.push(email.validate_with_context(context)?);
+            results.push(email.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -181,38 +168,35 @@ pub struct Issue {
 }
 
 impl Validate for Issue {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let issue_context = context.extend_context_with_struct_field("Issue", "issue_type");
 
-        results.push(self.issue_type.validate_with_context(issue_context)?);
+        results.push(self.issue_type.validate_with_context(issue_context));
 
         if let Some(id) = &self.id {
             let context = context.extend_context_with_struct_field("Issue", "id");
 
-            results.push(id.validate_with_context(context)?);
+            results.push(id.validate_with_context(context));
         }
 
         if let Some(name) = &self.name {
             let context = context.extend_context_with_struct_field("Issue", "name");
 
-            results.push(name.validate_with_context(context)?);
+            results.push(name.validate_with_context(context));
         }
 
         if let Some(description) = &self.description {
             let context = context.extend_context_with_struct_field("Issue", "description");
 
-            results.push(description.validate_with_context(context)?);
+            results.push(description.validate_with_context(context));
         }
 
         if let Some(source) = &self.source {
             let context = context.extend_context_with_struct_field("Issue", "source");
 
-            results.push(source.validate_with_context(context)?);
+            results.push(source.validate_with_context(context));
         }
 
         if let Some(reference) = &self.references {
@@ -224,13 +208,13 @@ impl Validate for Issue {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(reference.validate_with_context(context)?);
+                results.push(reference.validate_with_context(context));
             }
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -267,18 +251,15 @@ impl IssueClassification {
 }
 
 impl Validate for IssueClassification {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            IssueClassification::UnknownIssueClassification(_) => Ok(ValidationResult::Failed {
+            IssueClassification::UnknownIssueClassification(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown issue classification".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -291,20 +272,17 @@ pub struct Patch {
 }
 
 impl Validate for Patch {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let patch_type_context = context.extend_context_with_struct_field("Patch", "patch_type");
 
-        results.push(self.patch_type.validate_with_context(patch_type_context)?);
+        results.push(self.patch_type.validate_with_context(patch_type_context));
 
         if let Some(diff) = &self.diff {
             let context = context.extend_context_with_struct_field("Patch", "diff");
 
-            results.push(diff.validate_with_context(context)?);
+            results.push(diff.validate_with_context(context));
         }
 
         if let Some(resolves) = &self.resolves {
@@ -316,13 +294,13 @@ impl Validate for Patch {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(resolve.validate_with_context(context)?);
+                results.push(resolve.validate_with_context(context));
             }
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -330,20 +308,17 @@ impl Validate for Patch {
 pub struct Patches(pub Vec<Patch>);
 
 impl Validate for Patches {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, patch) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(patch.validate_with_context(context)?);
+            results.push(patch.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -383,18 +358,15 @@ impl PatchClassification {
 }
 
 impl Validate for PatchClassification {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            PatchClassification::UnknownPatchClassification(_) => Ok(ValidationResult::Failed {
+            PatchClassification::UnknownPatchClassification(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown patch classification".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -406,27 +378,24 @@ pub struct Source {
 }
 
 impl Validate for Source {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {
             let context = context.extend_context_with_struct_field("Source", "name");
 
-            results.push(name.validate_with_context(context)?);
+            results.push(name.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
             let context = context.extend_context_with_struct_field("Source", "url");
 
-            results.push(url.validate_with_context(context)?);
+            results.push(url.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -454,8 +423,7 @@ mod test {
             }),
             message: Some(NormalizedString("no_whitespace".to_string())),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -477,8 +445,7 @@ mod test {
             }),
             message: Some(NormalizedString("spaces and\ttabs".to_string())),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -639,8 +606,7 @@ mod test {
                 references: Some(vec![Uri("https://example.com".to_string())]),
             }]),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -669,8 +635,7 @@ mod test {
                 references: Some(vec![Uri("invalid uri".to_string())]),
             }]),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -133,8 +133,7 @@ impl Validate for IdentifiableAction {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {
-            let context =
-                context.with_struct("IdentifiableAction", "timestamp");
+            let context = context.with_struct("IdentifiableAction", "timestamp");
 
             results.push(timestamp.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -39,31 +39,31 @@ impl Validate for Commit {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(uid) = &self.uid {
-            let context = context.extend_context_with_struct_field("Commit", "uid");
+            let context = context.with_struct("Commit", "uid");
 
             results.push(uid.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
-            let context = context.extend_context_with_struct_field("Commit", "url");
+            let context = context.with_struct("Commit", "url");
 
             results.push(url.validate_with_context(context));
         }
 
         if let Some(author) = &self.author {
-            let context = context.extend_context_with_struct_field("Commit", "author");
+            let context = context.with_struct("Commit", "author");
 
             results.push(author.validate_with_context(context));
         }
 
         if let Some(committer) = &self.committer {
-            let context = context.extend_context_with_struct_field("Commit", "committer");
+            let context = context.with_struct("Commit", "committer");
 
             results.push(committer.validate_with_context(context));
         }
 
         if let Some(message) = &self.message {
-            let context = context.extend_context_with_struct_field("Commit", "message");
+            let context = context.with_struct("Commit", "message");
 
             results.push(message.validate_with_context(context));
         }
@@ -104,13 +104,13 @@ impl Validate for Diff {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(text) = &self.text {
-            let context = context.extend_context_with_struct_field("Diff", "text");
+            let context = context.with_struct("Diff", "text");
 
             results.push(text.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
-            let context = context.extend_context_with_struct_field("Diff", "url");
+            let context = context.with_struct("Diff", "url");
 
             results.push(url.validate_with_context(context));
         }
@@ -134,19 +134,19 @@ impl Validate for IdentifiableAction {
 
         if let Some(timestamp) = &self.timestamp {
             let context =
-                context.extend_context_with_struct_field("IdentifiableAction", "timestamp");
+                context.with_struct("IdentifiableAction", "timestamp");
 
             results.push(timestamp.validate_with_context(context));
         }
 
         if let Some(name) = &self.name {
-            let context = context.extend_context_with_struct_field("IdentifiableAction", "name");
+            let context = context.with_struct("IdentifiableAction", "name");
 
             results.push(name.validate_with_context(context));
         }
 
         if let Some(email) = &self.email {
-            let context = context.extend_context_with_struct_field("IdentifiableAction", "email");
+            let context = context.with_struct("IdentifiableAction", "email");
 
             results.push(email.validate_with_context(context));
         }
@@ -171,30 +171,30 @@ impl Validate for Issue {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let issue_context = context.extend_context_with_struct_field("Issue", "issue_type");
+        let issue_context = context.with_struct("Issue", "issue_type");
 
         results.push(self.issue_type.validate_with_context(issue_context));
 
         if let Some(id) = &self.id {
-            let context = context.extend_context_with_struct_field("Issue", "id");
+            let context = context.with_struct("Issue", "id");
 
             results.push(id.validate_with_context(context));
         }
 
         if let Some(name) = &self.name {
-            let context = context.extend_context_with_struct_field("Issue", "name");
+            let context = context.with_struct("Issue", "name");
 
             results.push(name.validate_with_context(context));
         }
 
         if let Some(description) = &self.description {
-            let context = context.extend_context_with_struct_field("Issue", "description");
+            let context = context.with_struct("Issue", "description");
 
             results.push(description.validate_with_context(context));
         }
 
         if let Some(source) = &self.source {
-            let context = context.extend_context_with_struct_field("Issue", "source");
+            let context = context.with_struct("Issue", "source");
 
             results.push(source.validate_with_context(context));
         }
@@ -275,12 +275,12 @@ impl Validate for Patch {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let patch_type_context = context.extend_context_with_struct_field("Patch", "patch_type");
+        let patch_type_context = context.with_struct("Patch", "patch_type");
 
         results.push(self.patch_type.validate_with_context(patch_type_context));
 
         if let Some(diff) = &self.diff {
-            let context = context.extend_context_with_struct_field("Patch", "diff");
+            let context = context.with_struct("Patch", "diff");
 
             results.push(diff.validate_with_context(context));
         }
@@ -382,13 +382,13 @@ impl Validate for Source {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {
-            let context = context.extend_context_with_struct_field("Source", "name");
+            let context = context.with_struct("Source", "name");
 
             results.push(name.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
-            let context = context.extend_context_with_struct_field("Source", "url");
+            let context = context.with_struct("Source", "url");
 
             results.push(url.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -106,8 +106,7 @@ impl Validate for Component {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let component_type_context =
-            context.with_struct("Component", "component_type");
+        let component_type_context = context.with_struct("Component", "component_type");
 
         results.push(
             self.component_type
@@ -209,8 +208,7 @@ impl Validate for Component {
         }
 
         if let Some(external_references) = &self.external_references {
-            let context =
-                context.with_struct("Component", "external_references");
+            let context = context.with_struct("Component", "external_references");
 
             results.push(external_references.validate_with_context(context));
         }
@@ -459,8 +457,7 @@ impl Validate for ComponentEvidence {
         }
 
         if let Some(copyright) = &self.copyright {
-            let context =
-                context.with_struct("ComponentEvidence", "copyright");
+            let context = context.with_struct("ComponentEvidence", "copyright");
 
             results.push(copyright.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -107,7 +107,7 @@ impl Validate for Component {
         let mut results: Vec<ValidationResult> = vec![];
 
         let component_type_context =
-            context.extend_context_with_struct_field("Component", "component_type");
+            context.with_struct("Component", "component_type");
 
         results.push(
             self.component_type
@@ -115,120 +115,120 @@ impl Validate for Component {
         );
 
         if let Some(mime_type) = &self.mime_type {
-            let context = context.extend_context_with_struct_field("Component", "mime_type");
+            let context = context.with_struct("Component", "mime_type");
 
             results.push(mime_type.validate_with_context(context));
         }
 
         if let Some(supplier) = &self.supplier {
-            let context = context.extend_context_with_struct_field("Component", "supplier");
+            let context = context.with_struct("Component", "supplier");
 
             results.push(supplier.validate_with_context(context));
         }
 
         if let Some(author) = &self.author {
-            let context = context.extend_context_with_struct_field("Component", "author");
+            let context = context.with_struct("Component", "author");
 
             results.push(author.validate_with_context(context));
         }
 
         if let Some(publisher) = &self.publisher {
-            let context = context.extend_context_with_struct_field("Component", "publisher");
+            let context = context.with_struct("Component", "publisher");
 
             results.push(publisher.validate_with_context(context));
         }
 
         if let Some(group) = &self.group {
-            let context = context.extend_context_with_struct_field("Component", "group");
+            let context = context.with_struct("Component", "group");
 
             results.push(group.validate_with_context(context));
         }
 
-        let name_context = context.extend_context_with_struct_field("Component", "name");
+        let name_context = context.with_struct("Component", "name");
 
         results.push(self.name.validate_with_context(name_context));
 
         if let Some(version) = &self.version {
-            let context = context.extend_context_with_struct_field("Component", "version");
+            let context = context.with_struct("Component", "version");
 
             results.push(version.validate_with_context(context));
         }
 
         if let Some(description) = &self.description {
-            let context = context.extend_context_with_struct_field("Component", "description");
+            let context = context.with_struct("Component", "description");
 
             results.push(description.validate_with_context(context));
         }
 
         if let Some(scope) = &self.scope {
-            let context = context.extend_context_with_struct_field("Component", "scope");
+            let context = context.with_struct("Component", "scope");
 
             results.push(scope.validate_with_context(context));
         }
 
         if let Some(hashes) = &self.hashes {
-            let context = context.extend_context_with_struct_field("Component", "hashes");
+            let context = context.with_struct("Component", "hashes");
 
             results.push(hashes.validate_with_context(context));
         }
 
         if let Some(licenses) = &self.licenses {
-            let context = context.extend_context_with_struct_field("Component", "licenses");
+            let context = context.with_struct("Component", "licenses");
 
             results.push(licenses.validate_with_context(context));
         }
 
         if let Some(copyright) = &self.copyright {
-            let context = context.extend_context_with_struct_field("Component", "copyright");
+            let context = context.with_struct("Component", "copyright");
 
             results.push(copyright.validate_with_context(context));
         }
 
         if let Some(cpe) = &self.cpe {
-            let context = context.extend_context_with_struct_field("Component", "cpe");
+            let context = context.with_struct("Component", "cpe");
 
             results.push(cpe.validate_with_context(context));
         }
 
         if let Some(purl) = &self.purl {
-            let context = context.extend_context_with_struct_field("Component", "purl");
+            let context = context.with_struct("Component", "purl");
 
             results.push(purl.validate_with_context(context));
         }
 
         if let Some(swid) = &self.swid {
-            let context = context.extend_context_with_struct_field("Component", "swid");
+            let context = context.with_struct("Component", "swid");
 
             results.push(swid.validate_with_context(context));
         }
 
         if let Some(pedigree) = &self.pedigree {
-            let context = context.extend_context_with_struct_field("Component", "pedigree");
+            let context = context.with_struct("Component", "pedigree");
 
             results.push(pedigree.validate_with_context(context));
         }
 
         if let Some(external_references) = &self.external_references {
             let context =
-                context.extend_context_with_struct_field("Component", "external_references");
+                context.with_struct("Component", "external_references");
 
             results.push(external_references.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
-            let context = context.extend_context_with_struct_field("Component", "properties");
+            let context = context.with_struct("Component", "properties");
 
             results.push(properties.validate_with_context(context));
         }
 
         if let Some(components) = &self.components {
-            let context = context.extend_context_with_struct_field("Component", "components");
+            let context = context.with_struct("Component", "components");
 
             results.push(components.validate_with_context(context));
         }
 
         if let Some(evidence) = &self.evidence {
-            let context = context.extend_context_with_struct_field("Component", "evidence");
+            let context = context.with_struct("Component", "evidence");
 
             results.push(evidence.validate_with_context(context));
         }
@@ -401,13 +401,13 @@ impl Validate for Swid {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(text) = &self.text {
-            let context = context.extend_context_with_struct_field("Swid", "text");
+            let context = context.with_struct("Swid", "text");
 
             results.push(text.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
-            let context = context.extend_context_with_struct_field("Swid", "url");
+            let context = context.with_struct("Swid", "url");
 
             results.push(url.validate_with_context(context));
         }
@@ -453,14 +453,14 @@ impl Validate for ComponentEvidence {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(licenses) = &self.licenses {
-            let context = context.extend_context_with_struct_field("ComponentEvidence", "licenses");
+            let context = context.with_struct("ComponentEvidence", "licenses");
 
             results.push(licenses.validate_with_context(context));
         }
 
         if let Some(copyright) = &self.copyright {
             let context =
-                context.extend_context_with_struct_field("ComponentEvidence", "copyright");
+                context.with_struct("ComponentEvidence", "copyright");
 
             results.push(copyright.validate_with_context(context));
         }
@@ -486,31 +486,31 @@ impl Validate for Pedigree {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(ancestors) = &self.ancestors {
-            let context = context.extend_context_with_struct_field("Pedigree", "ancestors");
+            let context = context.with_struct("Pedigree", "ancestors");
 
             results.push(ancestors.validate_with_context(context));
         }
 
         if let Some(descendants) = &self.descendants {
-            let context = context.extend_context_with_struct_field("Pedigree", "descendants");
+            let context = context.with_struct("Pedigree", "descendants");
 
             results.push(descendants.validate_with_context(context));
         }
 
         if let Some(variants) = &self.variants {
-            let context = context.extend_context_with_struct_field("Pedigree", "variants");
+            let context = context.with_struct("Pedigree", "variants");
 
             results.push(variants.validate_with_context(context));
         }
 
         if let Some(commits) = &self.commits {
-            let context = context.extend_context_with_struct_field("Pedigree", "commits");
+            let context = context.with_struct("Pedigree", "commits");
 
             results.push(commits.validate_with_context(context));
         }
 
         if let Some(patches) = &self.patches {
-            let context = context.extend_context_with_struct_field("Pedigree", "patches");
+            let context = context.with_struct("Pedigree", "patches");
 
             results.push(patches.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -18,7 +18,6 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::str::FromStr;
 
 use crate::models::attached_text::AttachedText;
 use crate::models::code::{Commits, Patches};
@@ -33,7 +32,7 @@ use crate::{
         normalized_string::NormalizedString,
         uri::{Purl, Uri},
     },
-    validation::{Validate, ValidationContext, ValidationError, ValidationResult},
+    validation::{Validate, ValidationContext, ValidationResult},
 };
 
 use super::signature::Signature;
@@ -104,10 +103,7 @@ impl Component {
 }
 
 impl Validate for Component {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let component_type_context =
@@ -115,131 +111,131 @@ impl Validate for Component {
 
         results.push(
             self.component_type
-                .validate_with_context(component_type_context)?,
+                .validate_with_context(component_type_context),
         );
 
         if let Some(mime_type) = &self.mime_type {
             let context = context.extend_context_with_struct_field("Component", "mime_type");
 
-            results.push(mime_type.validate_with_context(context)?);
+            results.push(mime_type.validate_with_context(context));
         }
 
         if let Some(supplier) = &self.supplier {
             let context = context.extend_context_with_struct_field("Component", "supplier");
 
-            results.push(supplier.validate_with_context(context)?);
+            results.push(supplier.validate_with_context(context));
         }
 
         if let Some(author) = &self.author {
             let context = context.extend_context_with_struct_field("Component", "author");
 
-            results.push(author.validate_with_context(context)?);
+            results.push(author.validate_with_context(context));
         }
 
         if let Some(publisher) = &self.publisher {
             let context = context.extend_context_with_struct_field("Component", "publisher");
 
-            results.push(publisher.validate_with_context(context)?);
+            results.push(publisher.validate_with_context(context));
         }
 
         if let Some(group) = &self.group {
             let context = context.extend_context_with_struct_field("Component", "group");
 
-            results.push(group.validate_with_context(context)?);
+            results.push(group.validate_with_context(context));
         }
 
         let name_context = context.extend_context_with_struct_field("Component", "name");
 
-        results.push(self.name.validate_with_context(name_context)?);
+        results.push(self.name.validate_with_context(name_context));
 
         if let Some(version) = &self.version {
             let context = context.extend_context_with_struct_field("Component", "version");
 
-            results.push(version.validate_with_context(context)?);
+            results.push(version.validate_with_context(context));
         }
 
         if let Some(description) = &self.description {
             let context = context.extend_context_with_struct_field("Component", "description");
 
-            results.push(description.validate_with_context(context)?);
+            results.push(description.validate_with_context(context));
         }
 
         if let Some(scope) = &self.scope {
             let context = context.extend_context_with_struct_field("Component", "scope");
 
-            results.push(scope.validate_with_context(context)?);
+            results.push(scope.validate_with_context(context));
         }
 
         if let Some(hashes) = &self.hashes {
             let context = context.extend_context_with_struct_field("Component", "hashes");
 
-            results.push(hashes.validate_with_context(context)?);
+            results.push(hashes.validate_with_context(context));
         }
 
         if let Some(licenses) = &self.licenses {
             let context = context.extend_context_with_struct_field("Component", "licenses");
 
-            results.push(licenses.validate_with_context(context)?);
+            results.push(licenses.validate_with_context(context));
         }
 
         if let Some(copyright) = &self.copyright {
             let context = context.extend_context_with_struct_field("Component", "copyright");
 
-            results.push(copyright.validate_with_context(context)?);
+            results.push(copyright.validate_with_context(context));
         }
 
         if let Some(cpe) = &self.cpe {
             let context = context.extend_context_with_struct_field("Component", "cpe");
 
-            results.push(cpe.validate_with_context(context)?);
+            results.push(cpe.validate_with_context(context));
         }
 
         if let Some(purl) = &self.purl {
             let context = context.extend_context_with_struct_field("Component", "purl");
 
-            results.push(purl.validate_with_context(context)?);
+            results.push(purl.validate_with_context(context));
         }
 
         if let Some(swid) = &self.swid {
             let context = context.extend_context_with_struct_field("Component", "swid");
 
-            results.push(swid.validate_with_context(context)?);
+            results.push(swid.validate_with_context(context));
         }
 
         if let Some(pedigree) = &self.pedigree {
             let context = context.extend_context_with_struct_field("Component", "pedigree");
 
-            results.push(pedigree.validate_with_context(context)?);
+            results.push(pedigree.validate_with_context(context));
         }
 
         if let Some(external_references) = &self.external_references {
             let context =
                 context.extend_context_with_struct_field("Component", "external_references");
 
-            results.push(external_references.validate_with_context(context)?);
+            results.push(external_references.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
             let context = context.extend_context_with_struct_field("Component", "properties");
 
-            results.push(properties.validate_with_context(context)?);
+            results.push(properties.validate_with_context(context));
         }
 
         if let Some(components) = &self.components {
             let context = context.extend_context_with_struct_field("Component", "components");
 
-            results.push(components.validate_with_context(context)?);
+            results.push(components.validate_with_context(context));
         }
 
         if let Some(evidence) = &self.evidence {
             let context = context.extend_context_with_struct_field("Component", "evidence");
 
-            results.push(evidence.validate_with_context(context)?);
+            results.push(evidence.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -247,20 +243,17 @@ impl Validate for Component {
 pub struct Components(pub Vec<Component>);
 
 impl Validate for Components {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, component) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(component.validate_with_context(context)?);
+            results.push(component.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -312,18 +305,15 @@ impl Classification {
 }
 
 impl Validate for Classification {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            Classification::UnknownClassification(_) => Ok(ValidationResult::Failed {
+            Classification::UnknownClassification(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown classification".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -361,18 +351,15 @@ impl Scope {
 }
 
 impl Validate for Scope {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            Scope::UnknownScope(_) => Ok(ValidationResult::Failed {
+            Scope::UnknownScope(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown scope".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -381,22 +368,19 @@ impl Validate for Scope {
 pub struct MimeType(pub(crate) String);
 
 impl Validate for MimeType {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"^[-+a-z0-9.]+/[-+a-z0-9.]+$").expect("Failed to compile regex.")
         });
 
         match UUID_REGEX.is_match(&self.0) {
-            true => Ok(ValidationResult::Passed),
-            false => Ok(ValidationResult::Failed {
+            true => ValidationResult::Passed,
+            false => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "MimeType does not match regular expression".to_string(),
                     context,
                 }],
-            }),
+            },
         }
     }
 }
@@ -413,48 +397,32 @@ pub struct Swid {
 }
 
 impl Validate for Swid {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(text) = &self.text {
             let context = context.extend_context_with_struct_field("Swid", "text");
 
-            results.push(text.validate_with_context(context)?);
+            results.push(text.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
             let context = context.extend_context_with_struct_field("Swid", "url");
 
-            results.push(url.validate_with_context(context)?);
+            results.push(url.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Cpe(pub(crate) String);
 
-impl FromStr for Cpe {
-    type Err = ValidationError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let result = Cpe(s.to_string());
-        result.validate()?;
-        Ok(result)
-    }
-}
-
 impl Validate for Cpe {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
             Regex::new(
                 r##"([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})"##,
@@ -462,14 +430,14 @@ impl Validate for Cpe {
         });
 
         if UUID_REGEX.is_match(&self.0) {
-            Ok(ValidationResult::Passed)
+            ValidationResult::Passed
         } else {
-            Ok(ValidationResult::Failed {
+            ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Cpe does not match regular expression".to_string(),
                     context,
                 }],
-            })
+            }
         }
     }
 }
@@ -481,28 +449,25 @@ pub struct ComponentEvidence {
 }
 
 impl Validate for ComponentEvidence {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(licenses) = &self.licenses {
             let context = context.extend_context_with_struct_field("ComponentEvidence", "licenses");
 
-            results.push(licenses.validate_with_context(context)?);
+            results.push(licenses.validate_with_context(context));
         }
 
         if let Some(copyright) = &self.copyright {
             let context =
                 context.extend_context_with_struct_field("ComponentEvidence", "copyright");
 
-            results.push(copyright.validate_with_context(context)?);
+            results.push(copyright.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -517,45 +482,42 @@ pub struct Pedigree {
 }
 
 impl Validate for Pedigree {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(ancestors) = &self.ancestors {
             let context = context.extend_context_with_struct_field("Pedigree", "ancestors");
 
-            results.push(ancestors.validate_with_context(context)?);
+            results.push(ancestors.validate_with_context(context));
         }
 
         if let Some(descendants) = &self.descendants {
             let context = context.extend_context_with_struct_field("Pedigree", "descendants");
 
-            results.push(descendants.validate_with_context(context)?);
+            results.push(descendants.validate_with_context(context));
         }
 
         if let Some(variants) = &self.variants {
             let context = context.extend_context_with_struct_field("Pedigree", "variants");
 
-            results.push(variants.validate_with_context(context)?);
+            results.push(variants.validate_with_context(context));
         }
 
         if let Some(commits) = &self.commits {
             let context = context.extend_context_with_struct_field("Pedigree", "commits");
 
-            results.push(commits.validate_with_context(context)?);
+            results.push(commits.validate_with_context(context));
         }
 
         if let Some(patches) = &self.patches {
             let context = context.extend_context_with_struct_field("Pedigree", "patches");
 
-            results.push(patches.validate_with_context(context)?);
+            results.push(patches.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -563,11 +525,8 @@ impl Validate for Pedigree {
 pub struct Copyright(pub String);
 
 impl Validate for Copyright {
-    fn validate_with_context(
-        &self,
-        _context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
-        Ok(ValidationResult::default())
+    fn validate_with_context(&self, _context: ValidationContext) -> ValidationResult {
+        ValidationResult::default()
     }
 }
 
@@ -575,20 +534,17 @@ impl Validate for Copyright {
 pub struct CopyrightTexts(pub(crate) Vec<Copyright>);
 
 impl Validate for CopyrightTexts {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, copyright) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(copyright.validate_with_context(context)?);
+            results.push(copyright.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -693,8 +649,7 @@ mod test {
                 value: "abcdefgh".to_string(),
             }),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -785,8 +740,7 @@ mod test {
                 value: "abcdefgh".to_string(),
             }),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -17,8 +17,7 @@
  */
 
 use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-    ValidationResult,
+    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
 };
 
 use super::signature::Signature;
@@ -32,20 +31,17 @@ pub struct Composition {
 }
 
 impl Validate for Composition {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let aggregate_context =
             context.extend_context_with_struct_field("Composition", "aggregate");
 
-        results.push(self.aggregate.validate_with_context(aggregate_context)?);
+        results.push(self.aggregate.validate_with_context(aggregate_context));
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -53,21 +49,18 @@ impl Validate for Composition {
 pub struct Compositions(pub Vec<Composition>);
 
 impl Validate for Compositions {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, composition) in self.0.iter().enumerate() {
             let composition_context =
                 context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(composition.validate_with_context(composition_context)?);
+            results.push(composition.validate_with_context(composition_context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -113,18 +106,15 @@ impl AggregateType {
 }
 
 impl Validate for AggregateType {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            AggregateType::UnknownAggregateType(_) => Ok(ValidationResult::Failed {
+            AggregateType::UnknownAggregateType(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown aggregate type".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -150,8 +140,7 @@ mod test {
                 value: "abcdefgh".to_string(),
             }),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -167,8 +156,7 @@ mod test {
                 value: "abcdefgh".to_string(),
             }),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -35,7 +35,7 @@ impl Validate for Composition {
         let mut results: Vec<ValidationResult> = vec![];
 
         let aggregate_context =
-            context.extend_context_with_struct_field("Composition", "aggregate");
+            context.with_struct("Composition", "aggregate");
 
         results.push(self.aggregate.validate_with_context(aggregate_context));
 

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -34,8 +34,7 @@ impl Validate for Composition {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let aggregate_context =
-            context.with_struct("Composition", "aggregate");
+        let aggregate_context = context.with_struct("Composition", "aggregate");
 
         results.push(self.aggregate.validate_with_context(aggregate_context));
 

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -19,8 +19,7 @@
 use crate::external_models::uri::Uri;
 use crate::models::hash::Hashes;
 use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-    ValidationResult,
+    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
 };
 
 /// Represents a way to document systems, sites, and information that may be relevant but which are not included with the BOM.
@@ -56,10 +55,7 @@ impl ExternalReference {
 }
 
 impl Validate for ExternalReference {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let external_reference_type_context = context
@@ -67,22 +63,22 @@ impl Validate for ExternalReference {
 
         results.push(
             self.external_reference_type
-                .validate_with_context(external_reference_type_context)?,
+                .validate_with_context(external_reference_type_context),
         );
 
         let url_context = context.extend_context_with_struct_field("ExternalReference", "url");
 
-        results.push(self.url.validate_with_context(url_context)?);
+        results.push(self.url.validate_with_context(url_context));
 
         if let Some(hashes) = &self.hashes {
             let context = context.extend_context_with_struct_field("ExternalReference", "hashes");
 
-            results.push(hashes.validate_with_context(context)?);
+            results.push(hashes.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -90,20 +86,17 @@ impl Validate for ExternalReference {
 pub struct ExternalReferences(pub Vec<ExternalReference>);
 
 impl Validate for ExternalReferences {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, external_reference) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(external_reference.validate_with_context(context)?);
+            results.push(external_reference.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -177,20 +170,15 @@ impl ExternalReferenceType {
 }
 
 impl Validate for ExternalReferenceType {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            ExternalReferenceType::UnknownExternalReferenceType(_) => {
-                Ok(ValidationResult::Failed {
-                    reasons: vec![FailureReason {
-                        message: "Unknown external reference type".to_string(),
-                        context,
-                    }],
-                })
-            }
-            _ => Ok(ValidationResult::Passed),
+            ExternalReferenceType::UnknownExternalReferenceType(_) => ValidationResult::Failed {
+                reasons: vec![FailureReason {
+                    message: "Unknown external reference type".to_string(),
+                    context,
+                }],
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -211,8 +199,7 @@ mod test {
             comment: Some("Comment".to_string()),
             hashes: Some(Hashes(vec![])),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -230,8 +217,7 @@ mod test {
                 content: HashValue("invalid hash".to_string()),
             }])),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -59,19 +59,19 @@ impl Validate for ExternalReference {
         let mut results: Vec<ValidationResult> = vec![];
 
         let external_reference_type_context = context
-            .extend_context_with_struct_field("ExternalReference", "external_reference_type");
+            .with_struct("ExternalReference", "external_reference_type");
 
         results.push(
             self.external_reference_type
                 .validate_with_context(external_reference_type_context),
         );
 
-        let url_context = context.extend_context_with_struct_field("ExternalReference", "url");
+        let url_context = context.with_struct("ExternalReference", "url");
 
         results.push(self.url.validate_with_context(url_context));
 
         if let Some(hashes) = &self.hashes {
-            let context = context.extend_context_with_struct_field("ExternalReference", "hashes");
+            let context = context.with_struct("ExternalReference", "hashes");
 
             results.push(hashes.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -58,8 +58,8 @@ impl Validate for ExternalReference {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let external_reference_type_context = context
-            .with_struct("ExternalReference", "external_reference_type");
+        let external_reference_type_context =
+            context.with_struct("ExternalReference", "external_reference_type");
 
         results.push(
             self.external_reference_type

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -36,11 +36,11 @@ impl Validate for Hash {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let alg_context = context.extend_context_with_struct_field("Hash", "alg");
+        let alg_context = context.with_struct("Hash", "alg");
 
         results.push(self.alg.validate_with_context(alg_context));
 
-        let content_context = context.extend_context_with_struct_field("Hash", "content");
+        let content_context = context.with_struct("Hash", "content");
 
         results.push(self.content.validate_with_context(content_context));
 

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -120,7 +120,7 @@ impl Validate for License {
         let mut results: Vec<ValidationResult> = vec![];
 
         let license_identifier_context =
-            context.extend_context_with_struct_field("License", "license_identifier");
+            context.with_struct("License", "license_identifier");
 
         results.push(
             self.license_identifier
@@ -128,13 +128,13 @@ impl Validate for License {
         );
 
         if let Some(text) = &self.text {
-            let context = context.extend_context_with_struct_field("License", "text");
+            let context = context.with_struct("License", "text");
 
             results.push(text.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
-            let context = context.extend_context_with_struct_field("License", "url");
+            let context = context.with_struct("License", "url");
 
             results.push(url.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -25,9 +25,7 @@ use crate::external_models::{
     uri::Uri,
 };
 use crate::models::attached_text::AttachedText;
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// Represents whether a license is a named license or an SPDX license expression
 ///
@@ -45,10 +43,7 @@ impl LicenseChoice {
 }
 
 impl Validate for LicenseChoice {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         match self {
@@ -57,22 +52,22 @@ impl Validate for LicenseChoice {
                     context.extend_context(vec![ValidationPathComponent::EnumVariant {
                         variant_name: "License".to_string(),
                     }]);
-                results.push(license.validate_with_context(license_context)?);
+                results.push(license.validate_with_context(license_context));
 
-                Ok(results
+                results
                     .into_iter()
-                    .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+                    .fold(ValidationResult::default(), |acc, result| acc.merge(result))
             }
             LicenseChoice::Expression(expression) => {
                 let expression_context =
                     context.extend_context(vec![ValidationPathComponent::EnumVariant {
                         variant_name: "Expression".to_string(),
                     }]);
-                results.push(expression.validate_with_context(expression_context)?);
+                results.push(expression.validate_with_context(expression_context));
 
-                Ok(results
+                results
                     .into_iter()
-                    .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+                    .fold(ValidationResult::default(), |acc, result| acc.merge(result))
             }
         }
     }
@@ -121,10 +116,7 @@ impl License {
 }
 
 impl Validate for License {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let license_identifier_context =
@@ -132,24 +124,24 @@ impl Validate for License {
 
         results.push(
             self.license_identifier
-                .validate_with_context(license_identifier_context)?,
+                .validate_with_context(license_identifier_context),
         );
 
         if let Some(text) = &self.text {
             let context = context.extend_context_with_struct_field("License", "text");
 
-            results.push(text.validate_with_context(context)?);
+            results.push(text.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
             let context = context.extend_context_with_struct_field("License", "url");
 
-            results.push(url.validate_with_context(context)?);
+            results.push(url.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -157,21 +149,18 @@ impl Validate for License {
 pub struct Licenses(pub Vec<LicenseChoice>);
 
 impl Validate for Licenses {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, license_choice) in self.0.iter().enumerate() {
             let license_choice_context =
                 context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(license_choice.validate_with_context(license_choice_context)?);
+            results.push(license_choice.validate_with_context(license_choice_context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -184,24 +173,21 @@ pub enum LicenseIdentifier {
 }
 
 impl Validate for LicenseIdentifier {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
             LicenseIdentifier::Name(name) => {
                 let name_context =
                     context.extend_context(vec![ValidationPathComponent::EnumVariant {
                         variant_name: "Name".to_string(),
                     }]);
-                Ok(name.validate_with_context(name_context)?)
+                name.validate_with_context(name_context)
             }
             LicenseIdentifier::SpdxId(id) => {
                 let spdxid_context =
                     context.extend_context(vec![ValidationPathComponent::EnumVariant {
                         variant_name: "SpdxId".to_string(),
                     }]);
-                Ok(id.validate_with_context(spdxid_context)?)
+                id.validate_with_context(spdxid_context)
             }
         }
     }
@@ -219,8 +205,7 @@ mod test {
         let validation_result = Licenses(vec![LicenseChoice::Expression(SpdxExpression(
             "MIT OR Apache-2.0".to_string(),
         ))])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -234,8 +219,7 @@ mod test {
             text: None,
             url: None,
         })])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -268,8 +252,7 @@ mod test {
             text: None,
             url: None,
         })])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -299,8 +282,7 @@ mod test {
         let validation_result = Licenses(vec![LicenseChoice::Expression(SpdxExpression(
             "MIT OR".to_string(),
         ))])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -341,8 +323,7 @@ mod test {
                 url: None,
             }),
         ])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -394,8 +375,7 @@ mod test {
             LicenseChoice::Expression(SpdxExpression("MIT OR".to_string())),
             LicenseChoice::Expression(SpdxExpression("MIT OR".to_string())),
         ])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -119,8 +119,7 @@ impl Validate for License {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let license_identifier_context =
-            context.with_struct("License", "license_identifier");
+        let license_identifier_context = context.with_struct("License", "license_identifier");
 
         results.push(
             self.license_identifier

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -24,9 +24,7 @@ use crate::models::license::Licenses;
 use crate::models::organization::{OrganizationalContact, OrganizationalEntity};
 use crate::models::property::Properties;
 use crate::models::tool::Tools;
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// Represents additional information about a BOM
 ///
@@ -66,22 +64,19 @@ impl Metadata {
 }
 
 impl Validate for Metadata {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {
             let context = context.extend_context_with_struct_field("Metadata", "timestamp");
 
-            results.push(timestamp.validate_with_context(context)?);
+            results.push(timestamp.validate_with_context(context));
         }
 
         if let Some(tools) = &self.tools {
             let context = context.extend_context_with_struct_field("Metadata", "tools");
 
-            results.push(tools.validate_with_context(context)?);
+            results.push(tools.validate_with_context(context));
         }
 
         if let Some(authors) = &self.authors {
@@ -93,43 +88,43 @@ impl Validate for Metadata {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(contact.validate_with_context(uri_context)?);
+                results.push(contact.validate_with_context(uri_context));
             }
         }
 
         if let Some(component) = &self.component {
             let context = context.extend_context_with_struct_field("Metadata", "component");
 
-            results.push(component.validate_with_context(context)?);
+            results.push(component.validate_with_context(context));
         }
 
         if let Some(manufacture) = &self.manufacture {
             let context = context.extend_context_with_struct_field("Metadata", "manufacture");
 
-            results.push(manufacture.validate_with_context(context)?);
+            results.push(manufacture.validate_with_context(context));
         }
 
         if let Some(supplier) = &self.supplier {
             let context = context.extend_context_with_struct_field("Metadata", "supplier");
 
-            results.push(supplier.validate_with_context(context)?);
+            results.push(supplier.validate_with_context(context));
         }
 
         if let Some(licenses) = &self.licenses {
             let context = context.extend_context_with_struct_field("Metadata", "licenses");
 
-            results.push(licenses.validate_with_context(context)?);
+            results.push(licenses.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
             let context = context.extend_context_with_struct_field("Metadata", "properties");
 
-            results.push(properties.validate_with_context(context)?);
+            results.push(properties.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -211,8 +206,7 @@ mod test {
                 value: NormalizedString::new("value"),
             }])),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -276,8 +270,7 @@ mod test {
                 value: NormalizedString("invalid\tvalue".to_string()),
             }])),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -68,13 +68,13 @@ impl Validate for Metadata {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {
-            let context = context.extend_context_with_struct_field("Metadata", "timestamp");
+            let context = context.with_struct("Metadata", "timestamp");
 
             results.push(timestamp.validate_with_context(context));
         }
 
         if let Some(tools) = &self.tools {
-            let context = context.extend_context_with_struct_field("Metadata", "tools");
+            let context = context.with_struct("Metadata", "tools");
 
             results.push(tools.validate_with_context(context));
         }
@@ -93,31 +93,31 @@ impl Validate for Metadata {
         }
 
         if let Some(component) = &self.component {
-            let context = context.extend_context_with_struct_field("Metadata", "component");
+            let context = context.with_struct("Metadata", "component");
 
             results.push(component.validate_with_context(context));
         }
 
         if let Some(manufacture) = &self.manufacture {
-            let context = context.extend_context_with_struct_field("Metadata", "manufacture");
+            let context = context.with_struct("Metadata", "manufacture");
 
             results.push(manufacture.validate_with_context(context));
         }
 
         if let Some(supplier) = &self.supplier {
-            let context = context.extend_context_with_struct_field("Metadata", "supplier");
+            let context = context.with_struct("Metadata", "supplier");
 
             results.push(supplier.validate_with_context(context));
         }
 
         if let Some(licenses) = &self.licenses {
-            let context = context.extend_context_with_struct_field("Metadata", "licenses");
+            let context = context.with_struct("Metadata", "licenses");
 
             results.push(licenses.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
-            let context = context.extend_context_with_struct_field("Metadata", "properties");
+            let context = context.with_struct("Metadata", "properties");
 
             results.push(properties.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -18,9 +18,7 @@
 
 use crate::{
     external_models::{normalized_string::NormalizedString, uri::Uri},
-    validation::{
-        Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-    },
+    validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult},
 };
 
 /// Represents the contact information for an organization
@@ -50,16 +48,13 @@ impl OrganizationalContact {
 }
 
 impl Validate for OrganizationalContact {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut name_result = ValidationResult::default();
         if let Some(name) = &self.name {
             let name_context =
                 context.extend_context_with_struct_field("OrganizationalContact", "name");
 
-            name_result = name.validate_with_context(name_context)?;
+            name_result = name.validate_with_context(name_context);
         }
 
         let mut email_result = ValidationResult::default();
@@ -67,7 +62,7 @@ impl Validate for OrganizationalContact {
             let email_context =
                 context.extend_context_with_struct_field("OrganizationalContact", "email");
 
-            email_result = email.validate_with_context(email_context)?;
+            email_result = email.validate_with_context(email_context);
         }
 
         let mut phone_result = ValidationResult::default();
@@ -75,10 +70,10 @@ impl Validate for OrganizationalContact {
             let phone_context =
                 context.extend_context_with_struct_field("OrganizationalContact", "phone");
 
-            phone_result = phone.validate_with_context(phone_context)?;
+            phone_result = phone.validate_with_context(phone_context);
         }
 
-        Ok(name_result.merge(email_result).merge(phone_result))
+        name_result.merge(email_result).merge(phone_result)
     }
 }
 
@@ -93,17 +88,14 @@ pub struct OrganizationalEntity {
 }
 
 impl Validate for OrganizationalEntity {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {
             let name_context =
                 context.extend_context_with_struct_field("OrganizationalEntity", "name");
 
-            results.push(name.validate_with_context(name_context)?);
+            results.push(name.validate_with_context(name_context));
         }
 
         if let Some(urls) = &self.url {
@@ -116,7 +108,7 @@ impl Validate for OrganizationalEntity {
                     ValidationPathComponent::Array { index },
                 ]);
 
-                results.push(url.validate_with_context(uri_context)?);
+                results.push(url.validate_with_context(uri_context));
             }
         }
 
@@ -129,13 +121,13 @@ impl Validate for OrganizationalEntity {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(contact.validate_with_context(uri_context)?);
+                results.push(contact.validate_with_context(uri_context));
             }
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -153,9 +145,7 @@ mod test {
             email: None,
             phone: None,
         };
-        let actual = contact
-            .validate_with_context(ValidationContext::default())
-            .expect("Failed to validate contact");
+        let actual = contact.validate();
         assert_eq!(actual, ValidationResult::Passed);
     }
 
@@ -166,9 +156,7 @@ mod test {
             email: None,
             phone: None,
         };
-        let actual = contact
-            .validate_with_context(ValidationContext::default())
-            .expect("Failed to validate contact");
+        let actual = contact.validate();
         assert_eq!(
             actual,
             ValidationResult::Failed {
@@ -195,9 +183,7 @@ mod test {
                 "invalid\tphone".to_string(),
             )),
         };
-        let actual = contact
-            .validate_with_context(ValidationContext::default())
-            .expect("Failed to validate contact");
+        let actual = contact.validate();
         assert_eq!(
             actual,
             ValidationResult::Failed {
@@ -241,9 +227,7 @@ mod test {
             url: None,
             contact: None,
         };
-        let actual = entity
-            .validate_with_context(ValidationContext::default())
-            .expect("Failed to validate entity");
+        let actual = entity.validate();
         assert_eq!(
             actual,
             ValidationResult::Failed {
@@ -270,9 +254,7 @@ mod test {
                 phone: None,
             }]),
         };
-        let actual = entity
-            .validate_with_context(ValidationContext::default())
-            .expect("Failed to validate entity");
+        let actual = entity.validate();
         assert_eq!(
             actual,
             ValidationResult::Failed {

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -51,24 +51,21 @@ impl Validate for OrganizationalContact {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut name_result = ValidationResult::default();
         if let Some(name) = &self.name {
-            let name_context =
-                context.with_struct("OrganizationalContact", "name");
+            let name_context = context.with_struct("OrganizationalContact", "name");
 
             name_result = name.validate_with_context(name_context);
         }
 
         let mut email_result = ValidationResult::default();
         if let Some(email) = &self.email {
-            let email_context =
-                context.with_struct("OrganizationalContact", "email");
+            let email_context = context.with_struct("OrganizationalContact", "email");
 
             email_result = email.validate_with_context(email_context);
         }
 
         let mut phone_result = ValidationResult::default();
         if let Some(phone) = &self.phone {
-            let phone_context =
-                context.with_struct("OrganizationalContact", "phone");
+            let phone_context = context.with_struct("OrganizationalContact", "phone");
 
             phone_result = phone.validate_with_context(phone_context);
         }
@@ -92,8 +89,7 @@ impl Validate for OrganizationalEntity {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {
-            let name_context =
-                context.with_struct("OrganizationalEntity", "name");
+            let name_context = context.with_struct("OrganizationalEntity", "name");
 
             results.push(name.validate_with_context(name_context));
         }

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -52,7 +52,7 @@ impl Validate for OrganizationalContact {
         let mut name_result = ValidationResult::default();
         if let Some(name) = &self.name {
             let name_context =
-                context.extend_context_with_struct_field("OrganizationalContact", "name");
+                context.with_struct("OrganizationalContact", "name");
 
             name_result = name.validate_with_context(name_context);
         }
@@ -60,7 +60,7 @@ impl Validate for OrganizationalContact {
         let mut email_result = ValidationResult::default();
         if let Some(email) = &self.email {
             let email_context =
-                context.extend_context_with_struct_field("OrganizationalContact", "email");
+                context.with_struct("OrganizationalContact", "email");
 
             email_result = email.validate_with_context(email_context);
         }
@@ -68,7 +68,7 @@ impl Validate for OrganizationalContact {
         let mut phone_result = ValidationResult::default();
         if let Some(phone) = &self.phone {
             let phone_context =
-                context.extend_context_with_struct_field("OrganizationalContact", "phone");
+                context.with_struct("OrganizationalContact", "phone");
 
             phone_result = phone.validate_with_context(phone_context);
         }
@@ -93,7 +93,7 @@ impl Validate for OrganizationalEntity {
 
         if let Some(name) = &self.name {
             let name_context =
-                context.extend_context_with_struct_field("OrganizationalEntity", "name");
+                context.with_struct("OrganizationalEntity", "name");
 
             results.push(name.validate_with_context(name_context));
         }

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -73,7 +73,7 @@ impl Validate for Property {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let value_context = context.extend_context_with_struct_field("Property", "value");
+        let value_context = context.with_struct("Property", "value");
 
         results.push(self.value.validate_with_context(value_context));
 

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -18,9 +18,7 @@
 
 use crate::{
     external_models::normalized_string::NormalizedString,
-    validation::{
-        Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-    },
+    validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult},
 };
 
 /// Represents a name-value store that can be used to describe additional data about the components, services, or the BOM that
@@ -32,21 +30,18 @@ use crate::{
 pub struct Properties(pub Vec<Property>);
 
 impl Validate for Properties {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, property) in self.0.iter().enumerate() {
             let property_context =
                 context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(property.validate_with_context(property_context)?);
+            results.push(property.validate_with_context(property_context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -75,19 +70,16 @@ impl Property {
 }
 
 impl Validate for Property {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let value_context = context.extend_context_with_struct_field("Property", "value");
 
-        results.push(self.value.validate_with_context(value_context)?);
+        results.push(self.value.validate_with_context(value_context));
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -103,8 +95,7 @@ mod test {
             name: "property name".to_string(),
             value: NormalizedString("property value".to_string()),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -115,8 +106,7 @@ mod test {
             name: "property name".to_string(),
             value: NormalizedString("spaces and \ttabs".to_string()),
         }])
-        .validate()
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -22,8 +22,7 @@ use crate::models::license::Licenses;
 use crate::models::organization::OrganizationalEntity;
 use crate::models::property::Properties;
 use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-    ValidationResult,
+    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
 };
 
 use super::signature::Signature;
@@ -80,38 +79,35 @@ impl Service {
 }
 
 impl Validate for Service {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(provider) = &self.provider {
             let context = context.extend_context_with_struct_field("Service", "provider");
 
-            results.push(provider.validate_with_context(context)?);
+            results.push(provider.validate_with_context(context));
         }
 
         if let Some(group) = &self.group {
             let context = context.extend_context_with_struct_field("Service", "group");
 
-            results.push(group.validate_with_context(context)?);
+            results.push(group.validate_with_context(context));
         }
 
         let name_context = context.extend_context_with_struct_field("Service", "name");
 
-        results.push(self.name.validate_with_context(name_context)?);
+        results.push(self.name.validate_with_context(name_context));
 
         if let Some(version) = &self.version {
             let context = context.extend_context_with_struct_field("Service", "version");
 
-            results.push(version.validate_with_context(context)?);
+            results.push(version.validate_with_context(context));
         }
 
         if let Some(description) = &self.description {
             let context = context.extend_context_with_struct_field("Service", "description");
 
-            results.push(description.validate_with_context(context)?);
+            results.push(description.validate_with_context(context));
         }
 
         if let Some(endpoints) = &self.endpoints {
@@ -123,7 +119,7 @@ impl Validate for Service {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(endpoint.validate_with_context(context)?);
+                results.push(endpoint.validate_with_context(context));
             }
         }
 
@@ -136,38 +132,38 @@ impl Validate for Service {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(classification.validate_with_context(context)?);
+                results.push(classification.validate_with_context(context));
             }
         }
 
         if let Some(licenses) = &self.licenses {
             let context = context.extend_context_with_struct_field("Service", "licenses");
 
-            results.push(licenses.validate_with_context(context)?);
+            results.push(licenses.validate_with_context(context));
         }
 
         if let Some(external_references) = &self.external_references {
             let context =
                 context.extend_context_with_struct_field("Service", "external_references");
 
-            results.push(external_references.validate_with_context(context)?);
+            results.push(external_references.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
             let context = context.extend_context_with_struct_field("Service", "properties");
 
-            results.push(properties.validate_with_context(context)?);
+            results.push(properties.validate_with_context(context));
         }
 
         if let Some(services) = &self.services {
             let context = context.extend_context_with_struct_field("Service", "services");
 
-            results.push(services.validate_with_context(context)?);
+            results.push(services.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -175,20 +171,17 @@ impl Validate for Service {
 pub struct Services(pub Vec<Service>);
 
 impl Validate for Services {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, service) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(service.validate_with_context(context)?);
+            results.push(service.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -202,27 +195,24 @@ pub struct DataClassification {
 }
 
 impl Validate for DataClassification {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let flow_context = context.extend_context_with_struct_field("DataClassification", "flow");
 
-        results.push(self.flow.validate_with_context(flow_context)?);
+        results.push(self.flow.validate_with_context(flow_context));
 
         let classification_context =
             context.extend_context_with_struct_field("DataClassification", "classification");
 
         results.push(
             self.classification
-                .validate_with_context(classification_context)?,
+                .validate_with_context(classification_context),
         );
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -265,18 +255,15 @@ impl DataFlowType {
 }
 
 impl Validate for DataFlowType {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            DataFlowType::UnknownDataFlow(_) => Ok(ValidationResult::Failed {
+            DataFlowType::UnknownDataFlow(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Unknown data flow type".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -335,8 +322,7 @@ mod test {
                 value: "abcdefgh".to_string(),
             }),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -398,8 +384,7 @@ mod test {
                 value: "abcdefgh".to_string(),
             }),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -143,8 +143,7 @@ impl Validate for Service {
         }
 
         if let Some(external_references) = &self.external_references {
-            let context =
-                context.with_struct("Service", "external_references");
+            let context = context.with_struct("Service", "external_references");
 
             results.push(external_references.validate_with_context(context));
         }
@@ -202,8 +201,7 @@ impl Validate for DataClassification {
 
         results.push(self.flow.validate_with_context(flow_context));
 
-        let classification_context =
-            context.with_struct("DataClassification", "classification");
+        let classification_context = context.with_struct("DataClassification", "classification");
 
         results.push(
             self.classification

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -83,29 +83,29 @@ impl Validate for Service {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(provider) = &self.provider {
-            let context = context.extend_context_with_struct_field("Service", "provider");
+            let context = context.with_struct("Service", "provider");
 
             results.push(provider.validate_with_context(context));
         }
 
         if let Some(group) = &self.group {
-            let context = context.extend_context_with_struct_field("Service", "group");
+            let context = context.with_struct("Service", "group");
 
             results.push(group.validate_with_context(context));
         }
 
-        let name_context = context.extend_context_with_struct_field("Service", "name");
+        let name_context = context.with_struct("Service", "name");
 
         results.push(self.name.validate_with_context(name_context));
 
         if let Some(version) = &self.version {
-            let context = context.extend_context_with_struct_field("Service", "version");
+            let context = context.with_struct("Service", "version");
 
             results.push(version.validate_with_context(context));
         }
 
         if let Some(description) = &self.description {
-            let context = context.extend_context_with_struct_field("Service", "description");
+            let context = context.with_struct("Service", "description");
 
             results.push(description.validate_with_context(context));
         }
@@ -137,26 +137,26 @@ impl Validate for Service {
         }
 
         if let Some(licenses) = &self.licenses {
-            let context = context.extend_context_with_struct_field("Service", "licenses");
+            let context = context.with_struct("Service", "licenses");
 
             results.push(licenses.validate_with_context(context));
         }
 
         if let Some(external_references) = &self.external_references {
             let context =
-                context.extend_context_with_struct_field("Service", "external_references");
+                context.with_struct("Service", "external_references");
 
             results.push(external_references.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
-            let context = context.extend_context_with_struct_field("Service", "properties");
+            let context = context.with_struct("Service", "properties");
 
             results.push(properties.validate_with_context(context));
         }
 
         if let Some(services) = &self.services {
-            let context = context.extend_context_with_struct_field("Service", "services");
+            let context = context.with_struct("Service", "services");
 
             results.push(services.validate_with_context(context));
         }
@@ -198,12 +198,12 @@ impl Validate for DataClassification {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let flow_context = context.extend_context_with_struct_field("DataClassification", "flow");
+        let flow_context = context.with_struct("DataClassification", "flow");
 
         results.push(self.flow.validate_with_context(flow_context));
 
         let classification_context =
-            context.extend_context_with_struct_field("DataClassification", "classification");
+            context.with_struct("DataClassification", "classification");
 
         results.push(
             self.classification

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -53,25 +53,25 @@ impl Validate for Tool {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vendor) = &self.vendor {
-            let context = context.extend_context_with_struct_field("Tool", "vendor");
+            let context = context.with_struct("Tool", "vendor");
 
             results.push(vendor.validate_with_context(context));
         }
 
         if let Some(name) = &self.name {
-            let context = context.extend_context_with_struct_field("Tool", "name");
+            let context = context.with_struct("Tool", "name");
 
             results.push(name.validate_with_context(context));
         }
 
         if let Some(version) = &self.version {
-            let context = context.extend_context_with_struct_field("Tool", "version");
+            let context = context.with_struct("Tool", "version");
 
             results.push(version.validate_with_context(context));
         }
 
         if let Some(hashes) = &self.hashes {
-            let context = context.extend_context_with_struct_field("Tool", "hashes");
+            let context = context.with_struct("Tool", "hashes");
 
             results.push(hashes.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -18,9 +18,7 @@
 
 use crate::external_models::normalized_string::NormalizedString;
 use crate::models::hash::Hashes;
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// Represents the tool used to create the BOM
 ///
@@ -51,39 +49,36 @@ impl Tool {
 }
 
 impl Validate for Tool {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vendor) = &self.vendor {
             let context = context.extend_context_with_struct_field("Tool", "vendor");
 
-            results.push(vendor.validate_with_context(context)?);
+            results.push(vendor.validate_with_context(context));
         }
 
         if let Some(name) = &self.name {
             let context = context.extend_context_with_struct_field("Tool", "name");
 
-            results.push(name.validate_with_context(context)?);
+            results.push(name.validate_with_context(context));
         }
 
         if let Some(version) = &self.version {
             let context = context.extend_context_with_struct_field("Tool", "version");
 
-            results.push(version.validate_with_context(context)?);
+            results.push(version.validate_with_context(context));
         }
 
         if let Some(hashes) = &self.hashes {
             let context = context.extend_context_with_struct_field("Tool", "hashes");
 
-            results.push(hashes.validate_with_context(context)?);
+            results.push(hashes.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -91,21 +86,18 @@ impl Validate for Tool {
 pub struct Tools(pub Vec<Tool>);
 
 impl Validate for Tools {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, tool) in self.0.iter().enumerate() {
             let tool_context =
                 context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(tool.validate_with_context(tool_context)?);
+            results.push(tool.validate_with_context(tool_context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -124,8 +116,7 @@ mod test {
             version: None,
             hashes: None,
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -138,8 +129,7 @@ mod test {
             version: None,
             hashes: None,
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,
@@ -181,8 +171,7 @@ mod test {
                 hashes: None,
             },
         ])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -26,9 +26,7 @@ use crate::models::vulnerability_rating::VulnerabilityRatings;
 use crate::models::vulnerability_reference::VulnerabilityReferences;
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::models::vulnerability_target::VulnerabilityTargets;
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// Represents a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -87,99 +85,96 @@ impl Vulnerability {
 }
 
 impl Validate for Vulnerability {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(id) = &self.id {
             let context = context.extend_context_with_struct_field("Vulnerability", "id");
 
-            results.push(id.validate_with_context(context)?);
+            results.push(id.validate_with_context(context));
         }
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
             let context =
                 context.extend_context_with_struct_field("Vulnerability", "vulnerability_source");
 
-            results.push(vulnerability_source.validate_with_context(context)?);
+            results.push(vulnerability_source.validate_with_context(context));
         }
 
         if let Some(vulnerability_references) = &self.vulnerability_references {
             let context = context
                 .extend_context_with_struct_field("Vulnerability", "vulnerability_references");
 
-            results.push(vulnerability_references.validate_with_context(context)?);
+            results.push(vulnerability_references.validate_with_context(context));
         }
 
         if let Some(vulnerability_ratings) = &self.vulnerability_ratings {
             let context =
                 context.extend_context_with_struct_field("Vulnerability", "vulnerability_ratings");
 
-            results.push(vulnerability_ratings.validate_with_context(context)?);
+            results.push(vulnerability_ratings.validate_with_context(context));
         }
 
         if let Some(advisories) = &self.advisories {
             let context = context.extend_context_with_struct_field("Vulnerability", "advisories");
 
-            results.push(advisories.validate_with_context(context)?);
+            results.push(advisories.validate_with_context(context));
         }
 
         if let Some(created) = &self.created {
             let context = context.extend_context_with_struct_field("Vulnerability", "created");
 
-            results.push(created.validate_with_context(context)?);
+            results.push(created.validate_with_context(context));
         }
 
         if let Some(published) = &self.published {
             let context = context.extend_context_with_struct_field("Vulnerability", "published");
 
-            results.push(published.validate_with_context(context)?);
+            results.push(published.validate_with_context(context));
         }
 
         if let Some(updated) = &self.updated {
             let context = context.extend_context_with_struct_field("Vulnerability", "updated");
 
-            results.push(updated.validate_with_context(context)?);
+            results.push(updated.validate_with_context(context));
         }
 
         if let Some(vulnerability_credits) = &self.vulnerability_credits {
             let context =
                 context.extend_context_with_struct_field("Vulnerability", "vulnerability_credits");
 
-            results.push(vulnerability_credits.validate_with_context(context)?);
+            results.push(vulnerability_credits.validate_with_context(context));
         }
 
         if let Some(tools) = &self.tools {
             let context = context.extend_context_with_struct_field("Vulnerability", "tools");
 
-            results.push(tools.validate_with_context(context)?);
+            results.push(tools.validate_with_context(context));
         }
 
         if let Some(vulnerability_analysis) = &self.vulnerability_analysis {
             let context =
                 context.extend_context_with_struct_field("Vulnerability", "vulnerability_analysis");
 
-            results.push(vulnerability_analysis.validate_with_context(context)?);
+            results.push(vulnerability_analysis.validate_with_context(context));
         }
 
         if let Some(vulnerability_targets) = &self.vulnerability_targets {
             let context =
                 context.extend_context_with_struct_field("Vulnerability", "vulnerability_targets");
 
-            results.push(vulnerability_targets.validate_with_context(context)?);
+            results.push(vulnerability_targets.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
             let context = context.extend_context_with_struct_field("Vulnerability", "properties");
 
-            results.push(properties.validate_with_context(context)?);
+            results.push(properties.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -187,20 +182,17 @@ impl Validate for Vulnerability {
 pub struct Vulnerabilities(pub Vec<Vulnerability>);
 
 impl Validate for Vulnerabilities {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability.validate_with_context(context)?);
+            results.push(vulnerability.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -288,8 +280,7 @@ mod test {
                 value: NormalizedString::new("value"),
             }])),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -354,8 +345,7 @@ mod test {
                 value: NormalizedString("invalid\tvalue".to_string()),
             }])),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -89,85 +89,85 @@ impl Validate for Vulnerability {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(id) = &self.id {
-            let context = context.extend_context_with_struct_field("Vulnerability", "id");
+            let context = context.with_struct("Vulnerability", "id");
 
             results.push(id.validate_with_context(context));
         }
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
             let context =
-                context.extend_context_with_struct_field("Vulnerability", "vulnerability_source");
+                context.with_struct("Vulnerability", "vulnerability_source");
 
             results.push(vulnerability_source.validate_with_context(context));
         }
 
         if let Some(vulnerability_references) = &self.vulnerability_references {
             let context = context
-                .extend_context_with_struct_field("Vulnerability", "vulnerability_references");
+                .with_struct("Vulnerability", "vulnerability_references");
 
             results.push(vulnerability_references.validate_with_context(context));
         }
 
         if let Some(vulnerability_ratings) = &self.vulnerability_ratings {
             let context =
-                context.extend_context_with_struct_field("Vulnerability", "vulnerability_ratings");
+                context.with_struct("Vulnerability", "vulnerability_ratings");
 
             results.push(vulnerability_ratings.validate_with_context(context));
         }
 
         if let Some(advisories) = &self.advisories {
-            let context = context.extend_context_with_struct_field("Vulnerability", "advisories");
+            let context = context.with_struct("Vulnerability", "advisories");
 
             results.push(advisories.validate_with_context(context));
         }
 
         if let Some(created) = &self.created {
-            let context = context.extend_context_with_struct_field("Vulnerability", "created");
+            let context = context.with_struct("Vulnerability", "created");
 
             results.push(created.validate_with_context(context));
         }
 
         if let Some(published) = &self.published {
-            let context = context.extend_context_with_struct_field("Vulnerability", "published");
+            let context = context.with_struct("Vulnerability", "published");
 
             results.push(published.validate_with_context(context));
         }
 
         if let Some(updated) = &self.updated {
-            let context = context.extend_context_with_struct_field("Vulnerability", "updated");
+            let context = context.with_struct("Vulnerability", "updated");
 
             results.push(updated.validate_with_context(context));
         }
 
         if let Some(vulnerability_credits) = &self.vulnerability_credits {
             let context =
-                context.extend_context_with_struct_field("Vulnerability", "vulnerability_credits");
+                context.with_struct("Vulnerability", "vulnerability_credits");
 
             results.push(vulnerability_credits.validate_with_context(context));
         }
 
         if let Some(tools) = &self.tools {
-            let context = context.extend_context_with_struct_field("Vulnerability", "tools");
+            let context = context.with_struct("Vulnerability", "tools");
 
             results.push(tools.validate_with_context(context));
         }
 
         if let Some(vulnerability_analysis) = &self.vulnerability_analysis {
             let context =
-                context.extend_context_with_struct_field("Vulnerability", "vulnerability_analysis");
+                context.with_struct("Vulnerability", "vulnerability_analysis");
 
             results.push(vulnerability_analysis.validate_with_context(context));
         }
 
         if let Some(vulnerability_targets) = &self.vulnerability_targets {
             let context =
-                context.extend_context_with_struct_field("Vulnerability", "vulnerability_targets");
+                context.with_struct("Vulnerability", "vulnerability_targets");
 
             results.push(vulnerability_targets.validate_with_context(context));
         }
 
         if let Some(properties) = &self.properties {
-            let context = context.extend_context_with_struct_field("Vulnerability", "properties");
+            let context = context.with_struct("Vulnerability", "properties");
 
             results.push(properties.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -95,22 +95,19 @@ impl Validate for Vulnerability {
         }
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
-            let context =
-                context.with_struct("Vulnerability", "vulnerability_source");
+            let context = context.with_struct("Vulnerability", "vulnerability_source");
 
             results.push(vulnerability_source.validate_with_context(context));
         }
 
         if let Some(vulnerability_references) = &self.vulnerability_references {
-            let context = context
-                .with_struct("Vulnerability", "vulnerability_references");
+            let context = context.with_struct("Vulnerability", "vulnerability_references");
 
             results.push(vulnerability_references.validate_with_context(context));
         }
 
         if let Some(vulnerability_ratings) = &self.vulnerability_ratings {
-            let context =
-                context.with_struct("Vulnerability", "vulnerability_ratings");
+            let context = context.with_struct("Vulnerability", "vulnerability_ratings");
 
             results.push(vulnerability_ratings.validate_with_context(context));
         }
@@ -140,8 +137,7 @@ impl Validate for Vulnerability {
         }
 
         if let Some(vulnerability_credits) = &self.vulnerability_credits {
-            let context =
-                context.with_struct("Vulnerability", "vulnerability_credits");
+            let context = context.with_struct("Vulnerability", "vulnerability_credits");
 
             results.push(vulnerability_credits.validate_with_context(context));
         }
@@ -153,15 +149,13 @@ impl Validate for Vulnerability {
         }
 
         if let Some(vulnerability_analysis) = &self.vulnerability_analysis {
-            let context =
-                context.with_struct("Vulnerability", "vulnerability_analysis");
+            let context = context.with_struct("Vulnerability", "vulnerability_analysis");
 
             results.push(vulnerability_analysis.validate_with_context(context));
         }
 
         if let Some(vulnerability_targets) = &self.vulnerability_targets {
-            let context =
-                context.with_struct("Vulnerability", "vulnerability_targets");
+            let context = context.with_struct("Vulnerability", "vulnerability_targets");
 
             results.push(vulnerability_targets.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -62,14 +62,14 @@ impl Validate for VulnerabilityAnalysis {
 
         if let Some(state) = &self.state {
             let context =
-                context.extend_context_with_struct_field("VulnerabilityAnalysis", "state");
+                context.with_struct("VulnerabilityAnalysis", "state");
 
             results.push(state.validate_with_context(context));
         }
 
         if let Some(justification) = &self.justification {
             let context =
-                context.extend_context_with_struct_field("VulnerabilityAnalysis", "justification");
+                context.with_struct("VulnerabilityAnalysis", "justification");
 
             results.push(justification.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -61,15 +61,13 @@ impl Validate for VulnerabilityAnalysis {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(state) = &self.state {
-            let context =
-                context.with_struct("VulnerabilityAnalysis", "state");
+            let context = context.with_struct("VulnerabilityAnalysis", "state");
 
             results.push(state.validate_with_context(context));
         }
 
         if let Some(justification) = &self.justification {
-            let context =
-                context.with_struct("VulnerabilityAnalysis", "justification");
+            let context = context.with_struct("VulnerabilityAnalysis", "justification");
 
             results.push(justification.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -17,8 +17,7 @@
  */
 
 use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-    ValidationResult,
+    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
 };
 
 /// Represents a vulnerability's analysis as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
@@ -58,24 +57,21 @@ impl VulnerabilityAnalysis {
 }
 
 impl Validate for VulnerabilityAnalysis {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(state) = &self.state {
             let context =
                 context.extend_context_with_struct_field("VulnerabilityAnalysis", "state");
 
-            results.push(state.validate_with_context(context)?);
+            results.push(state.validate_with_context(context));
         }
 
         if let Some(justification) = &self.justification {
             let context =
                 context.extend_context_with_struct_field("VulnerabilityAnalysis", "justification");
 
-            results.push(justification.validate_with_context(context)?);
+            results.push(justification.validate_with_context(context));
         }
 
         if let Some(responses) = &self.responses {
@@ -87,13 +83,13 @@ impl Validate for VulnerabilityAnalysis {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(response.validate_with_context(context)?);
+                results.push(response.validate_with_context(context));
             }
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -127,18 +123,15 @@ impl ImpactAnalysisState {
 }
 
 impl Validate for ImpactAnalysisState {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            ImpactAnalysisState::UndefinedImpactAnalysisState(_) => Ok(ValidationResult::Failed {
+            ImpactAnalysisState::UndefinedImpactAnalysisState(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Undefined impact analysis state".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -194,20 +187,17 @@ impl ImpactAnalysisJustification {
 }
 
 impl Validate for ImpactAnalysisJustification {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
             ImpactAnalysisJustification::UndefinedImpactAnalysisJustification(_) => {
-                Ok(ValidationResult::Failed {
+                ValidationResult::Failed {
                     reasons: vec![FailureReason {
                         message: "Undefined impact analysis justification".to_string(),
                         context,
                     }],
-                })
+                }
             }
-            _ => Ok(ValidationResult::Passed),
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -262,18 +252,15 @@ impl ImpactAnalysisResponse {
 }
 
 impl Validate for ImpactAnalysisResponse {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            ImpactAnalysisResponse::UndefinedResponse(_) => Ok(ValidationResult::Failed {
+            ImpactAnalysisResponse::UndefinedResponse(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Undefined response".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -305,8 +292,7 @@ mod test {
             responses: Some(vec![ImpactAnalysisResponse::Update]),
             detail: Some("detail".to_string()),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -327,8 +313,7 @@ mod test {
             )]),
             detail: Some("detail".to_string()),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -17,9 +17,7 @@
  */
 
 use crate::models::organization::{OrganizationalContact, OrganizationalEntity};
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// Provides credits to organizations or individuals who contributed to a vulnerability.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -29,10 +27,7 @@ pub struct VulnerabilityCredits {
 }
 
 impl Validate for VulnerabilityCredits {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(organizations) = &self.organizations {
@@ -44,7 +39,7 @@ impl Validate for VulnerabilityCredits {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(organization.validate_with_context(uri_context)?);
+                results.push(organization.validate_with_context(uri_context));
             }
         }
 
@@ -57,13 +52,13 @@ impl Validate for VulnerabilityCredits {
                     },
                     ValidationPathComponent::Array { index },
                 ]);
-                results.push(individual.validate_with_context(uri_context)?);
+                results.push(individual.validate_with_context(uri_context));
             }
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -88,8 +83,7 @@ mod test {
                 phone: None,
             }]),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -108,8 +102,7 @@ mod test {
                 phone: None,
             }]),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -66,15 +66,13 @@ impl Validate for VulnerabilityRating {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
-            let context = context
-                .with_struct("VulnerabilityRating", "vulnerability_source");
+            let context = context.with_struct("VulnerabilityRating", "vulnerability_source");
 
             results.push(vulnerability_source.validate_with_context(context));
         }
 
         if let Some(severity) = &self.severity {
-            let context =
-                context.with_struct("VulnerabilityRating", "severity");
+            let context = context.with_struct("VulnerabilityRating", "severity");
 
             results.push(severity.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -67,20 +67,20 @@ impl Validate for VulnerabilityRating {
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
             let context = context
-                .extend_context_with_struct_field("VulnerabilityRating", "vulnerability_source");
+                .with_struct("VulnerabilityRating", "vulnerability_source");
 
             results.push(vulnerability_source.validate_with_context(context));
         }
 
         if let Some(severity) = &self.severity {
             let context =
-                context.extend_context_with_struct_field("VulnerabilityRating", "severity");
+                context.with_struct("VulnerabilityRating", "severity");
 
             results.push(severity.validate_with_context(context));
         }
 
         if let Some(vector) = &self.vector {
-            let context = context.extend_context_with_struct_field("VulnerabilityRating", "vector");
+            let context = context.with_struct("VulnerabilityRating", "vector");
 
             results.push(vector.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -21,8 +21,7 @@ use ordered_float::OrderedFloat;
 use crate::external_models::normalized_string::NormalizedString;
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-    ValidationResult,
+    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
 };
 
 /// Represents a vulnerability's rating as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
@@ -63,35 +62,32 @@ impl VulnerabilityRating {
 
 // todo: how to decide what to validate, check this
 impl Validate for VulnerabilityRating {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
             let context = context
                 .extend_context_with_struct_field("VulnerabilityRating", "vulnerability_source");
 
-            results.push(vulnerability_source.validate_with_context(context)?);
+            results.push(vulnerability_source.validate_with_context(context));
         }
 
         if let Some(severity) = &self.severity {
             let context =
                 context.extend_context_with_struct_field("VulnerabilityRating", "severity");
 
-            results.push(severity.validate_with_context(context)?);
+            results.push(severity.validate_with_context(context));
         }
 
         if let Some(vector) = &self.vector {
             let context = context.extend_context_with_struct_field("VulnerabilityRating", "vector");
 
-            results.push(vector.validate_with_context(context)?);
+            results.push(vector.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -99,20 +95,17 @@ impl Validate for VulnerabilityRating {
 pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 
 impl Validate for VulnerabilityRatings {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_rating) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability_rating.validate_with_context(context)?);
+            results.push(vulnerability_rating.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -184,18 +177,15 @@ impl Severity {
 }
 
 impl Validate for Severity {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            Severity::UndefinedSeverity(_) => Ok(ValidationResult::Failed {
+            Severity::UndefinedSeverity(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Undefined severity".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -276,8 +266,7 @@ mod test {
             vector: Some(NormalizedString::new("vector")),
             justification: None,
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -295,8 +284,7 @@ mod test {
             vector: Some(NormalizedString("invalid\tvector".to_string())),
             justification: None,
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -55,12 +55,12 @@ impl Validate for VulnerabilityReference {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let id_context = context.extend_context_with_struct_field("VulnerabilityReference", "id");
+        let id_context = context.with_struct("VulnerabilityReference", "id");
 
         results.push(self.id.validate_with_context(id_context));
 
         let source_context = context
-            .extend_context_with_struct_field("VulnerabilityReference", "vulnerability_source");
+            .with_struct("VulnerabilityReference", "vulnerability_source");
 
         results.push(
             self.vulnerability_source

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -59,8 +59,7 @@ impl Validate for VulnerabilityReference {
 
         results.push(self.id.validate_with_context(id_context));
 
-        let source_context = context
-            .with_struct("VulnerabilityReference", "vulnerability_source");
+        let source_context = context.with_struct("VulnerabilityReference", "vulnerability_source");
 
         results.push(
             self.vulnerability_source

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -18,9 +18,7 @@
 
 use crate::external_models::normalized_string::NormalizedString;
 use crate::models::vulnerability_source::VulnerabilitySource;
-use crate::validation::{
-    Validate, ValidationContext, ValidationError, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
 
 /// References a vulnerability equivalent to the vulnerability specified, e.g.
 /// to correlate vulnerabilities across multiple sources of vulnerability intelligence.
@@ -54,27 +52,24 @@ impl VulnerabilityReference {
 }
 
 impl Validate for VulnerabilityReference {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let id_context = context.extend_context_with_struct_field("VulnerabilityReference", "id");
 
-        results.push(self.id.validate_with_context(id_context)?);
+        results.push(self.id.validate_with_context(id_context));
 
         let source_context = context
             .extend_context_with_struct_field("VulnerabilityReference", "vulnerability_source");
 
         results.push(
             self.vulnerability_source
-                .validate_with_context(source_context)?,
+                .validate_with_context(source_context),
         );
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -82,20 +77,17 @@ impl Validate for VulnerabilityReference {
 pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 
 impl Validate for VulnerabilityReferences {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_reference) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability_reference.validate_with_context(context)?);
+            results.push(vulnerability_reference.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -119,8 +111,7 @@ mod test {
                 url: Some(Uri("https://www.example.com".to_string())),
             },
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -134,8 +125,7 @@ mod test {
                 url: Some(Uri("invalid url".to_string())),
             },
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -17,7 +17,7 @@
  */
 
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
-use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
 
 /// Defines a source related to the vulnerability, e.g. who published or calculated the severity or risk rating the vulnerability.
 ///
@@ -51,27 +51,24 @@ impl VulnerabilitySource {
 }
 
 impl Validate for VulnerabilitySource {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {
             let context = context.extend_context_with_struct_field("VulnerabilitySource", "name");
 
-            results.push(name.validate_with_context(context)?);
+            results.push(name.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
             let context = context.extend_context_with_struct_field("VulnerabilitySource", "url");
 
-            results.push(url.validate_with_context(context)?);
+            results.push(url.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -91,8 +88,7 @@ mod test {
             name: Some(NormalizedString::new("name")),
             url: Some(Uri("url".to_string())),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -103,8 +99,7 @@ mod test {
             name: Some(NormalizedString("invalid\tname".to_string())),
             url: Some(Uri("invalid url".to_string())),
         }
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -55,13 +55,13 @@ impl Validate for VulnerabilitySource {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {
-            let context = context.extend_context_with_struct_field("VulnerabilitySource", "name");
+            let context = context.with_struct("VulnerabilitySource", "name");
 
             results.push(name.validate_with_context(context));
         }
 
         if let Some(url) = &self.url {
-            let context = context.extend_context_with_struct_field("VulnerabilitySource", "url");
+            let context = context.with_struct("VulnerabilitySource", "url");
 
             results.push(url.validate_with_context(context));
         }

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -54,7 +54,7 @@ impl Validate for VulnerabilityTarget {
 
         if let Some(versions) = &self.versions {
             let context =
-                context.extend_context_with_struct_field("VulnerabilityTarget", "versions");
+                context.with_struct("VulnerabilityTarget", "versions");
 
             results.push(versions.validate_with_context(context));
         }
@@ -127,14 +127,14 @@ impl Validate for Version {
         let mut results: Vec<ValidationResult> = vec![];
 
         let version_range_context =
-            context.extend_context_with_struct_field("Version", "version_range");
+            context.with_struct("Version", "version_range");
 
         results.push(
             self.version_range
                 .validate_with_context(version_range_context),
         );
 
-        let status_context = context.extend_context_with_struct_field("Version", "status");
+        let status_context = context.with_struct("Version", "status");
 
         results.push(self.status.validate_with_context(status_context));
 

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -21,8 +21,7 @@ use regex::Regex;
 
 use crate::external_models::normalized_string::NormalizedString;
 use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationError, ValidationPathComponent,
-    ValidationResult,
+    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
 };
 
 /// Defines how a component or service is affected by a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
@@ -50,22 +49,19 @@ impl VulnerabilityTarget {
 }
 
 impl Validate for VulnerabilityTarget {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(versions) = &self.versions {
             let context =
                 context.extend_context_with_struct_field("VulnerabilityTarget", "versions");
 
-            results.push(versions.validate_with_context(context)?);
+            results.push(versions.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -73,20 +69,17 @@ impl Validate for VulnerabilityTarget {
 pub struct VulnerabilityTargets(pub Vec<VulnerabilityTarget>);
 
 impl Validate for VulnerabilityTargets {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_target) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability_target.validate_with_context(context)?);
+            results.push(vulnerability_target.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -94,20 +87,17 @@ impl Validate for VulnerabilityTargets {
 pub struct Versions(pub Vec<Version>);
 
 impl Validate for Versions {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, version) in self.0.iter().enumerate() {
             let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(version.validate_with_context(context)?);
+            results.push(version.validate_with_context(context));
         }
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -133,10 +123,7 @@ impl Version {
 }
 
 impl Validate for Version {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let version_range_context =
@@ -144,16 +131,16 @@ impl Validate for Version {
 
         results.push(
             self.version_range
-                .validate_with_context(version_range_context)?,
+                .validate_with_context(version_range_context),
         );
 
         let status_context = context.extend_context_with_struct_field("Version", "status");
 
-        results.push(self.status.validate_with_context(status_context)?);
+        results.push(self.status.validate_with_context(status_context));
 
-        Ok(results
+        results
             .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result)))
+            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
     }
 }
 
@@ -179,18 +166,15 @@ impl VersionRange {
 }
 
 impl Validate for VersionRange {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            VersionRange::UndefinedVersionRange(_) => Ok(ValidationResult::Failed {
+            VersionRange::UndefinedVersionRange(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Undefined version range".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -236,18 +220,15 @@ impl Status {
 }
 
 impl Validate for Status {
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError> {
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         match self {
-            Status::UndefinedStatus(_) => Ok(ValidationResult::Failed {
+            Status::UndefinedStatus(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
                     message: "Undefined status".to_string(),
                     context,
                 }],
-            }),
-            _ => Ok(ValidationResult::Passed),
+            },
+            _ => ValidationResult::Passed,
         }
     }
 }
@@ -286,8 +267,7 @@ mod test {
                 status: Status::Affected,
             }])),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -301,8 +281,7 @@ mod test {
                 status: Status::UndefinedStatus("invalid\tstatus".to_string()),
             }])),
         }])
-        .validate_with_context(ValidationContext::default())
-        .expect("Error while validating");
+        .validate();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -20,9 +20,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::external_models::normalized_string::NormalizedString;
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{FailureReason, Validate, ValidationContext, ValidationResult};
 
 /// Defines how a component or service is affected by a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -53,8 +51,7 @@ impl Validate for VulnerabilityTarget {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(versions) = &self.versions {
-            let context =
-                context.with_struct("VulnerabilityTarget", "versions");
+            let context = context.with_struct("VulnerabilityTarget", "versions");
 
             results.push(versions.validate_with_context(context));
         }
@@ -73,7 +70,7 @@ impl Validate for VulnerabilityTargets {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_target) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
+            let context = context.with_index(index);
             results.push(vulnerability_target.validate_with_context(context));
         }
 
@@ -91,7 +88,7 @@ impl Validate for Versions {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, version) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
+            let context = context.with_index(index);
             results.push(version.validate_with_context(context));
         }
 
@@ -126,8 +123,7 @@ impl Validate for Version {
     fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
-        let version_range_context =
-            context.with_struct("Version", "version_range");
+        let version_range_context = context.with_struct("Version", "version_range");
 
         results.push(
             self.version_range
@@ -287,36 +283,22 @@ mod test {
             validation_result,
             ValidationResult::Failed {
                 reasons: vec![
-                    FailureReason {
-                        message: "Undefined version range".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityTarget".to_string(),
-                                field_name: "versions".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Version".to_string(),
-                                field_name: "version_range".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Undefined status".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityTarget".to_string(),
-                                field_name: "versions".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Version".to_string(),
-                                field_name: "status".to_string()
-                            },
-                        ])
-                    },
+                    FailureReason::new(
+                        "Undefined version range",
+                        ValidationContext::new()
+                            .with_index(0)
+                            .with_struct("VulnerabilityTarget", "versions")
+                            .with_index(0)
+                            .with_struct("Version", "version_range")
+                    ),
+                    FailureReason::new(
+                        "Undefined status",
+                        ValidationContext::new()
+                            .with_index(0)
+                            .with_struct("VulnerabilityTarget", "versions")
+                            .with_index(0)
+                            .with_struct("Version", "status")
+                    )
                 ]
             }
         );

--- a/cyclonedx-bom/src/validation.rs
+++ b/cyclonedx-bom/src/validation.rs
@@ -17,14 +17,11 @@
  */
 
 pub trait Validate {
-    fn validate(&self) -> Result<ValidationResult, ValidationError> {
+    fn validate(&self) -> ValidationResult {
         self.validate_with_context(ValidationContext::default())
     }
 
-    fn validate_with_context(
-        &self,
-        context: ValidationContext,
-    ) -> Result<ValidationResult, ValidationError>;
+    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -92,6 +89,13 @@ impl ValidationResult {
             }
         }
     }
+
+    /// Returns a [`ValidationResult::Failed`] with a single failure.
+    pub fn failure(reason: &str, context: ValidationContext) -> Self {
+        Self::Failed {
+            reasons: vec![FailureReason::new(reason, context)],
+        }
+    }
 }
 
 impl Default for ValidationResult {
@@ -105,8 +109,12 @@ pub struct FailureReason {
     pub message: String,
     pub context: ValidationContext,
 }
-#[derive(Debug, PartialEq, thiserror::Error)]
-pub enum ValidationError {
-    #[error("Failed to compile regular expression: {0}")]
-    InvalidRegularExpressionError(#[from] regex::Error),
+
+impl FailureReason {
+    pub fn new(message: &str, context: ValidationContext) -> Self {
+        Self {
+            message: message.to_string(),
+            context,
+        }
+    }
 }

--- a/cyclonedx-bom/src/validation.rs
+++ b/cyclonedx-bom/src/validation.rs
@@ -27,14 +27,20 @@ pub trait Validate {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ValidationContext(pub(crate) Vec<ValidationPathComponent>);
 
+#[allow(dead_code)]
 impl ValidationContext {
+    pub(crate) fn new() -> Self {
+        ValidationContext::default()
+    }
+
     pub(crate) fn extend_context(&self, components: Vec<ValidationPathComponent>) -> Self {
         let mut extended_context = self.0.clone();
         extended_context.extend(components);
         Self(extended_context)
     }
 
-    pub(crate) fn extend_context_with_struct_field(
+    /// Extends the [`ValidationContext`] with a struct field.
+    pub(crate) fn with_struct(
         &self,
         struct_name: impl ToString,
         field_name: impl ToString,
@@ -43,7 +49,6 @@ impl ValidationContext {
             struct_name: struct_name.to_string(),
             field_name: field_name.to_string(),
         }];
-
         self.extend_context(component)
     }
 }

--- a/cyclonedx-bom/src/validation.rs
+++ b/cyclonedx-bom/src/validation.rs
@@ -39,6 +39,12 @@ impl ValidationContext {
         Self(extended_context)
     }
 
+    /// Extends the [`ValidationContext`] with an index, e.g. to specify the index in array.
+    pub(crate) fn with_index(&self, index: usize) -> Self {
+        let component = vec![ValidationPathComponent::Array { index }];
+        self.extend_context(component)
+    }
+
     /// Extends the [`ValidationContext`] with a struct field.
     pub(crate) fn with_struct(
         &self,

--- a/cyclonedx-bom/tests/examples_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/examples_tests_v1_4.rs
@@ -13,7 +13,7 @@ mod examples {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate().expect("Failed to validate BOM");
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -40,7 +40,7 @@ mod examples {
             insta::glob!("examples/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate().expect("Failed to validate BOM");
+                    let validation_result = bom.validate();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/specification_tests_v1_3.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_3.rs
@@ -12,7 +12,7 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate().expect("Failed to validate BOM");
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -39,7 +39,7 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate().expect("Failed to validate BOM");
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -65,7 +65,7 @@ mod v1_3 {
             insta::glob!("spec/1.3/invalid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_3(file) {
-                    let validation_result = bom.validate().expect("Failed to validate BOM");
+                    let validation_result = bom.validate();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,
@@ -85,7 +85,7 @@ mod v1_3 {
             insta::glob!("spec/1.3/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_3(file) {
-                    let validation_result = bom.validate().expect("Failed to validate BOM");
+                    let validation_result = bom.validate();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/specification_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_4.rs
@@ -12,7 +12,7 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate().expect("Failed to validate BOM");
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -39,7 +39,7 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate().expect("Failed to validate BOM");
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -65,7 +65,7 @@ mod v1_4 {
             insta::glob!("spec/1.4/invalid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_4(file) {
-                    let validation_result = bom.validate().expect("Failed to validate BOM");
+                    let validation_result = bom.validate();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,
@@ -85,7 +85,7 @@ mod v1_4 {
             insta::glob!("spec/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate().expect("Failed to validate BOM");
+                    let validation_result = bom.validate();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,


### PR DESCRIPTION
This PR changes the methods of the `Validate` trait to not return a `Result`.

Before this change the `Validate` trait looked as follows:

```rust
pub trait Validate {
    fn validate_with_context(
        &self,
        context: ValidationContext,
    ) -> Result<ValidationResult, ValidationError>;
}
```

Due to PR #606 all occurrences of regular expressions have been refactored to not return `RegexError` anymore. A `ValidationError` was only returned when a regular expression failed to compile during runtime. Tests now ensure that an invalid Regex is caught immediately & all regexes are valid. This eliminates the requirement for `validate_with_context` to return a `Result`. All validation errors are aggregated in the `ValidationResult` type.

The trait was simplified to:

```rust
pub trait Validate {
    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult;
}
```

Unfortunately this change affects a lot of validation methods for a lot of different structs.

* refactor `validate` & `validate_with_context` implementations
* refactor tests to use `validate()` rather than `validate_with_context(ValidationContext::default())`