### PR TITLE
fix: Make CycloneDx dependencies.dependsOn optional

### DIFF
--- a/cyclonedx-bom/src/specs/v1_3/dependency.rs
+++ b/cyclonedx-bom/src/specs/v1_3/dependency.rs
@@ -83,6 +83,7 @@ impl FromXml for Dependencies {
 pub(crate) struct Dependency {
     #[serde(rename = "ref")]
     dependency_ref: String,
+    #[serde(default)]
     depends_on: Vec<String>,
 }
 

--- a/cyclonedx-bom/src/specs/v1_4/dependency.rs
+++ b/cyclonedx-bom/src/specs/v1_4/dependency.rs
@@ -83,6 +83,7 @@ impl FromXml for Dependencies {
 pub(crate) struct Dependency {
     #[serde(rename = "ref")]
     dependency_ref: String,
+    #[serde(default)]
     depends_on: Vec<String>,
 }
 


### PR DESCRIPTION
Resolves https://github.com/CycloneDX/cyclonedx-rust-cargo/issues/615

Hi, I reported the issue above. And I though it would be good to help with it. Although I'm not sure of whether or not this is a good solution I'd be happy if you could give it a review and let me know if that is the way to solve this issue. 


