### PR TITLE
Update 'version' to be required field

### DIFF
--- a/cyclonedx-bom/src/specs/v1_4/bom.rs
+++ b/cyclonedx-bom/src/specs/v1_4/bom.rs
@@ -41,7 +41,7 @@ use xml::{reader, writer::XmlEvent};
 pub(crate) struct Bom {
     bom_format: BomFormat,
     spec_version: SpecVersion,
-    version: Option<u32>,
+    version: u32,
     serial_number: Option<UrnUuid>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<Metadata>,
@@ -68,7 +68,7 @@ impl From<models::bom::Bom> for Bom {
         Self {
             bom_format: BomFormat::CycloneDX,
             spec_version: SpecVersion::V1_4,
-            version: Some(other.version),
+            version: other.version,
             serial_number: convert_optional(other.serial_number),
             metadata: convert_optional(other.metadata),
             components: convert_optional(other.components),
@@ -86,7 +86,7 @@ impl From<models::bom::Bom> for Bom {
 impl From<Bom> for models::bom::Bom {
     fn from(other: Bom) -> Self {
         Self {
-            version: other.version.unwrap_or(1),
+            version: other.version,
             serial_number: convert_optional(other.serial_number),
             metadata: convert_optional(other.metadata),
             components: convert_optional(other.components),
@@ -110,7 +110,7 @@ impl ToXml for Bom {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        let version = self.version.map(|v| format!("{}", v));
+        let version = format!("{}", self.version);
         let mut bom_start_element =
             XmlEvent::start_element(BOM_TAG).default_ns("http://cyclonedx.org/schema/bom/1.4");
 
@@ -118,9 +118,7 @@ impl ToXml for Bom {
             bom_start_element = bom_start_element.attr(SERIAL_NUMBER_ATTR, &serial_number.0);
         }
 
-        if let Some(version) = &version {
-            bom_start_element = bom_start_element.attr(VERSION_ATTR, version);
-        }
+        bom_start_element = bom_start_element.attr(VERSION_ATTR, version.as_str());
 
         writer
             .write(bom_start_element)
@@ -203,10 +201,9 @@ impl FromXmlDocument for Bom {
                     expected_namespace_or_error("1.4", &namespace)?;
                     let version =
                         if let Some(version) = optional_attribute(&attributes, VERSION_ATTR) {
-                            let version = u32::from_xml_value(VERSION_ATTR, version)?;
-                            Some(version)
+                            u32::from_xml_value(VERSION_ATTR, version)?
                         } else {
-                            None
+                            1
                         };
                     let serial_number =
                         optional_attribute(&attributes, SERIAL_NUMBER_ATTR).map(UrnUuid);
@@ -394,7 +391,7 @@ pub(crate) mod test {
         Bom {
             bom_format: BomFormat::CycloneDX,
             spec_version: SpecVersion::V1_4,
-            version: Some(1),
+            version: 1,
             serial_number: Some(UrnUuid("fake-uuid".to_string())),
             metadata: None,
             components: None,
@@ -412,7 +409,7 @@ pub(crate) mod test {
         Bom {
             bom_format: BomFormat::CycloneDX,
             spec_version: SpecVersion::V1_4,
-            version: Some(1),
+            version: 1,
             serial_number: Some(UrnUuid("fake-uuid".to_string())),
             metadata: Some(example_metadata()),
             components: Some(example_components()),

--- a/cyclonedx-bom/src/specs/v1_4/signature.rs
+++ b/cyclonedx-bom/src/specs/v1_4/signature.rs
@@ -364,7 +364,7 @@ impl FromXml for Signature {
                     got_end_tag = true;
                 }
                 _ => {
-                    let signer = Signer::read_xml_element(event_reader, &element_name, &[])?;
+                    let signer = Signer::read_xml_element(event_reader, element_name, &[])?;
                     signature = Some(Signature::Single(signer));
                 }
             }


### PR DESCRIPTION
According to the JSON specification (in [1.3](https://cyclonedx.org/docs/1.3/json/#version) & [1.4](https://cyclonedx.org/docs/1.4/json/#version)) the top-level field 'version' is required, it defaults to 1.

Therefore the field is refactored to not be optional.

* update conversion & serialization functions