### PR TITLE
Revamp CLI, add CycloneDX spec version configuration

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -184,8 +184,8 @@ impl Args {
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ArgsError {
-    #[error("Invalid prefix from CLI")]
-    CustomPrefixError(#[from] FilenameOverrideError),
+    #[error("Invalid filename")]
+    FilenameOverrideError(#[from] FilenameOverrideError),
 }
 
 #[cfg(test)]

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -8,6 +8,7 @@ use cargo_cyclonedx::{
     platform::host_platform,
 };
 use clap::{ArgAction, ArgGroup, Parser};
+use cyclonedx_bom::models::bom::SpecVersion;
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::path;
@@ -95,6 +96,10 @@ Defaults to the host target, as printed by 'rustc -vV'"
     /// Add license names which will not be warned about when parsing them as a SPDX expression fails
     #[clap(long = "license-accept-named", action=ArgAction::Append)]
     pub license_accept_named: Vec<String>,
+
+    /// The CycloneDX specification version to output: `1.3` or `1.4`
+    #[clap(long = "spec-version")]
+    pub spec_version: Option<SpecVersion>,
 }
 
 impl Args {
@@ -164,6 +169,7 @@ impl Args {
         });
 
         let describe = self.describe.clone();
+        let spec_version = self.spec_version.clone();
 
         Ok(SbomConfig {
             format: self.format,
@@ -173,6 +179,7 @@ impl Args {
             target,
             license_parser,
             describe,
+            spec_version,
         })
     }
 }

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -33,7 +33,7 @@ pub struct Args {
     #[clap(long = "format", short = 'f', value_name = "FORMAT")]
     pub format: Option<Format>,
 
-    /// Use verbose output (-vv very verbose/build.rs output)
+    /// Use verbose output (-vv for debug logging, -vvv for tracing)
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
     pub verbose: u8,
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -26,7 +26,7 @@ pub enum Opts {
 #[clap(group(ArgGroup::new("dependencies-group").required(false).args(&["all", "top-level"])))]
 pub struct Args {
     /// Path to Cargo.toml
-    #[clap(long = "manifest-path", value_name = "PATH")]
+    #[clap(long = "manifest-path", value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
     pub manifest_path: Option<path::PathBuf>,
 
     /// Output BOM format: json, xml
@@ -34,7 +34,7 @@ pub struct Args {
     pub format: Option<Format>,
 
     /// What to describe in the SBOM: `crate`, `binaries` or `all-cargo-targets`
-    #[clap(long = "describe", value_name = "SBOM_TARGET")]
+    #[clap(long = "describe")]
     pub describe: Option<Describe>,
 
     /// Use verbose output (-vv for debug logging, -vvv for tracing)

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -34,7 +34,7 @@ pub struct Args {
     #[clap(long = "format", short = 'f', value_name = "FORMAT")]
     pub format: Option<Format>,
 
-    /// What to describe in the SBOM: `crate`, `binaries` or `all-cargo-targets`
+    // the ValueEnum derive provides ample help text
     #[clap(long = "describe")]
     pub describe: Option<Describe>,
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -97,7 +97,7 @@ Defaults to the host target, as printed by 'rustc -vV'"
     #[clap(long = "license-accept-named", action=ArgAction::Append)]
     pub license_accept_named: Vec<String>,
 
-    /// The CycloneDX specification version to output: `1.3` or `1.4`
+    /// The CycloneDX specification version to output: `1.3` or `1.4`. Defaults to 1.3
     #[clap(long = "spec-version")]
     pub spec_version: Option<SpecVersion>,
 }

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -1,6 +1,6 @@
 use cargo_cyclonedx::{
     config::{
-        CdxExtension, Describe, Features, FilenameOverride, FilenameOverrideError, FilenamePattern,
+        Describe, Features, FilenameOverride, FilenameOverrideError, FilenamePattern,
         IncludedDependencies, LicenseParserOptions, OutputOptions, ParseMode, PlatformSuffix,
         SbomConfig, Target,
     },
@@ -137,25 +137,20 @@ impl Args {
             Target::SingleTarget(target_string)
         });
 
-        let mut cdx_extension = match self.output_cdx {
-            true => Some(CdxExtension::Included),
-            false => None,
-        };
-
         let platform_suffix = match self.target_in_filename {
             true => PlatformSuffix::Included,
             false => PlatformSuffix::NotIncluded,
         };
 
-        let filename_pattern = match self.filename_override {
+        let filename_pattern = match &self.filename_override {
             Some(string) => {
                 let name_override = FilenameOverride::new(string)?;
-                FilenamePattern::Custom(name_override);
+                FilenamePattern::Custom(name_override)
             }
             None => FilenamePattern::CrateName,
         };
 
-        Some(OutputOptions {
+        let output_options = Some(OutputOptions {
             filename: filename_pattern,
             platform_suffix,
         });

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -1,6 +1,6 @@
 use cargo_cyclonedx::{
     config::{
-        CdxExtension, CustomPrefix, Features, IncludedDependencies, LicenseParserOptions,
+        CdxExtension, CustomPrefix, Describe, Features, IncludedDependencies, LicenseParserOptions,
         OutputOptions, ParseMode, Pattern, PlatformSuffix, Prefix, PrefixError, SbomConfig, Target,
     },
     format::Format,
@@ -32,6 +32,10 @@ pub struct Args {
     /// Output BOM format: json, xml
     #[clap(long = "format", short = 'f', value_name = "FORMAT")]
     pub format: Option<Format>,
+
+    /// What to describe in the SBOM: `crate`, `binaries` or `all-cargo-targets`
+    #[clap(long = "describe", value_name = "SBOM_TARGET")]
+    pub describe: Option<Describe>,
 
     /// Use verbose output (-vv for debug logging, -vvv for tracing)
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
@@ -196,6 +200,8 @@ impl Args {
             accept_named: HashSet::from_iter(self.license_accept_named.clone()),
         });
 
+        let describe = self.describe.clone();
+
         Ok(SbomConfig {
             format: self.format,
             included_dependencies,
@@ -203,6 +209,7 @@ impl Args {
             features,
             target,
             license_parser,
+            describe,
         })
     }
 }

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -1,7 +1,7 @@
 use cargo_cyclonedx::{
     config::{
         CdxExtension, CustomPrefix, Describe, Features, IncludedDependencies, LicenseParserOptions,
-        OutputOptions, ParseMode, Pattern, PlatformSuffix, Prefix, PrefixError, SbomConfig, Target,
+        OutputOptions, ParseMode, PlatformSuffix, Prefix, PrefixError, SbomConfig, Target,
     },
     format::Format,
     platform::host_platform,
@@ -23,7 +23,6 @@ pub enum Opts {
 #[derive(Parser, Debug)]
 #[clap(version)]
 #[clap(group(ArgGroup::new("dependencies-group").required(false).args(&["all", "top-level"])))]
-#[clap(group(ArgGroup::new("prefix-or-pattern-group").required(false).args(&["output-prefix", "output-pattern"])))]
 pub struct Args {
     /// Path to Cargo.toml
     #[clap(long = "manifest-path", value_name = "PATH")]
@@ -68,7 +67,7 @@ Defaults to the host target, as printed by 'rustc -vV'"
     )]
     pub target: Option<String>,
 
-    /// Include the target platform of the BOM in the filename. Implies --output-cdx
+    /// Include the target platform of the BOM in the filename
     #[clap(long = "target-in-filename")]
     pub target_in_filename: bool,
 
@@ -80,27 +79,13 @@ Defaults to the host target, as printed by 'rustc -vV'"
     #[clap(name = "top-level", long = "top-level", conflicts_with = "all")]
     pub top_level: bool,
 
-    /// Prepend file extension with .cdx
-    #[clap(long = "output-cdx")]
-    pub output_cdx: bool,
-
-    /// Prefix patterns to use for the filename: bom, package, binary, cargo-target
-    /// Values other than 'bom' imply --output-cdx
+    /// Custom string to use for the output filename
     #[clap(
-        name = "output-pattern",
-        long = "output-pattern",
-        value_name = "PATTERN"
+        long = "override-filename",
+        value_name = "FILENAME",
+        conflicts_with = "describe"
     )]
-    pub output_pattern: Option<Pattern>,
-
-    /// Custom prefix string to use for the filename
-    #[clap(
-        name = "output-prefix",
-        long = "output-prefix",
-        value_name = "FILENAME_PREFIX",
-        conflicts_with = "output-pattern"
-    )]
-    pub output_prefix: Option<String>,
+    pub filename_override: Option<String>,
 
     /// Reject the deprecated '/' separator for licenses, treating 'MIT/Apache-2.0' as an error
     #[clap(long = "license-strict")]

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Args {
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// No output printed to stdout
+    /// Suppress warnings
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Args {
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Suppress warnings
+    /// Disable progress reports and suppress warnings
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -58,7 +58,7 @@ pub struct Args {
     #[clap(long = "features", short = 'F')]
     pub features: Vec<String>,
 
-    /// The target to generate the SBOM for, or 'all' for all targets.
+    /// The target platform to generate the SBOM for, or 'all' for all targets.
     #[clap(
         long = "target",
         long_help = "The target to generate the SBOM for, e.g. 'x86_64-unknown-linux-gnu'.

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Args {
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Disable progress reports and suppress warnings
+    /// Suppress warnings
     #[clap(long = "quiet", short = 'q')]
     pub quiet: bool,
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -37,9 +37,9 @@ pub struct Args {
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
     pub verbose: u8,
 
-    /// Disable progress reports and suppress warnings
-    #[clap(long = "quiet", short = 'q')]
-    pub quiet: bool,
+    /// Disable progress reports (-qq to suppress warnings)
+    #[clap(long = "quiet", short = 'q', action = clap::ArgAction::Count)]
+    pub quiet: u8,
 
     // `--all-features`, `--no-default-features` and `--features`
     // are not mutually exclusive in Cargo, so we keep the same behavior here too.

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -30,6 +30,7 @@ pub struct SbomConfig {
     pub features: Option<Features>,
     pub target: Option<Target>,
     pub license_parser: Option<LicenseParserOptions>,
+    pub describe: Option<Describe>,
 }
 
 impl SbomConfig {
@@ -52,6 +53,7 @@ impl SbomConfig {
                 .clone()
                 .map(|other| self.license_parser.clone().unwrap_or_default().merge(other))
                 .or_else(|| self.license_parser.clone()),
+            describe: other.describe.clone().or_else(|| self.describe.clone()),
         }
     }
 
@@ -251,6 +253,18 @@ pub enum ParseMode {
     /// Parse licenses in lax mode
     #[default]
     Lax,
+}
+
+/// What does the SBOM describe?
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum Describe {
+    /// The entire crate, with Cargo targets as subcomponents
+    #[default]
+    Crate,
+    /// A separate SBOM is emitted for each binary (bin, cdylib) while all other targets are ignored
+    Binaries,
+    /// A separate SBOM is emitted for each target, including things that aren't directly executable (e.g rlib)
+    AllCargoTargets,
 }
 
 #[cfg(test)]

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -1,3 +1,4 @@
+use cyclonedx_bom::models::bom::SpecVersion;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::str::FromStr;
@@ -31,6 +32,7 @@ pub struct SbomConfig {
     pub target: Option<Target>,
     pub license_parser: Option<LicenseParserOptions>,
     pub describe: Option<Describe>,
+    pub spec_version: Option<SpecVersion>,
 }
 
 impl SbomConfig {
@@ -54,6 +56,10 @@ impl SbomConfig {
                 .map(|other| self.license_parser.clone().unwrap_or_default().merge(other))
                 .or_else(|| self.license_parser.clone()),
             describe: other.describe.clone().or_else(|| self.describe.clone()),
+            spec_version: other
+                .spec_version
+                .clone()
+                .or_else(|| self.spec_version.clone()),
         }
     }
 

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -235,28 +235,15 @@ pub enum ParseMode {
 }
 
 /// What does the SBOM describe?
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum Describe {
-    /// The entire crate, with Cargo targets as subcomponents
+    /// Describe the entire crate in a single SBOM file, with Cargo targets as subcomponents. (default)
     #[default]
     Crate,
     /// A separate SBOM is emitted for each binary (bin, cdylib) while all other targets are ignored
     Binaries,
-    /// A separate SBOM is emitted for each target, including things that aren't directly executable (e.g rlib)
+    /// A separate SBOM is emitted for each Cargo target, including things that aren't directly executable (e.g rlib)
     AllCargoTargets,
-}
-
-impl FromStr for Describe {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "crate" => Ok(Self::Crate),
-            "binaries" => Ok(Self::Binaries),
-            "all-cargo-targets" => Ok(Self::AllCargoTargets),
-            _ => Err(format!("Expected bom or package, got `{}`", s)),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -229,7 +229,7 @@ pub enum ParseMode {
 }
 
 /// What does the SBOM describe?
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum Describe {
     /// The entire crate, with Cargo targets as subcomponents
     #[default]

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -267,6 +267,19 @@ pub enum Describe {
     AllCargoTargets,
 }
 
+impl FromStr for Describe {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "crate" => Ok(Self::Crate),
+            "binaries" => Ok(Self::Binaries),
+            "all-cargo-targets" => Ok(Self::AllCargoTargets),
+            _ => Err(format!("Expected bom or package, got `{}`", s)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -719,17 +719,28 @@ impl GeneratedSbom {
             }
         }
 
+        use cyclonedx_bom::models::bom::SpecVersion::*;
+        let spec_version = config.spec_version.unwrap_or(V1_3);
+
         log::info!("Outputting {}", path.display());
         let file = File::create(path)?;
         let mut writer = BufWriter::new(file);
         match config.format() {
             Format::Json => {
-                bom.output_as_json_v1_3(&mut writer)
-                    .map_err(SbomWriterError::JsonWriteError)?;
+                match spec_version {
+                    V1_3 => bom.output_as_json_v1_3(&mut writer),
+                    V1_4 => bom.output_as_json_v1_4(&mut writer),
+                    _ => unimplemented!(),
+                }
+                .map_err(SbomWriterError::JsonWriteError)?;
             }
             Format::Xml => {
-                bom.output_as_xml_v1_3(&mut writer)
-                    .map_err(SbomWriterError::XmlWriteError)?;
+                match spec_version {
+                    V1_3 => bom.output_as_xml_v1_3(&mut writer),
+                    V1_4 => bom.output_as_xml_v1_4(&mut writer),
+                    _ => unimplemented!(),
+                }
+                .map_err(SbomWriterError::XmlWriteError)?;
             }
         }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -816,6 +816,7 @@ impl GeneratedSbom {
         let platform_suffix = match output_options.platform_suffix {
             PlatformSuffix::NotIncluded => "".to_owned(),
             PlatformSuffix::Included => {
+                extension = ".cdx"; // only a literal "bom.{xml,json}" is allowed not to have .cdx
                 let target_string = self.sbom_config.target.as_ref().unwrap();
                 format!("_{}", target_string.as_str())
             }

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -133,7 +133,7 @@ fn locate_manifest(args: &Args) -> Result<PathBuf, io::Error> {
 }
 
 fn get_metadata(
-    _args: &Args,
+    args: &Args,
     manifest_path: &Path,
     config: &SbomConfig,
 ) -> anyhow::Result<Metadata> {
@@ -154,9 +154,17 @@ fn get_metadata(
         }
     }
 
-    if let Some(Target::SingleTarget(target)) = config.target.as_ref() {
-        cmd.other_options(vec!["--filter-platform".to_owned(), target.to_owned()]);
+    let mut other_options: Vec<String> = Vec::new();
+
+    if args.quiet {
+        other_options.push("--quiet".to_owned());
     }
+
+    if let Some(Target::SingleTarget(target)) = config.target.as_ref() {
+        other_options.extend_from_slice(&["--filter-platform".to_owned(), target.to_owned()]);
+    }
+
+    cmd.other_options(other_options);
 
     Ok(cmd.exec()?)
 }

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -133,7 +133,7 @@ fn locate_manifest(args: &Args) -> Result<PathBuf, io::Error> {
 }
 
 fn get_metadata(
-    args: &Args,
+    _args: &Args,
     manifest_path: &Path,
     config: &SbomConfig,
 ) -> anyhow::Result<Metadata> {
@@ -154,17 +154,9 @@ fn get_metadata(
         }
     }
 
-    let mut other_options: Vec<String> = Vec::new();
-
-    if args.quiet {
-        other_options.push("--quiet".to_owned());
-    }
-
     if let Some(Target::SingleTarget(target)) = config.target.as_ref() {
-        other_options.extend_from_slice(&["--filter-platform".to_owned(), target.to_owned()]);
+        cmd.other_options(vec!["--filter-platform".to_owned(), target.to_owned()]);
     }
-
-    cmd.other_options(other_options);
 
     Ok(cmd.exec()?)
 }

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -150,7 +150,7 @@ fn get_metadata(
         }
     }
 
-    if args.quiet >= 1 {
+    if args.quiet == 0 {
         // Contrary to the name, this does not enable verbose output.
         // It merely forwards the cargo stdout to our stdout,
         // so that `cargo metadata` can show a progressbar on long-running operations.

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -133,7 +133,7 @@ fn locate_manifest(args: &Args) -> Result<PathBuf, io::Error> {
 }
 
 fn get_metadata(
-    _args: &Args,
+    args: &Args,
     manifest_path: &Path,
     config: &SbomConfig,
 ) -> anyhow::Result<Metadata> {
@@ -152,6 +152,13 @@ fn get_metadata(
                 feature_configuration.features.clone(),
             ));
         }
+    }
+
+    if !args.quiet {
+        // Contrary to the name, this does not enable verbose output.
+        // It merely forwards the cargo stdout to our stdout,
+        // so that `cargo metadata` can show a progressbar on long-running operations.
+        cmd.verbose(true);
     }
 
     if let Some(Target::SingleTarget(target)) = config.target.as_ref() {

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -93,7 +93,7 @@ fn main() -> anyhow::Result<()> {
 fn setup_logging(args: &Args) -> anyhow::Result<()> {
     let mut builder = Builder::new();
 
-    let level_filter = if args.quiet {
+    let level_filter = if args.quiet >= 2 {
         LevelFilter::Off
     } else {
         match args.verbose {
@@ -150,7 +150,7 @@ fn get_metadata(
         }
     }
 
-    if !args.quiet {
+    if args.quiet >= 1 {
         // Contrary to the name, this does not enable verbose output.
         // It merely forwards the cargo stdout to our stdout,
         // so that `cargo metadata` can show a progressbar on long-running operations.

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -93,10 +93,6 @@ fn main() -> anyhow::Result<()> {
 fn setup_logging(args: &Args) -> anyhow::Result<()> {
     let mut builder = Builder::new();
 
-    // default cargo internals to quiet unless overridden via an environment variable
-    // call with RUST_LOG='cargo::=debug' to access these logs
-    builder.filter_module("cargo::", LevelFilter::Error);
-
     let level_filter = if args.quiet {
         LevelFilter::Off
     } else {

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -54,7 +54,8 @@ fn find_content_in_bom_files() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.current_dir(tmp_dir.path())
         .arg("cyclonedx")
-        .arg("--top-level");
+        .arg("--top-level")
+        .arg("--override-filename=bom");
 
     cmd.assert().success().stdout("");
 
@@ -117,10 +118,6 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert()
         .success()
         .stderr(predicate::str::contains(format!(
-            "Outputting {}",
-            tmp_dir.path().join("bom.xml").display(),
-        )))
-        .stderr(predicate::str::contains(format!(
             "Package {} has an invalid license expression ({}), using as named license: Invalid SPDX expression: unknown term",
             pkg_name, license,
         )));
@@ -129,30 +126,7 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.current_dir(tmp_dir.path()).arg("cyclonedx").arg("-qq");
 
-    cmd.assert().success().stdout("").stderr("");
-
-    tmp_dir.close()?;
-
-    Ok(())
-}
-
-#[test]
-fn bom_file_name_extension_is_prepended_with_cdx() -> Result<(), Box<dyn std::error::Error>> {
-    let tmp_dir = make_temp_rust_project()?;
-
-    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
-
-    cmd.current_dir(tmp_dir.path())
-        .arg("cyclonedx")
-        .arg("--output-cdx");
-
     cmd.assert().success().stdout("");
-
-    tmp_dir.child("bom.xml").assert(predicate::path::missing());
-
-    tmp_dir
-        .child("bom.cdx.xml")
-        .assert(predicate::path::exists());
 
     tmp_dir.close()?;
 

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -127,9 +127,7 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
 
-    cmd.current_dir(tmp_dir.path())
-        .arg("cyclonedx")
-        .arg("-qq");
+    cmd.current_dir(tmp_dir.path()).arg("cyclonedx").arg("-qq");
 
     cmd.assert().success().stdout("").stderr("");
 

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -129,7 +129,7 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.current_dir(tmp_dir.path())
         .arg("cyclonedx")
-        .arg("--quiet");
+        .arg("-qq");
 
     cmd.assert().success().stdout("").stderr("");
 


### PR DESCRIPTION
1. Show progress information from `cargo metadata` by default (no more "why is it taking so long?!")
2. Switch `-q` to disabling progress reports, add `-qq` to suppress warnings (previously done by `-q`)
3. Remove `--output-prefix`, `--output-pattern`, `--output-cdx` flags, subsumed by the newly introduced `--override-filename` flag
4. Split configuration of what the SBOM describes into a separate flag `--describe`
5. Make CycloneDX version configurable

Fixes #633, #605, #562, #632