### PR TITLE
BOM per binary, take 3

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -80,7 +80,7 @@ Defaults to the host target, as printed by 'rustc -vV'"
     #[clap(long = "output-cdx")]
     pub output_cdx: bool,
 
-    /// Prefix patterns to use for the filename: bom, package
+    /// Prefix patterns to use for the filename: bom, package, binary, cargo-target
     #[clap(
         name = "output-pattern",
         long = "output-pattern",

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -164,6 +164,10 @@ pub enum Pattern {
     #[default]
     Bom,
     Package,
+    Binary,
+    /// Not to be confused with a compilation target:
+    /// https://doc.rust-lang.org/cargo/reference/cargo-targets.html
+    CargoTarget,
 }
 
 impl FromStr for Pattern {
@@ -173,6 +177,8 @@ impl FromStr for Pattern {
         match s {
             "bom" => Ok(Self::Bom),
             "package" => Ok(Self::Package),
+            "binary" => Ok(Self::Binary),
+            "cargo-target" => Ok(Self::CargoTarget),
             _ => Err(format!("Expected bom or package, got `{}`", s)),
         }
     }

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -719,13 +719,8 @@ impl GeneratedSbom {
                 // Most properties apply to the entire package and should be kept;
                 // we just need to update the name, type and purl.
                 let mut new_bom = bom.clone();
-                let toplevel_component = new_bom
-                    .metadata
-                    .as_mut()
-                    .unwrap()
-                    .component
-                    .as_mut()
-                    .unwrap();
+                let metadata = new_bom.metadata.as_mut().unwrap();
+                let toplevel_component = metadata.component.as_mut().unwrap();
                 toplevel_component.name = component.name.clone();
                 toplevel_component.component_type = component.component_type.clone();
                 toplevel_component.purl = component.purl.clone();

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -663,6 +663,8 @@ impl GeneratedSbom {
         let prefix = match output_options.prefix {
             Prefix::Pattern(Pattern::Bom) => "bom".to_string(),
             Prefix::Pattern(Pattern::Package) => self.package_name.clone(),
+            Prefix::Pattern(Pattern::Binary) => todo!(),
+            Prefix::Pattern(Pattern::CargoTarget) => todo!(),
             Prefix::Custom(c) => c.to_string(),
         };
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -105,11 +105,20 @@ impl SbomGenerator {
                 }
             }
 
+            // Figure out the types of the various produced artifacts.
+            // This is additional information on top of the SBOM structure
+            // that is used to implement emitting a separate SBOM for each binary or artifact.
+            let root_package = &packages[member];
+            let target_kinds: Vec<Vec<String>> = filter_targets(&root_package.targets).map(|tgt| {
+                tgt.kind.clone()
+            }).collect();
+
             let generated = GeneratedSbom {
                 bom,
                 manifest_path: packages[member].manifest_path.clone().into_std_path_buf(),
                 package_name: packages[member].name.clone(),
                 sbom_config: generator.config,
+                target_kinds,
             };
 
             result.push(generated);
@@ -632,6 +641,7 @@ pub struct GeneratedSbom {
     pub manifest_path: PathBuf,
     pub package_name: String,
     pub sbom_config: SbomConfig,
+    pub target_kinds: Vec<Vec<String>>,
 }
 
 impl GeneratedSbom {

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -682,6 +682,29 @@ impl GeneratedSbom {
         Ok(())
     }
 
+    fn per_artifact_sboms<'a>(bom: &'a Bom, target_kinds: &'a [Vec<String>], pattern: Pattern) -> impl Iterator<Item = Bom> + 'a {
+        let meta = bom.metadata.as_ref().unwrap();
+        let component = meta.component.as_ref().unwrap();
+        let components = component.components.as_ref().unwrap();
+        components.0.iter().zip(target_kinds.iter()).filter(move |(component, target_kind)| {
+            match pattern {
+                Pattern::Binary => {
+                    // only record binary artifacts
+                    // TODO: refactor this to use an enum, coming Soon(tm) to cargo-metadata:
+                    // https://github.com/oli-obk/cargo_metadata/pull/258
+                    target_kind.contains(&"bin".to_owned()) || target_kind.contains(&"cdylib".to_owned())
+                },
+                Pattern::CargoTarget => true, // pass everything through
+                Pattern::Bom | Pattern::Package => unreachable!(),
+            }
+        }).map(|(component, target_kind)| {
+            let bom = bom.clone();
+            // BIG FAT TODO
+
+            bom
+        })
+    }
+
     fn filename(&self) -> String {
         let output_options = self.sbom_config.output_options();
         let prefix = match output_options.prefix {

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -181,7 +181,6 @@ impl SbomGenerator {
     fn create_toplevel_component(&self, package: &Package) -> Component {
         let mut top_component = self.create_component(package, package);
         let mut subcomponents: Vec<Component> = Vec::new();
-        let mut subcomp_count: u32 = 0;
         for tgt in &package.targets {
             // Ignore tests, benches, examples and build scripts.
             // They are not part of the final build artifacts, which is what we are after.
@@ -209,9 +208,8 @@ impl SbomGenerator {
                 let bom_ref = format!(
                     "{} bin-target-{}",
                     top_component.bom_ref.as_ref().unwrap(),
-                    subcomp_count
+                    subcomponents.len(), // numbers the components
                 );
-                subcomp_count += 1;
 
                 // create the subcomponent
                 let mut subcomponent = Component::new(

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -651,7 +651,8 @@ impl GeneratedSbom {
             },
             Prefix::Pattern(pattern @ (Pattern::Binary | Pattern::CargoTarget)) => {
                 for (sbom, target_kind) in Self::per_artifact_sboms(&self.bom, &self.target_kinds, pattern) {
-                    todo!();
+                    let path = self.manifest_path.with_file_name(self.filename(&target_kind));
+                    Self::write_to_file(sbom, &path, &self.sbom_config)?;
                 }
                 Ok(())
             },

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
 
     log::trace!("SBOM output started");
     for bom in boms {
-        bom.write_to_file()?;
+        bom.write_to_files()?;
     }
     log::trace!("SBOM output finished");
 


### PR DESCRIPTION
Adds `--output-pattern=binary` and `--output-pattern=cargo-target` modes that emit SBOMs for compiled binaries and for all compilation targets (including Rust libraries that do not exist as standalone binaries) respectively.

@lfrancke please test this and let me know if `--output-pattern=binary` fulfills your needs.