### PR TITLE
Refactor validation logic to be more concise

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ version = "0.5.0"
 dependencies = [
  "base64",
  "fluent-uri",
+ "indexmap",
  "insta",
  "once_cell",
  "ordered-float",

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -168,8 +168,8 @@ impl Args {
             accept_named: HashSet::from_iter(self.license_accept_named.clone()),
         });
 
-        let describe = self.describe.clone();
-        let spec_version = self.spec_version.clone();
+        let describe = self.describe;
+        let spec_version = self.spec_version;
 
         Ok(SbomConfig {
             format: self.format,

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -55,11 +55,8 @@ impl SbomConfig {
                 .clone()
                 .map(|other| self.license_parser.clone().unwrap_or_default().merge(other))
                 .or_else(|| self.license_parser.clone()),
-            describe: other.describe.clone().or_else(|| self.describe.clone()),
-            spec_version: other
-                .spec_version
-                .clone()
-                .or_else(|| self.spec_version.clone()),
+            describe: other.describe.or(self.describe),
+            spec_version: other.spec_version.or(self.spec_version),
         }
     }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -49,7 +49,7 @@ use cyclonedx_bom::models::metadata::Metadata;
 use cyclonedx_bom::models::metadata::MetadataError;
 use cyclonedx_bom::models::organization::OrganizationalContact;
 use cyclonedx_bom::models::tool::{Tool, Tools};
-use cyclonedx_bom::validation::{Validate, ValidationResult};
+use cyclonedx_bom::validation::Validate;
 use once_cell::sync::Lazy;
 use regex::Regex;
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -714,8 +714,11 @@ impl GeneratedSbom {
         // If running in debug mode, validate that the SBOM is self-consistent and well-formed
         if cfg!(debug_assertions) {
             let result = bom.validate();
-            if let ValidationResult::Failed { reasons } = result {
-                panic!("The generated SBOM failed validation: {:?}", &reasons);
+            if result.has_errors() {
+                panic!(
+                    "The generated SBOM failed validation: {:?}",
+                    result.errors()
+                );
             }
         }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -49,8 +49,7 @@ use cyclonedx_bom::models::metadata::Metadata;
 use cyclonedx_bom::models::metadata::MetadataError;
 use cyclonedx_bom::models::organization::OrganizationalContact;
 use cyclonedx_bom::models::tool::{Tool, Tools};
-use cyclonedx_bom::validation::Validate;
-use cyclonedx_bom::validation::ValidationResult;
+use cyclonedx_bom::validation::{Validate, ValidationResult};
 use once_cell::sync::Lazy;
 use regex::Regex;
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -798,7 +798,7 @@ impl GeneratedSbom {
 
     fn filename(&self, binary_name: Option<&str>, target_kind: &[String]) -> String {
         let output_options = self.sbom_config.output_options();
-        let describe = self.sbom_config.describe.clone().unwrap_or_default();
+        let describe = self.sbom_config.describe.unwrap_or_default();
 
         let mut prefix = match describe {
             Describe::Crate => self.package_name.clone(),

--- a/cargo-cyclonedx/src/purl.rs
+++ b/cargo-cyclonedx/src/purl.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use cargo_metadata::{camino::Utf8Path, Package};
-use cyclonedx_bom::prelude::Purl as CdxPurl;
+use cyclonedx_bom::{external_models::uri::validate_purl, prelude::Purl as CdxPurl};
 use pathdiff::diff_utf8_paths;
 use purl::{PackageError, PackageType, PurlBuilder};
 
@@ -81,8 +81,7 @@ fn to_purl_subpath(path: &Utf8Path) -> String {
 }
 
 fn assert_validation_passes(purl: &CdxPurl) {
-    use cyclonedx_bom::validation::{Validate, ValidationResult};
-    assert_eq!(purl.validate(), ValidationResult::Passed);
+    assert!(validate_purl(purl).is_ok());
 }
 
 #[cfg(test)]

--- a/cyclonedx-bom/Cargo.toml
+++ b/cyclonedx-bom/Cargo.toml
@@ -16,6 +16,7 @@ rust-version.workspace = true
 [dependencies]
 base64 = "0.21.2"
 fluent-uri = "0.1.4"
+indexmap = "2.2.2"
 once_cell = "1.18.0"
 ordered-float = { version = "4.2.0", default-features = false }
 packageurl = "0.3.0"

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -16,12 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::convert::TryFrom;
+use std::{convert::TryFrom, ops::Deref};
 
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};
 
-use crate::validation::{Validate, ValidationContext, ValidationResult};
+use crate::validation::{Validate, ValidationError, ValidationResult};
 
 /// For the purposes of CycloneDX SBOM documents, `DateTime` is a ISO8601 formatted timestamp
 ///
@@ -40,6 +40,13 @@ use crate::validation::{Validate, ValidationContext, ValidationResult};
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DateTime(pub(crate) String);
+
+pub fn validate_date_time(date_time: &DateTime) -> Result<(), ValidationError> {
+    if OffsetDateTime::parse(&date_time.0, &Iso8601::DEFAULT).is_err() {
+        return Err("DateTime does not conform to ISO 8601".into());
+    }
+    Ok(())
+}
 
 impl DateTime {
     pub fn now() -> Result<Self, DateTimeError> {

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{convert::TryFrom, ops::Deref};
+use std::{convert::TryFrom, path::StripPrefixError};
 
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{convert::TryFrom, path::StripPrefixError};
+use std::convert::TryFrom;
 
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -21,7 +21,7 @@ use std::{convert::TryFrom, ops::Deref};
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};
 
-use crate::validation::{Validate, ValidationError, ValidationResult};
+use crate::validation::ValidationError;
 
 /// For the purposes of CycloneDX SBOM documents, `DateTime` is a ISO8601 formatted timestamp
 ///
@@ -71,15 +71,6 @@ impl TryFrom<String> for DateTime {
     }
 }
 
-impl Validate for DateTime {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match OffsetDateTime::parse(&self.0.to_string(), &Iso8601::DEFAULT) {
-            Ok(_) => ValidationResult::Passed,
-            Err(_) => ValidationResult::failure("DateTime does not conform to ISO 8601", context),
-        }
-    }
-}
-
 impl ToString for DateTime {
     fn to_string(&self) -> String {
         self.0.clone()
@@ -97,26 +88,25 @@ pub enum DateTimeError {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use pretty_assertions::assert_eq;
+
+    use crate::{external_models::validate_date_time, prelude::DateTime};
 
     #[test]
     fn valid_datetimes_should_pass_validation() {
-        let validation_result = DateTime("1969-06-28T01:20:00.00-04:00".to_string()).validate();
+        let validation_result =
+            validate_date_time(&DateTime("1969-06-28T01:20:00.00-04:00".to_string()));
 
-        assert_eq!(validation_result, ValidationResult::Passed)
+        assert!(validation_result.is_ok());
     }
 
     #[test]
     fn invalid_datetimes_should_fail_validation() {
-        let validation_result = DateTime("invalid date".to_string()).validate();
+        let validation_result = validate_date_time(&DateTime("invalid date".to_string()));
 
         assert_eq!(
             validation_result,
-            ValidationResult::failure(
-                "DateTime does not conform to ISO 8601",
-                ValidationContext::default()
-            )
-        )
+            Err("DateTime does not conform to ISO 8601".into()),
+        );
     }
 }

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -65,7 +65,7 @@ impl TryFrom<String> for DateTime {
 }
 
 impl Validate for DateTime {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match OffsetDateTime::parse(&self.0.to_string(), &Iso8601::DEFAULT) {
             Ok(_) => ValidationResult::Passed,
             Err(_) => ValidationResult::failure("DateTime does not conform to ISO 8601", context),

--- a/cyclonedx-bom/src/external_models/mod.rs
+++ b/cyclonedx-bom/src/external_models/mod.rs
@@ -20,3 +20,5 @@ pub mod date_time;
 pub mod normalized_string;
 pub mod spdx;
 pub mod uri;
+
+pub(crate) use date_time::validate_date_time;

--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -53,6 +53,12 @@ impl Deref for NormalizedString {
     }
 }
 
+impl AsRef<NormalizedString> for NormalizedString {
+    fn as_ref(&self) -> &NormalizedString {
+        self
+    }
+}
+
 impl AsRef<str> for NormalizedString {
     fn as_ref(&self) -> &str {
         &self.0

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -81,8 +81,8 @@ impl ToString for SpdxIdentifier {
 }
 
 pub fn validate_spdx_identifier(identifier: &SpdxIdentifier) -> Result<(), ValidationError> {
-    match SpdxIdentifier::try_from(identifier.0) {
-        Err(error) => Err(ValidationError::new("SPDX identifier is not valid")),
+    match SpdxIdentifier::try_from(identifier.0.to_string()) {
+        Err(_error) => Err(ValidationError::new("SPDX identifier is not valid")),
         _ => Ok(()),
     }
 }

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -188,8 +188,6 @@ pub enum SpdxExpressionError {
 
 #[cfg(test)]
 mod test {
-    use crate::validation::{ValidationContext, ValidationResult};
-
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -279,18 +277,20 @@ mod test {
 
     #[test]
     fn valid_spdx_expressions_should_pass_validation() {
-        let validation_result = SpdxExpression("MIT OR Apache-2.0".to_string()).validate_default();
+        let validation_result =
+            validate_spdx_expression(&SpdxExpression("MIT OR Apache-2.0".to_string()));
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.is_ok());
     }
 
     #[test]
     fn invalid_spdx_expressions_should_fail_validation() {
-        let validation_result = SpdxExpression("not a real license".to_string()).validate_default();
+        let validation_result =
+            validate_spdx_expression(&SpdxExpression("not a real license".to_string()));
 
         assert_eq!(
             validation_result,
-            ValidationResult::failure("SPDX expression is not valid", ValidationContext::default())
+            Err("SPDX expression is not valid".into()),
         );
     }
 }

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -237,18 +237,19 @@ mod test {
 
     #[test]
     fn valid_spdx_identifiers_should_pass_validation() {
-        let validation_result = SpdxIdentifier("MIT".to_string()).validate_default();
+        let validaton_result = validate_spdx_identifier(&SpdxIdentifier("MIT".to_string()));
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validaton_result.is_ok());
     }
 
     #[test]
     fn invalid_spdx_identifiers_should_fail_validation() {
-        let validation_result = SpdxIdentifier("MIT OR Apache-2.0".to_string()).validate_default();
+        let validation_result =
+            validate_spdx_identifier(&SpdxIdentifier("MIT OR Apache-2.0".to_string()));
 
         assert_eq!(
             validation_result,
-            ValidationResult::failure("SPDX identifier is not valid", ValidationContext::default()),
+            Err("SPDX identifier is not valid".into()),
         );
     }
 

--- a/cyclonedx-bom/src/external_models/uri.rs
+++ b/cyclonedx-bom/src/external_models/uri.rs
@@ -43,7 +43,7 @@ impl ToString for Purl {
 }
 
 impl Validate for Purl {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match PackageUrl::from_str(&self.0.to_string()) {
             Ok(_) => ValidationResult::Passed,
             Err(e) => ValidationResult::failure(
@@ -78,7 +78,7 @@ impl TryFrom<String> for Uri {
 }
 
 impl Validate for Uri {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match Url::parse(&self.0.to_string()) {
             Ok(_) => ValidationResult::Passed,
             Err(_) => ValidationResult::failure("Uri does not conform to RFC 3986", context),

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -46,8 +46,8 @@
 //! }"#;
 //! let bom = Bom::parse_from_json_v1_3(bom_json.as_bytes()).expect("Failed to parse BOM");
 //!
-//! let validation_result = bom.validate_default();
-//! assert_eq!(validation_result, ValidationResult::Passed);
+//! let validation_result = bom.validate();
+//! assert!(validation_result.passed());
 //! ```
 //!
 //! ## Create and output an SBOM

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -46,7 +46,7 @@
 //! }"#;
 //! let bom = Bom::parse_from_json_v1_3(bom_json.as_bytes()).expect("Failed to parse BOM");
 //!
-//! let validation_result = bom.validate();
+//! let validation_result = bom.validate_default();
 //! assert_eq!(validation_result, ValidationResult::Passed);
 //! ```
 //!

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -101,7 +101,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "Advisory",
-                &[(
+                [(
                     0,
                     vec![
                         validation::field(

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -45,7 +45,8 @@ impl Advisory {
 }
 
 impl Validate for Advisory {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(title) = &self.title {
@@ -67,7 +68,7 @@ impl Validate for Advisory {
 pub struct Advisories(pub Vec<Advisory>);
 
 impl Validate for Advisories {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, advisory) in self.0.iter().enumerate() {

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -63,7 +63,9 @@ pub struct Advisories(pub Vec<Advisory>);
 impl Validate for Advisories {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |advisory| advisory.validate_version(version))
+            .add_list("inner", &self.0, |advisory| {
+                advisory.validate_version(version)
+            })
             .into()
     }
 }
@@ -86,7 +88,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -98,8 +100,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -111,7 +113,7 @@ mod test {
                         validation::field("url", "Uri does not conform to RFC 3986")
                     ]
                 )]
-            ))
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -63,7 +63,7 @@ pub struct Advisories(pub Vec<Advisory>);
 impl Validate for Advisories {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", self.0, |advisory| advisory.validate(version))
+            .add_list("inner", &self.0, |advisory| advisory.validate(version))
             .into()
     }
 }

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -49,7 +49,7 @@ impl Advisory {
 }
 
 impl Validate for Advisory {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("title", self.title.as_ref(), validate_normalized_string)
             .add_field("url", &self.url, validate_uri)

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -100,7 +100,7 @@ mod test {
         assert_eq!(
             validation_result.errors(),
             Some(validation::list(
-                "Advisory",
+                "inner",
                 [(
                     0,
                     vec![

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -49,7 +49,7 @@ impl Advisory {
 }
 
 impl Validate for Advisory {
-    fn validate(&self, _version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("title", self.title.as_ref(), validate_normalized_string)
             .add_field("url", &self.url, validate_uri)
@@ -61,9 +61,9 @@ impl Validate for Advisory {
 pub struct Advisories(pub Vec<Advisory>);
 
 impl Validate for Advisories {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |advisory| advisory.validate(version))
+            .add_list("inner", &self.0, |advisory| advisory.validate_version(version))
             .into()
     }
 }
@@ -84,7 +84,7 @@ mod test {
             title: Some(NormalizedString::new("title")),
             url: Uri("https://example.com".to_string()),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -95,7 +95,7 @@ mod test {
             title: Some(NormalizedString("invalid\ttitle".to_string())),
             url: Uri("invalid url".to_string()),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -20,8 +20,10 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 
 use crate::{
     external_models::normalized_string::NormalizedString,
-    validation::{Validate, ValidationContext, ValidationResult},
+    validation::{Validate, ValidationResult},
 };
+
+use super::bom::SpecVersion;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AttachedText {
@@ -46,6 +48,7 @@ impl AttachedText {
 
 impl Validate for AttachedText {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
+        /*
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(content_type) = &self.content_type {
@@ -76,6 +79,8 @@ impl Validate for AttachedText {
         results
             .into_iter()
             .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        */
+        todo!("")
     }
 }
 

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -47,7 +47,7 @@ impl AttachedText {
 }
 
 impl Validate for AttachedText {
-    fn validate(&self, _version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         let mut context = ValidationContext::new().add_field_option(
             "content_type",
             self.content_type.as_ref(),
@@ -138,7 +138,7 @@ mod test {
             encoding: Some(Encoding::Base64),
             content: "dGhpcyB0ZXh0IGlzIHBsYWlu".to_string(),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -150,7 +150,7 @@ mod test {
             encoding: Some(Encoding::Base64),
             content: "not base64 encoded".to_string(),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),
@@ -174,7 +174,7 @@ mod test {
             encoding: Some(Encoding::UnknownEncoding("unknown".to_string())),
             content: "not base64 encoded".to_string(),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),
@@ -189,7 +189,7 @@ mod test {
             encoding: None,
             content: "not base64 encoded".to_string(),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -47,7 +47,7 @@ impl AttachedText {
 }
 
 impl Validate for AttachedText {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate(&self, _version: SpecVersion) -> ValidationResult {
         let mut context = ValidationContext::new().add_field_option(
             "content_type",
             self.content_type.as_ref(),
@@ -58,12 +58,12 @@ impl Validate for AttachedText {
             match (encoding, STANDARD.decode(self.content.clone())) {
                 (Encoding::Base64, Ok(_)) => (),
                 (Encoding::Base64, Err(_)) => {
-                    context.add_field("content", self.content, |_| {
+                    context = context.add_field("content", &self.content, |_| {
                         Err("Content is not Base64 encoded".into())
                     });
                 }
                 (Encoding::UnknownEncoding(_), _) => {
-                    context.add_field("encoding", encoding, validate_encoding);
+                    context = context.add_field("encoding", encoding, validate_encoding);
                 }
             }
         }

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -45,7 +45,7 @@ impl AttachedText {
 }
 
 impl Validate for AttachedText {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(content_type) = &self.content_type {
@@ -105,7 +105,7 @@ impl Encoding {
 }
 
 impl Validate for Encoding {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             Encoding::UnknownEncoding(_) => ValidationResult::failure("Unknown encoding", context),
             _ => ValidationResult::Passed,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -574,7 +574,7 @@ mod test {
             actual.errors(),
             Some(validation::list(
                 "compositions",
-                &[(
+                [(
                     0,
                     vec![
                         validation::custom(

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -19,7 +19,6 @@
 use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fmt;
-use std::ops::Deref;
 use std::str::FromStr;
 
 use once_cell::sync::Lazy;

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -226,7 +226,7 @@ impl Default for Bom {
 }
 
 impl Validate for Bom {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         let mut context = ValidationContext::new()
             .add_field_option(
                 "serial_number",
@@ -503,7 +503,7 @@ mod test {
             signature: None,
         };
 
-        let actual = bom.validate_default();
+        let actual = bom.validate();
 
         assert_eq!(actual, ValidationResult::Passed);
     }
@@ -527,7 +527,7 @@ mod test {
             signature: None,
         };
 
-        let actual = bom.validate_default();
+        let actual = bom.validate();
 
         assert_eq!(
             actual.errors(),
@@ -568,7 +568,7 @@ mod test {
             signature: None,
         };
 
-        let actual = bom.validate(SpecVersion::V1_3);
+        let actual = bom.validate_version(SpecVersion::V1_3);
 
         assert_eq!(
             actual.errors(),
@@ -685,7 +685,7 @@ mod test {
             signature: None,
         };
 
-        let actual = bom.validate_default();
+        let actual = bom.validate();
 
         /*
         assert_eq!(
@@ -845,7 +845,7 @@ mod test {
             vulnerabilities: None,
             signature: None,
         }
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -534,13 +534,13 @@ mod test {
             Some(
                 vec![
                     validation::custom(
-                        "dependency ref",
-                        "Dependency reference does not exist in the BOM"
+                        "dependency_ref",
+                        ["Dependency ref 'dependency' does not exist in the BOM",],
                     ),
                     validation::custom(
-                        "dependency ref",
-                        "Dependency reference does not exist in the BOM"
-                    ),
+                        "sub dependency_ref",
+                        ["Dependency ref 'sub-dependency' does not exist in the BOM"]
+                    )
                 ]
                 .into()
             )
@@ -572,21 +572,12 @@ mod test {
 
         assert_eq!(
             actual.errors(),
-            Some(validation::list(
-                "compositions",
-                [(
-                    0,
-                    vec![
-                        validation::custom(
-                            "composition ref",
-                            "Composition reference 'abc' does not exist in the BOM"
-                        ),
-                        validation::custom(
-                            "composition ref",
-                            "Composition reference 'abc' does not exist in the BOM"
-                        )
-                    ]
-                )]
+            Some(validation::custom(
+                "composition ref",
+                [
+                    "Composition reference 'assembly' does not exist in the BOM",
+                    "Composition reference 'dependencies' does not exist in the BOM"
+                ]
             ))
         );
     }

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -38,7 +38,7 @@ pub struct Commit {
 }
 
 impl Validate for Commit {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("uid", self.uid.as_ref(), validate_normalized_string)
             .add_field_option("url", self.url.as_ref(), validate_uri)
@@ -53,9 +53,9 @@ impl Validate for Commit {
 pub struct Commits(pub Vec<Commit>);
 
 impl Validate for Commits {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |commit| commit.validate(version))
+            .add_list("inner", &self.0, |commit| commit.validate_version(version))
             .into()
     }
 }
@@ -67,7 +67,7 @@ pub struct Diff {
 }
 
 impl Validate for Diff {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option("text", self.text.as_ref(), version)
             .add_field_option("url", self.url.as_ref(), validate_uri)
@@ -83,7 +83,7 @@ pub struct IdentifiableAction {
 }
 
 impl Validate for IdentifiableAction {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("timestamp", self.timestamp.as_ref(), validate_date_time)
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
@@ -103,7 +103,7 @@ pub struct Issue {
 }
 
 impl Validate for Issue {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field(
                 "issue_type",
@@ -175,7 +175,7 @@ pub struct Patch {
 }
 
 impl Validate for Patch {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_enum(
                 "patch_type",
@@ -184,7 +184,7 @@ impl Validate for Patch {
             )
             .add_struct_option("diff", self.diff.as_ref(), version)
             .add_list_option("resolves", self.resolves.as_ref(), |issue| {
-                issue.validate(version)
+                issue.validate_version(version)
             })
             .into()
     }
@@ -194,9 +194,9 @@ impl Validate for Patch {
 pub struct Patches(pub Vec<Patch>);
 
 impl Validate for Patches {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |patch| patch.validate(version))
+            .add_list("inner", &self.0, |patch| patch.validate_version(version))
             .into()
     }
 }
@@ -255,7 +255,7 @@ pub struct Source {
 }
 
 impl Validate for Source {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("url", self.url.as_ref(), validate_uri)
@@ -287,7 +287,7 @@ mod test {
             }),
             message: Some(NormalizedString("no_whitespace".to_string())),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -309,7 +309,7 @@ mod test {
             }),
             message: Some(NormalizedString("spaces and\ttabs".to_string())),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),
@@ -370,7 +370,7 @@ mod test {
                 references: Some(vec![Uri("https://example.com".to_string())]),
             }]),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -399,7 +399,7 @@ mod test {
                 references: Some(vec![Uri("invalid uri".to_string())]),
             }]),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -318,7 +318,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[(
+                [(
                     0,
                     vec![
                         validation::field(
@@ -408,7 +408,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[(
+                [(
                     0,
                     vec![
                         validation::field("patch_type", "Unknown patch classification"),
@@ -429,7 +429,7 @@ mod test {
                         ),
                         validation::list(
                             "resolves",
-                            &[(
+                            [(
                                 0,
                                 vec![
                                     validation::field("issue_type", "Unknown issue classification"),
@@ -449,7 +449,7 @@ mod test {
                                             )
                                         ]
                                     ),
-                                    validation::list("references", &[(0, validation::field("inner", "Uri does not conform to RFC 3986"))])
+                                    validation::list("references", [(0, validation::field("inner", "Uri does not conform to RFC 3986"))])
                                 ]
                             )]
                         )

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -17,13 +17,15 @@
  */
 
 use crate::{
-    external_models::{date_time::DateTime, normalized_string::NormalizedString, uri::Uri},
-    validation::{
-        FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
+    external_models::{
+        date_time::DateTime,
+        normalized_string::{validate_normalized_string, NormalizedString},
+        uri::Uri,
     },
+    validation::{Validate, ValidationContext, ValidationResult},
 };
 
-use super::attached_text::AttachedText;
+use super::{attached_text::AttachedText, bom::SpecVersion};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Commit {
@@ -35,7 +37,11 @@ pub struct Commit {
 }
 
 impl Validate for Commit {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
+        ValidationContext::new()
+            .add_field("uid", self.uid.as_deref(), validate_normalized_string)
+            .into()
+        /*
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(uid) = &self.uid {
@@ -71,6 +77,7 @@ impl Validate for Commit {
         results
             .into_iter()
             .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        */
     }
 }
 
@@ -78,7 +85,7 @@ impl Validate for Commit {
 pub struct Commits(pub Vec<Commit>);
 
 impl Validate for Commits {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, commit) in self.0.iter().enumerate() {
@@ -100,7 +107,7 @@ pub struct Diff {
 }
 
 impl Validate for Diff {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(text) = &self.text {
@@ -129,7 +136,7 @@ pub struct IdentifiableAction {
 }
 
 impl Validate for IdentifiableAction {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {
@@ -167,7 +174,7 @@ pub struct Issue {
 }
 
 impl Validate for Issue {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let issue_context = context.with_struct("Issue", "issue_type");
@@ -250,7 +257,7 @@ impl IssueClassification {
 }
 
 impl Validate for IssueClassification {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             IssueClassification::UnknownIssueClassification(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -271,7 +278,7 @@ pub struct Patch {
 }
 
 impl Validate for Patch {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let patch_type_context = context.with_struct("Patch", "patch_type");
@@ -307,7 +314,7 @@ impl Validate for Patch {
 pub struct Patches(pub Vec<Patch>);
 
 impl Validate for Patches {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, patch) in self.0.iter().enumerate() {
@@ -357,7 +364,7 @@ impl PatchClassification {
 }
 
 impl Validate for PatchClassification {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             PatchClassification::UnknownPatchClassification(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -377,7 +384,7 @@ pub struct Source {
 }
 
 impl Validate for Source {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -118,10 +118,7 @@ impl Validate for Issue {
                 validate_normalized_string,
             )
             .add_struct_option("source", self.source.as_ref(), version)
-            // TODO:
-            // .add_list_option("references", self.references.as_ref(), |uri| {
-            //     validate_uri(uri)
-            // })
+            .add_list_option("references", self.references.as_ref(), validate_uri)
             .into()
     }
 }
@@ -411,7 +408,7 @@ mod test {
                 [(
                     0,
                     vec![
-                        validation::field("patch_type", "Unknown patch classification"),
+                        validation::r#enum("patch_type", "Unknown patch classification"),
                         validation::r#struct(
                             "diff",
                             vec![
@@ -449,7 +446,7 @@ mod test {
                                             )
                                         ]
                                     ),
-                                    validation::list("references", [(0, validation::field("inner", "Uri does not conform to RFC 3986"))])
+                                    validation::list("references", [(0, validation::custom("", ["Uri does not conform to RFC 3986"]))])
                                 ]
                             )]
                         )

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -255,7 +255,7 @@ pub struct Source {
 }
 
 impl Validate for Source {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("url", self.url.as_ref(), validate_uri)
@@ -289,7 +289,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -312,8 +312,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -342,7 +342,7 @@ mod test {
                         validation::field("message", "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n")
                     ]
                 )]
-            ))
+            )
         );
     }
 
@@ -372,7 +372,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -402,8 +402,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -452,7 +452,7 @@ mod test {
                         )
                     ]
                 )]
-            ))
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -103,7 +103,7 @@ impl Component {
 }
 
 impl Validate for Component {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let component_type_context = context.with_struct("Component", "component_type");
@@ -241,7 +241,7 @@ impl Validate for Component {
 pub struct Components(pub Vec<Component>);
 
 impl Validate for Components {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, component) in self.0.iter().enumerate() {
@@ -303,7 +303,7 @@ impl Classification {
 }
 
 impl Validate for Classification {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             Classification::UnknownClassification(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -349,7 +349,7 @@ impl Scope {
 }
 
 impl Validate for Scope {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             Scope::UnknownScope(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -366,7 +366,7 @@ impl Validate for Scope {
 pub struct MimeType(pub(crate) String);
 
 impl Validate for MimeType {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
             Regex::new(r"^[-+a-z0-9.]+/[-+a-z0-9.]+$").expect("Failed to compile regex.")
         });
@@ -395,7 +395,7 @@ pub struct Swid {
 }
 
 impl Validate for Swid {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(text) = &self.text {
@@ -420,7 +420,7 @@ impl Validate for Swid {
 pub struct Cpe(pub(crate) String);
 
 impl Validate for Cpe {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         static UUID_REGEX: Lazy<Regex> = Lazy::new(|| {
             Regex::new(
                 r##"([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6})|(cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?!"#$$%&'\(\)\+,/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4})"##,
@@ -447,7 +447,7 @@ pub struct ComponentEvidence {
 }
 
 impl Validate for ComponentEvidence {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(licenses) = &self.licenses {
@@ -479,7 +479,7 @@ pub struct Pedigree {
 }
 
 impl Validate for Pedigree {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(ancestors) = &self.ancestors {
@@ -531,7 +531,7 @@ impl Validate for Copyright {
 pub struct CopyrightTexts(pub(crate) Vec<Copyright>);
 
 impl Validate for CopyrightTexts {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, copyright) in self.0.iter().enumerate() {

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -107,49 +107,49 @@ impl Component {
 
 impl Validate for Component {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
-        ValidationContext::new()
-            .add_field(
-                "component_type",
-                &self.component_type,
-                validate_classification,
-            )
-            .add_field_option("mime_type", self.mime_type.as_ref(), validate_mime_type)
-            .add_struct_option("supplier", self.supplier.as_ref(), version)
-            .add_field_option("author", self.author.as_ref(), validate_normalized_string)
-            .add_field_option(
-                "publisher",
-                self.publisher.as_ref(),
-                validate_normalized_string,
-            )
-            .add_field_option("group", self.group.as_ref(), validate_normalized_string)
-            .add_field("name", self.name.as_ref(), validate_normalized_string)
-            .add_field_option("version", self.version.as_ref(), validate_normalized_string)
-            .add_field_option(
-                "description",
-                self.description.as_ref(),
-                validate_normalized_string,
-            )
-            .add_enum_option("scope", self.scope.as_ref(), validate_scope)
-            .add_struct_option("hashes", self.hashes.as_ref(), version)
-            .add_struct_option("licenses", self.licenses.as_ref(), version)
-            .add_field_option(
-                "copyright",
-                self.copyright.as_ref(),
-                validate_normalized_string,
-            )
-            .add_field_option("cpe", self.cpe.as_ref(), validate_cpe)
-            .add_field_option("purl", self.purl.as_ref(), validate_purl)
-            .add_struct_option("swid", self.swid.as_ref(), version)
-            .add_struct_option("pedigree", self.pedigree.as_ref(), version)
-            .add_struct_option(
-                "external_references",
-                self.external_references.as_ref(),
-                version,
-            )
-            .add_struct_option("properties", self.properties.as_ref(), version)
-            .add_struct_option("components", self.components.as_ref(), version)
-            .add_struct_option("evidence", self.evidence.as_ref(), version)
-            .into()
+        let mut ctx = ValidationContext::new();
+        ctx.add_field(
+            "component_type",
+            &self.component_type,
+            validate_classification,
+        );
+        ctx.add_field_option("mime_type", self.mime_type.as_ref(), validate_mime_type);
+        ctx.add_struct_option("supplier", self.supplier.as_ref(), version);
+        ctx.add_field_option("author", self.author.as_ref(), validate_normalized_string);
+        ctx.add_field_option(
+            "publisher",
+            self.publisher.as_ref(),
+            validate_normalized_string,
+        );
+        ctx.add_field_option("group", self.group.as_ref(), validate_normalized_string);
+        ctx.add_field("name", self.name.as_ref(), validate_normalized_string);
+        ctx.add_field_option("version", self.version.as_ref(), validate_normalized_string);
+        ctx.add_field_option(
+            "description",
+            self.description.as_ref(),
+            validate_normalized_string,
+        );
+        ctx.add_enum_option("scope", self.scope.as_ref(), validate_scope);
+        ctx.add_struct_option("hashes", self.hashes.as_ref(), version);
+        ctx.add_struct_option("licenses", self.licenses.as_ref(), version);
+        ctx.add_field_option(
+            "copyright",
+            self.copyright.as_ref(),
+            validate_normalized_string,
+        );
+        ctx.add_field_option("cpe", self.cpe.as_ref(), validate_cpe);
+        ctx.add_field_option("purl", self.purl.as_ref(), validate_purl);
+        ctx.add_struct_option("swid", self.swid.as_ref(), version);
+        ctx.add_struct_option("pedigree", self.pedigree.as_ref(), version);
+        ctx.add_struct_option(
+            "external_references",
+            self.external_references.as_ref(),
+            version,
+        );
+        ctx.add_struct_option("properties", self.properties.as_ref(), version);
+        ctx.add_struct_option("components", self.components.as_ref(), version);
+        ctx.add_struct_option("evidence", self.evidence.as_ref(), version);
+        ctx.into()
     }
 }
 
@@ -159,7 +159,9 @@ pub struct Components(pub Vec<Component>);
 impl Validate for Components {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |component| component.validate_version(version))
+            .add_list("inner", &self.0, |component| {
+                component.validate_version(version)
+            })
             .into()
     }
 }
@@ -342,44 +344,13 @@ pub struct Pedigree {
 
 impl Validate for Pedigree {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
-        ValidationContext::new().into()
-        /*
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(ancestors) = &self.ancestors {
-            let context = context.with_struct("Pedigree", "ancestors");
-
-            results.push(ancestors.validate_with_context(context));
-        }
-
-        if let Some(descendants) = &self.descendants {
-            let context = context.with_struct("Pedigree", "descendants");
-
-            results.push(descendants.validate_with_context(context));
-        }
-
-        if let Some(variants) = &self.variants {
-            let context = context.with_struct("Pedigree", "variants");
-
-            results.push(variants.validate_with_context(context));
-        }
-
-        if let Some(commits) = &self.commits {
-            let context = context.with_struct("Pedigree", "commits");
-
-            results.push(commits.validate_with_context(context));
-        }
-
-        if let Some(patches) = &self.patches {
-            let context = context.with_struct("Pedigree", "patches");
-
-            results.push(patches.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-        */
+        let mut context = ValidationContext::new();
+        context.add_struct_option("ancestors", self.ancestors.as_ref(), version);
+        context.add_struct_option("descendants", self.descendants.as_ref(), version);
+        context.add_struct_option("variants", self.variants.as_ref(), version);
+        context.add_struct_option("commits", self.commits.as_ref(), version);
+        context.add_struct_option("patches", self.patches.as_ref(), version);
+        context.into()
     }
 }
 
@@ -417,7 +388,6 @@ mod test {
     };
 
     use super::*;
-    use pretty_assertions::assert_eq;
 
     #[test]
     fn valid_components_should_pass_validation() {
@@ -500,7 +470,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -259,22 +259,6 @@ impl Scope {
     }
 }
 
-/*
-impl Validate for Scope {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            Scope::UnknownScope(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Unknown scope".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
-        }
-    }
-}
-*/
-
 /// Checks if given [`MimeType`] is valid / supported.
 pub fn validate_mime_type(mime_type: &MimeType) -> Result<(), ValidationError> {
     static UUID_REGEX: Lazy<Regex> =
@@ -341,26 +325,8 @@ impl Validate for ComponentEvidence {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option("licenses", self.licenses.as_ref(), version)
+            .add_struct_option("copyright", self.copyright.as_ref(), version)
             .into()
-        /*
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(licenses) = &self.licenses {
-            let context = context.with_struct("ComponentEvidence", "licenses");
-
-            results.push(licenses.validate_with_context(context));
-        }
-
-        if let Some(copyright) = &self.copyright {
-            let context = context.with_struct("ComponentEvidence", "copyright");
-
-            results.push(copyright.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-        */
     }
 }
 

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -106,7 +106,7 @@ impl Component {
 }
 
 impl Validate for Component {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field(
                 "component_type",
@@ -157,9 +157,9 @@ impl Validate for Component {
 pub struct Components(pub Vec<Component>);
 
 impl Validate for Components {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |component| component.validate(version))
+            .add_list("inner", &self.0, |component| component.validate_version(version))
             .into()
     }
 }
@@ -288,7 +288,7 @@ pub struct Swid {
 }
 
 impl Validate for Swid {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option("text", self.text.as_ref(), version)
             .add_field_option("url", self.url.as_ref(), validate_uri)
@@ -322,7 +322,7 @@ pub struct ComponentEvidence {
 }
 
 impl Validate for ComponentEvidence {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option("licenses", self.licenses.as_ref(), version)
             .add_struct_option("copyright", self.copyright.as_ref(), version)
@@ -341,7 +341,7 @@ pub struct Pedigree {
 }
 
 impl Validate for Pedigree {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new().into()
         /*
         let mut results: Vec<ValidationResult> = vec![];
@@ -394,7 +394,7 @@ pub struct Copyright(pub String);
 pub struct CopyrightTexts(pub(crate) Vec<Copyright>);
 
 impl Validate for CopyrightTexts {
-    fn validate(&self, _version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_list("inner", &self.0, validate_copyright)
             .into()
@@ -498,7 +498,7 @@ mod test {
             }),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -586,7 +586,7 @@ mod test {
             }),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -19,7 +19,8 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::external_models::uri::validate_uri;
+use crate::external_models::normalized_string::validate_normalized_string;
+use crate::external_models::uri::{validate_purl, validate_uri};
 use crate::models::attached_text::AttachedText;
 use crate::models::code::{Commits, Patches};
 use crate::models::external_reference::ExternalReferences;
@@ -114,126 +115,41 @@ impl Validate for Component {
             )
             .add_field_option("mime_type", self.mime_type.as_ref(), validate_mime_type)
             .add_struct_option("supplier", self.supplier.as_ref(), version)
+            .add_field_option("author", self.author.as_ref(), validate_normalized_string)
+            .add_field_option(
+                "publisher",
+                self.publisher.as_ref(),
+                validate_normalized_string,
+            )
+            .add_field_option("group", self.group.as_ref(), validate_normalized_string)
+            .add_field("name", self.name.as_ref(), validate_normalized_string)
+            .add_field_option("version", self.version.as_ref(), validate_normalized_string)
+            .add_field_option(
+                "description",
+                self.description.as_ref(),
+                validate_normalized_string,
+            )
+            .add_enum_option("scope", self.scope.as_ref(), validate_scope)
+            .add_struct_option("hashes", self.hashes.as_ref(), version)
+            .add_struct_option("licenses", self.licenses.as_ref(), version)
+            .add_field_option(
+                "copyright",
+                self.copyright.as_ref(),
+                validate_normalized_string,
+            )
+            .add_field_option("cpe", self.cpe.as_ref(), validate_cpe)
+            .add_field_option("purl", self.purl.as_ref(), validate_purl)
+            .add_struct_option("swid", self.swid.as_ref(), version)
+            .add_struct_option("pedigree", self.pedigree.as_ref(), version)
+            .add_struct_option(
+                "external_references",
+                self.external_references.as_ref(),
+                version,
+            )
+            .add_struct_option("properties", self.properties.as_ref(), version)
+            .add_struct_option("components", self.components.as_ref(), version)
+            .add_struct_option("evidence", self.evidence.as_ref(), version)
             .into()
-
-        /*
-        if let Some(supplier) = &self.supplier {
-            let context = context.with_struct("Component", "supplier");
-
-            results.push(supplier.validate_with_context(context));
-        }
-
-        if let Some(author) = &self.author {
-            let context = context.with_struct("Component", "author");
-
-            results.push(author.validate_with_context(context));
-        }
-
-        if let Some(publisher) = &self.publisher {
-            let context = context.with_struct("Component", "publisher");
-
-            results.push(publisher.validate_with_context(context));
-        }
-
-        if let Some(group) = &self.group {
-            let context = context.with_struct("Component", "group");
-
-            results.push(group.validate_with_context(context));
-        }
-
-        let name_context = context.with_struct("Component", "name");
-
-        results.push(self.name.validate_with_context(name_context));
-
-        if let Some(version) = &self.version {
-            let context = context.with_struct("Component", "version");
-
-            results.push(version.validate_with_context(context));
-        }
-
-        if let Some(description) = &self.description {
-            let context = context.with_struct("Component", "description");
-
-            results.push(description.validate_with_context(context));
-        }
-
-        if let Some(scope) = &self.scope {
-            let context = context.with_struct("Component", "scope");
-
-            results.push(scope.validate_with_context(context));
-        }
-
-        if let Some(hashes) = &self.hashes {
-            let context = context.with_struct("Component", "hashes");
-
-            results.push(hashes.validate_with_context(context));
-        }
-
-        if let Some(licenses) = &self.licenses {
-            let context = context.with_struct("Component", "licenses");
-
-            results.push(licenses.validate_with_context(context));
-        }
-
-        if let Some(copyright) = &self.copyright {
-            let context = context.with_struct("Component", "copyright");
-
-            results.push(copyright.validate_with_context(context));
-        }
-
-        if let Some(cpe) = &self.cpe {
-            let context = context.with_struct("Component", "cpe");
-
-            results.push(cpe.validate_with_context(context));
-        }
-
-        if let Some(purl) = &self.purl {
-            let context = context.with_struct("Component", "purl");
-
-            results.push(purl.validate_with_context(context));
-        }
-
-        if let Some(swid) = &self.swid {
-            let context = context.with_struct("Component", "swid");
-
-            results.push(swid.validate_with_context(context));
-        }
-
-        if let Some(pedigree) = &self.pedigree {
-            let context = context.with_struct("Component", "pedigree");
-
-            results.push(pedigree.validate_with_context(context));
-        }
-
-        if let Some(external_references) = &self.external_references {
-            let context = context.with_struct("Component", "external_references");
-
-            results.push(external_references.validate_with_context(context));
-        }
-
-        if let Some(properties) = &self.properties {
-            let context = context.with_struct("Component", "properties");
-
-            results.push(properties.validate_with_context(context));
-        }
-
-        if let Some(components) = &self.components {
-            let context = context.with_struct("Component", "components");
-
-            results.push(components.validate_with_context(context));
-        }
-
-        if let Some(evidence) = &self.evidence {
-            let context = context.with_struct("Component", "evidence");
-
-            results.push(evidence.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-
-        */
     }
 }
 
@@ -512,7 +428,7 @@ pub struct Copyright(pub String);
 pub struct CopyrightTexts(pub(crate) Vec<Copyright>);
 
 impl Validate for CopyrightTexts {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_list("inner", &self.0, validate_copyright)
             .into()

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -122,7 +122,7 @@ impl Validate for Component {
             validate_normalized_string,
         );
         ctx.add_field_option("group", self.group.as_ref(), validate_normalized_string);
-        ctx.add_field("name", self.name.as_ref(), validate_normalized_string);
+        ctx.add_field("name", &self.name, validate_normalized_string);
         ctx.add_field_option("version", self.version.as_ref(), validate_normalized_string);
         ctx.add_field_option(
             "description",

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -374,6 +374,7 @@ impl Validate for CopyrightTexts {
 
 #[cfg(test)]
 mod test {
+    use pretty_assertions::assert_eq;
 
     use crate::{
         external_models::spdx::SpdxExpression,
@@ -385,6 +386,7 @@ mod test {
             property::Property,
             signature::Algorithm,
         },
+        validation,
     };
 
     use super::*;
@@ -558,391 +560,218 @@ mod test {
         }])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message: "Unknown classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "component_type".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "MimeType does not match regular expression".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "mime_type".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    vec![
+                        validation::field("component_type", "Unknown classification"),
+                        validation::field(
+                            "mime_type",
+                            "MimeType does not match regular expression"
+                        ),
+                        validation::r#struct(
+                            "supplier",
+                            validation::field(
+                                "name",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            )
+                        ),
+                        validation::field(
+                            "author",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "supplier".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+                        ),
+                        validation::field(
+                            "publisher",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "author".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+                        ),
+                        validation::field(
+                            "group",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "publisher".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+                        ),
+                        validation::field(
+                            "name",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "group".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+                        ),
+                        validation::field(
+                            "version",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+                        ),
+                        validation::field(
+                            "description",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "version".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
+                        ),
+                        validation::r#enum(
+                            "scope",
+                            "Unknown scope"
+                        ),
+                        validation::r#struct(
+                            "hashes",
+                            validation::list(
+                                "inner",
+                                [(
+                                    0,
+                                    validation::field(
+                                        "content",
+                                        "HashValue does not match regular expression"
+                                    )
+                                )]
+                            )
+                        ),
+                        validation::r#struct(
+                            "licenses",
+                            validation::list(
+                                "inner",
+                                [(
+                                    0,
+                                    validation::r#enum(
+                                        "expression",
+                                        "SPDX expression is not valid"
+                                    )
+                                )]
+                            )
+                        ),
+                        validation::field(
+                            "copyright",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "description".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown scope".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "scope".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "HashValue does not match regular expression".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "hashes".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Hash".to_string(),
-                                field_name: "content".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "SPDX expression is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "licenses".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Expression".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "copyright".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Cpe does not match regular expression".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "cpe".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Purl does not conform to Package URL spec: missing scheme"
-                            .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "purl".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "swid".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Swid".to_string(),
-                                field_name: "text".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "AttachedText".to_string(),
-                                field_name: "content_type".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "swid".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Swid".to_string(),
-                                field_name: "url".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "pedigree".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Pedigree".to_string(),
-                                field_name: "ancestors".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "component_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "pedigree".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Pedigree".to_string(),
-                                field_name: "descendants".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "component_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "pedigree".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Pedigree".to_string(),
-                                field_name: "variants".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "component_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "pedigree".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Pedigree".to_string(),
-                                field_name: "commits".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Commit".to_string(),
-                                field_name: "uid".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown patch classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "pedigree".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Pedigree".to_string(),
-                                field_name: "patches".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Patch".to_string(),
-                                field_name: "patch_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown external reference type".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "external_references".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "ExternalReference".to_string(),
-                                field_name: "external_reference_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "properties".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Property".to_string(),
-                                field_name: "value".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "components".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "component_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "SPDX expression is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "evidence".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "ComponentEvidence".to_string(),
-                                field_name: "licenses".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Expression".to_string()
-                            },
-                        ])
-                    },
-                ]
-            }
+                        ),
+                        validation::field(
+                            "cpe",
+                            "Cpe does not match regular expression"
+                        ),
+                        validation::field(
+                            "purl",
+                            "Purl does not conform to Package URL spec"
+                        ),
+                        validation::r#struct(
+                            "swid",
+                            vec![
+                                validation::r#struct(
+                                    "text",
+                                    validation::field(
+                                        "content_type",
+                                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                    )
+                                ),
+                                validation::field(
+                                    "url",
+                                    "Uri does not conform to RFC 3986"
+                                )
+                            ]
+                        ),
+                        validation::r#struct(
+                            "pedigree",
+                            vec![
+                                validation::r#struct(
+                                    "ancestors",
+                                    validation::list(
+                                        "inner",
+                                        [(
+                                            0,
+                                            validation::field("component_type", "Unknown classification")
+                                        )]
+                                    )
+                                ),
+                                validation::r#struct(
+                                    "descendants",
+                                    validation::list(
+                                        "inner",
+                                        [(
+                                            0,
+                                            validation::field("component_type", "Unknown classification")
+                                        )]
+                                    )
+                                ),
+                                validation::r#struct(
+                                    "variants",
+                                    validation::list(
+                                        "inner",
+                                        [(
+                                            0,
+                                            validation::field("component_type", "Unknown classification")
+                                        )]
+                                    )
+                                ),
+                                validation::r#struct(
+                                    "commits",
+                                    validation::list(
+                                        "inner",
+                                        [(
+                                            0,
+                                            validation::field(
+                                                "uid",
+                                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                            )
+                                        )]
+                                    )
+                                ),
+                                validation::r#struct(
+                                    "patches",
+                                    validation::list(
+                                        "inner",
+                                        [(
+                                            0,
+                                            validation::r#enum("patch_type", "Unknown patch classification")
+                                        )]
+                                    )
+                                )
+                            ]
+                        ),
+                        validation::r#struct(
+                            "external_references",
+                            validation::list(
+                                "inner",
+                                [(
+                                    0,
+                                    validation::field(
+                                        "external_reference_type",
+                                        "Unknown external reference type"
+                                    )
+                                )]
+                            )
+                        ),
+                        validation::r#struct(
+                            "properties",
+                            validation::list(
+                                "inner",
+                                [(
+                                    0,
+                                    validation::field(
+                                        "value",
+                                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                    )
+                                )]
+                            )
+                        ),
+                        validation::r#struct(
+                            "components",
+                            validation::list(
+                                "inner",
+                                [(
+                                    0,
+                                    validation::field("component_type", "Unknown classification")
+                                )]
+                            )
+                        ),
+                        validation::r#struct(
+                            "evidence",
+                            validation::r#struct(
+                                "licenses",
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::r#enum("expression", "SPDX expression is not valid")
+                                    )]
+                                )
+                            )
+                        )
+                    ]
+                )]
+            )
         );
-        */
     }
 
     fn invalid_component() -> Component {

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -135,7 +135,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "composition",
-                &[(
+                [(
                     0,
                     validation::r#field("aggregate", "Unknown aggregate type")
                 )]

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -139,7 +139,6 @@ mod test {
                     0,
                     validation::r#field("aggregate", "Unknown aggregate type")
                 )]
-                .into()
             ))
         );
     }

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -29,7 +29,7 @@ pub struct Composition {
 }
 
 impl Validate for Composition {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("aggregate", &self.aggregate, validate_aggregate_type)
             .into()
@@ -40,10 +40,10 @@ impl Validate for Composition {
 pub struct Compositions(pub Vec<Composition>);
 
 impl Validate for Compositions {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_list("composition", &self.0, |composition| {
-                composition.validate(version)
+                composition.validate_version(version)
             })
             .into()
     }
@@ -116,7 +116,7 @@ mod test {
             dependencies: Some(vec![BomReference("reference".to_string())]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate(SpecVersion::V1_3);
+        .validate_version(SpecVersion::V1_3);
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -129,7 +129,7 @@ mod test {
             dependencies: Some(vec![BomReference("reference".to_string())]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate(SpecVersion::V1_3);
+        .validate_version(SpecVersion::V1_3);
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -116,9 +116,9 @@ mod test {
             dependencies: Some(vec![BomReference("reference".to_string())]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate_version(SpecVersion::V1_3);
+        .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -129,17 +129,17 @@ mod test {
             dependencies: Some(vec![BomReference("reference".to_string())]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate_version(SpecVersion::V1_3);
+        .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "composition",
                 [(
                     0,
                     validation::r#field("aggregate", "Unknown aggregate type")
                 )]
-            ))
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -31,7 +31,7 @@ pub struct Composition {
 }
 
 impl Validate for Composition {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let aggregate_context = context.with_struct("Composition", "aggregate");
@@ -48,7 +48,7 @@ impl Validate for Composition {
 pub struct Compositions(pub Vec<Composition>);
 
 impl Validate for Compositions {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, composition) in self.0.iter().enumerate() {
@@ -105,7 +105,7 @@ impl AggregateType {
 }
 
 impl Validate for AggregateType {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             AggregateType::UnknownAggregateType(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -29,7 +29,7 @@ pub struct Composition {
 }
 
 impl Validate for Composition {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("aggregate", &self.aggregate, validate_aggregate_type)
             .into()

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -204,26 +204,29 @@ mod test {
                 "inner",
                 [(
                     0,
-                    validation::r#struct(
-                        "ExternalReference",
-                        vec![
-                            validation::field(
-                                "external_reference_type",
-                                "Unknown external reference type"
-                            ),
-                            validation::field("url", "Uri does not conform to RFC 3986"),
-                            validation::list(
-                                "hashes",
-                                [(
-                                    0,
-                                    validation::field(
-                                        "content",
-                                        "HashValue does not match regular expression"
-                                    )
-                                )]
-                            ),
-                        ]
-                    )
+                    vec![
+                        validation::field(
+                            "external_reference_type",
+                            "Unknown external reference type"
+                        ),
+                        validation::field("url", "Uri does not conform to RFC 3986"),
+                        validation::list(
+                            "hashes",
+                            [(
+                                0,
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::field(
+                                            "content",
+                                            "HashValue does not match regular expression"
+                                        )
+                                    )]
+                                )
+                            )]
+                        )
+                    ]
                 )]
             ))
         );

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -55,7 +55,7 @@ impl ExternalReference {
 }
 
 impl Validate for ExternalReference {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let external_reference_type_context =
@@ -86,7 +86,7 @@ impl Validate for ExternalReference {
 pub struct ExternalReferences(pub Vec<ExternalReference>);
 
 impl Validate for ExternalReferences {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, external_reference) in self.0.iter().enumerate() {
@@ -170,7 +170,7 @@ impl ExternalReferenceType {
 }
 
 impl Validate for ExternalReferenceType {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             ExternalReferenceType::UnknownExternalReferenceType(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -202,7 +202,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[(
+                [(
                     0,
                     validation::r#struct(
                         "ExternalReference",
@@ -214,7 +214,7 @@ mod test {
                             validation::field("url", "Uri does not conform to RFC 3986"),
                             validation::list(
                                 "hashes",
-                                &[(
+                                [(
                                     0,
                                     validation::field(
                                         "content",

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::external_models::uri::Uri;
+use crate::external_models::uri::{validate_uri, Uri};
 use crate::models::hash::Hashes;
-use crate::validation::{Validate, ValidationContext, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
 
 use super::bom::SpecVersion;
 
@@ -56,29 +56,15 @@ impl ExternalReference {
 
 impl Validate for ExternalReference {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        let external_reference_type_context =
-            context.with_struct("ExternalReference", "external_reference_type");
-
-        results.push(
-            self.external_reference_type
-                .validate_with_context(external_reference_type_context),
-        );
-
-        let url_context = context.with_struct("ExternalReference", "url");
-
-        results.push(self.url.validate_with_context(url_context));
-
-        if let Some(hashes) = &self.hashes {
-            let context = context.with_struct("ExternalReference", "hashes");
-
-            results.push(hashes.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_field(
+                "external_reference_type",
+                &self.external_reference_type,
+                validate_external_reference_type,
+            )
+            .add_field("url", &self.url, validate_uri)
+            .add_list("hashes", &self.hashes, |hash| hash.validate(version))
+            .into()
     }
 }
 
@@ -87,17 +73,22 @@ pub struct ExternalReferences(pub Vec<ExternalReference>);
 
 impl Validate for ExternalReferences {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, external_reference) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(external_reference.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", &self.0, |reference| reference.validate(version))
+            .into()
     }
+}
+
+pub fn validate_external_reference_type(
+    reference_type: &ExternalReferenceType,
+) -> Result<(), ValidationError> {
+    if matches!(
+        reference_type,
+        ExternalReferenceType::UnknownExternalReferenceType(_)
+    ) {
+        return Err("Unknown external reference type".into());
+    }
+    Ok(())
 }
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_externalReferenceType).
@@ -169,24 +160,12 @@ impl ExternalReferenceType {
     }
 }
 
-impl Validate for ExternalReferenceType {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            ExternalReferenceType::UnknownExternalReferenceType(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Unknown external reference type".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use crate::models::hash::{Hash, HashValue};
-    use crate::validation::{FailureReason, ValidationPathComponent};
+    use crate::{
+        models::hash::{Hash, HashValue},
+        validation,
+    };
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -199,7 +178,7 @@ mod test {
             comment: Some("Comment".to_string()),
             hashes: Some(Hashes(vec![])),
         }])
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -217,49 +196,36 @@ mod test {
                 content: HashValue("invalid hash".to_string()),
             }])),
         }])
-        .validate();
+        .validate_default();
 
         assert_eq!(
-            validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message: "Unknown external reference type".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "ExternalReference".to_string(),
-                                field_name: "external_reference_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "ExternalReference".to_string(),
-                                field_name: "url".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "HashValue does not match regular expression".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "ExternalReference".to_string(),
-                                field_name: "hashes".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Hash".to_string(),
-                                field_name: "content".to_string()
-                            },
-                        ])
-                    },
-                ]
-            }
+            validation_result.errors(),
+            Some(validation::list(
+                "inner",
+                &[(
+                    0,
+                    validation::r#struct(
+                        "ExternalReference",
+                        vec![
+                            validation::field(
+                                "external_reference_type",
+                                "Unknown external reference type"
+                            ),
+                            validation::field("url", "Uri does not conform to RFC 3986"),
+                            validation::list(
+                                "hashes",
+                                &[(
+                                    0,
+                                    validation::field(
+                                        "content",
+                                        "HashValue does not match regular expression"
+                                    )
+                                )]
+                            ),
+                        ]
+                    )
+                )]
+            ))
         );
     }
 }

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -18,9 +18,9 @@
 
 use crate::external_models::uri::Uri;
 use crate::models::hash::Hashes;
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Represents a way to document systems, sites, and information that may be relevant but which are not included with the BOM.
 ///

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -63,7 +63,9 @@ impl Validate for ExternalReference {
                 validate_external_reference_type,
             )
             .add_field("url", &self.url, validate_uri)
-            .add_list("hashes", &self.hashes, |hash| hash.validate_version(version))
+            .add_list("hashes", &self.hashes, |hash| {
+                hash.validate_version(version)
+            })
             .into()
     }
 }
@@ -74,7 +76,9 @@ pub struct ExternalReferences(pub Vec<ExternalReference>);
 impl Validate for ExternalReferences {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |reference| reference.validate_version(version))
+            .add_list("inner", &self.0, |reference| {
+                reference.validate_version(version)
+            })
             .into()
     }
 }
@@ -180,7 +184,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -199,8 +203,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -228,7 +232,7 @@ mod test {
                         )
                     ]
                 )]
-            ))
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -55,7 +55,7 @@ impl ExternalReference {
 }
 
 impl Validate for ExternalReference {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field(
                 "external_reference_type",
@@ -63,7 +63,7 @@ impl Validate for ExternalReference {
                 validate_external_reference_type,
             )
             .add_field("url", &self.url, validate_uri)
-            .add_list("hashes", &self.hashes, |hash| hash.validate(version))
+            .add_list("hashes", &self.hashes, |hash| hash.validate_version(version))
             .into()
     }
 }
@@ -72,9 +72,9 @@ impl Validate for ExternalReference {
 pub struct ExternalReferences(pub Vec<ExternalReference>);
 
 impl Validate for ExternalReferences {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |reference| reference.validate(version))
+            .add_list("inner", &self.0, |reference| reference.validate_version(version))
             .into()
     }
 }
@@ -178,7 +178,7 @@ mod test {
             comment: Some("Comment".to_string()),
             hashes: Some(Hashes(vec![])),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -196,7 +196,7 @@ mod test {
                 content: HashValue("invalid hash".to_string()),
             }])),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -33,7 +33,7 @@ pub struct Hash {
 }
 
 impl Validate for Hash {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let alg_context = context.with_struct("Hash", "alg");
@@ -54,7 +54,7 @@ impl Validate for Hash {
 pub struct Hashes(pub Vec<Hash>);
 
 impl Validate for Hashes {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, hash) in self.0.iter().enumerate() {
@@ -133,7 +133,7 @@ impl HashAlgorithm {
 }
 
 impl Validate for HashAlgorithm {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             HashAlgorithm::UnknownHashAlgorithm(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -151,7 +151,7 @@ impl Validate for HashAlgorithm {
 pub struct HashValue(pub String);
 
 impl Validate for HashValue {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         static HASH_VALUE_REGEX: Lazy<Regex> = Lazy::new(|| {
             Regex::new(
                 r"^([a-fA-F0-9]{32})|([a-fA-F0-9]{40})|([a-fA-F0-9]{64})|([a-fA-F0-9]{96})|([a-fA-F0-9]{128})$",

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -33,7 +33,7 @@ pub struct Hash {
 }
 
 impl Validate for Hash {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("alg", &self.alg, validate_hash_algorithm)
             .add_field("content", &self.content, validate_hash_value)
@@ -45,9 +45,9 @@ impl Validate for Hash {
 pub struct Hashes(pub Vec<Hash>);
 
 impl Validate for Hashes {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |hash| hash.validate(version))
+            .add_list("inner", &self.0, |hash| hash.validate_version(version))
             .into()
     }
 }
@@ -155,7 +155,7 @@ mod test {
             alg: HashAlgorithm::MD5,
             content: HashValue("a3bf1f3d584747e2569483783ddee45b".to_string()),
         }])
-        .validate(SpecVersion::V1_3);
+        .validate_version(SpecVersion::V1_3);
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -166,7 +166,7 @@ mod test {
             alg: HashAlgorithm::UnknownHashAlgorithm("unknown algorithm".to_string()),
             content: HashValue("not a hash".to_string()),
         }])
-        .validate(SpecVersion::V1_3);
+        .validate_version(SpecVersion::V1_3);
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -157,7 +157,7 @@ mod test {
         }])
         .validate_version(SpecVersion::V1_3);
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -169,8 +169,8 @@ mod test {
         .validate_version(SpecVersion::V1_3);
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -179,7 +179,7 @@ mod test {
                         validation::field("content", "HashValue does not match regular expression")
                     ]
                 )]
-            ))
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -144,7 +144,7 @@ pub struct HashValue(pub String);
 
 #[cfg(test)]
 mod test {
-    use crate::validation::{self, ValidationErrorsKind};
+    use crate::validation::{self};
 
     use super::*;
     use pretty_assertions::assert_eq;

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -19,9 +19,9 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Represents the hash of the component
 ///
@@ -34,19 +34,10 @@ pub struct Hash {
 
 impl Validate for Hash {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        let alg_context = context.with_struct("Hash", "alg");
-
-        results.push(self.alg.validate_with_context(alg_context));
-
-        let content_context = context.with_struct("Hash", "content");
-
-        results.push(self.content.validate_with_context(content_context));
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_field("alg", &self.alg, validate_hash_algorithm)
+            .add_field("content", &self.content, validate_hash_value)
+            .into()
     }
 }
 
@@ -55,18 +46,17 @@ pub struct Hashes(pub Vec<Hash>);
 
 impl Validate for Hashes {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, hash) in self.0.iter().enumerate() {
-            let tool_context =
-                context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(hash.validate_with_context(tool_context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", &self.0, |hash| hash.validate(version))
+            .into()
     }
+}
+
+pub fn validate_hash_algorithm(algorithm: &HashAlgorithm) -> Result<(), ValidationError> {
+    if matches!(algorithm, HashAlgorithm::UnknownHashAlgorithm(_)) {
+        return Err(ValidationError::new("Unknown HashAlgorithm"));
+    }
+    Ok(())
 }
 
 /// Represents the algorithm used to create the hash
@@ -132,47 +122,30 @@ impl HashAlgorithm {
     }
 }
 
-impl Validate for HashAlgorithm {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            HashAlgorithm::UnknownHashAlgorithm(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Unknown HashAlgorithm".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
-        }
+pub fn validate_hash_value(value: &HashValue) -> Result<(), ValidationError> {
+    static HASH_VALUE_REGEX: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(
+            r"^([a-fA-F0-9]{32})|([a-fA-F0-9]{40})|([a-fA-F0-9]{64})|([a-fA-F0-9]{96})|([a-fA-F0-9]{128})$",
+        ).expect("Failed to compile regex.")
+    });
+
+    if !HASH_VALUE_REGEX.is_match(&value.0) {
+        return Err(ValidationError::new(
+            "HashValue does not match regular expression",
+        ));
     }
+
+    Ok(())
 }
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashValue)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HashValue(pub String);
 
-impl Validate for HashValue {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        static HASH_VALUE_REGEX: Lazy<Regex> = Lazy::new(|| {
-            Regex::new(
-                r"^([a-fA-F0-9]{32})|([a-fA-F0-9]{40})|([a-fA-F0-9]{64})|([a-fA-F0-9]{96})|([a-fA-F0-9]{128})$",
-            ).expect("Failed to compile regex.")
-        });
-
-        if HASH_VALUE_REGEX.is_match(&self.0) {
-            ValidationResult::Passed
-        } else {
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "HashValue does not match regular expression".to_string(),
-                    context,
-                }],
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
+    use crate::validation::ValidationErrorsKind;
+
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -182,7 +155,7 @@ mod test {
             alg: HashAlgorithm::MD5,
             content: HashValue("a3bf1f3d584747e2569483783ddee45b".to_string()),
         }])
-        .validate();
+        .validate(SpecVersion::V1_3);
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -193,34 +166,21 @@ mod test {
             alg: HashAlgorithm::UnknownHashAlgorithm("unknown algorithm".to_string()),
             content: HashValue("not a hash".to_string()),
         }])
-        .validate();
+        .validate(SpecVersion::V1_3);
 
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message: "Unknown HashAlgorithm".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Hash".to_string(),
-                                field_name: "alg".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "HashValue does not match regular expression".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Hash".to_string(),
-                                field_name: "content".to_string()
-                            }
-                        ])
-                    }
-                ]
-            }
+            Some(&vec![ValidationErrorsKind::list((
+                0,
+                ValidationErrorsKind::r#struct(&[
+                    ("alg", ValidationErrorsKind::field("Unknown HashAlgorithm")),
+                    (
+                        "content",
+                        ValidationErrorsKind::field("HashValue does not match regular expression")
+                    )
+                ])
+            ))
+            .into()])
         );
     }
 }

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -172,7 +172,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[(
+                [(
                     0,
                     vec![
                         validation::field("alg", "Unknown HashAlgorithm"),

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -144,7 +144,7 @@ pub struct HashValue(pub String);
 
 #[cfg(test)]
 mod test {
-    use crate::validation::ValidationErrorsKind;
+    use crate::validation::{self, ValidationErrorsKind};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -169,18 +169,17 @@ mod test {
         .validate(SpecVersion::V1_3);
 
         assert_eq!(
-            validation_result,
-            Some(&vec![ValidationErrorsKind::list((
-                0,
-                ValidationErrorsKind::r#struct(&[
-                    ("alg", ValidationErrorsKind::field("Unknown HashAlgorithm")),
-                    (
-                        "content",
-                        ValidationErrorsKind::field("HashValue does not match regular expression")
-                    )
-                ])
+            validation_result.errors(),
+            Some(validation::list(
+                "inner",
+                &[(
+                    0,
+                    vec![
+                        validation::field("alg", "Unknown HashAlgorithm"),
+                        validation::field("content", "HashValue does not match regular expression")
+                    ]
+                )]
             ))
-            .into()])
         );
     }
 }

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -33,7 +33,7 @@ pub struct Hash {
 }
 
 impl Validate for Hash {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("alg", &self.alg, validate_hash_algorithm)
             .add_field("content", &self.content, validate_hash_value)

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -54,10 +54,10 @@ impl Validate for LicenseChoice {
 
         match self {
             LicenseChoice::License(license) => {
-                context = context.add_struct("license", license, version);
+                context.add_struct("license", license, version);
             }
             LicenseChoice::Expression(expression) => {
-                context = context.add_enum("expression", expression, validate_spdx_expression);
+                context.add_enum("expression", expression, validate_spdx_expression);
             }
         }
 
@@ -172,7 +172,7 @@ mod test {
         ))])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -110,11 +110,7 @@ impl License {
 impl Validate for License {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_field(
-                "license_identifier",
-                &self.license_identifier,
-                validate_license_identifier,
-            )
+            .add_struct("license_identifier", &self.license_identifier, version)
             .add_struct_option("text", self.text.as_ref(), version)
             .add_field_option("url", self.url.as_ref(), validate_uri)
             .into()
@@ -154,7 +150,7 @@ impl Validate for LicenseIdentifier {
                 .add_enum("Name", name, validate_normalized_string)
                 .into(),
             LicenseIdentifier::SpdxId(id) => ValidationContext::new()
-                .add_field("SpdxId", id, validate_spdx_identifier)
+                .add_enum("SpdxId", id, validate_spdx_identifier)
                 .into(),
         }
     }
@@ -162,6 +158,8 @@ impl Validate for LicenseIdentifier {
 
 #[cfg(test)]
 mod test {
+    use crate::validation;
+
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -186,30 +184,25 @@ mod test {
         })])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                        .to_string(),
-                    context: ValidationContext(vec![
-                        ValidationPathComponent::Array { index: 0 },
-                        ValidationPathComponent::EnumVariant {
-                            variant_name: "License".to_string()
-                        },
-                        ValidationPathComponent::Struct {
-                            struct_name: "License".to_string(),
-                            field_name: "license_identifier".to_string(),
-                        },
-                        ValidationPathComponent::EnumVariant {
-                            variant_name: "Name".to_string()
-                        },
-                    ])
-                }]
-            }
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    validation::r#struct(
+                        "license",
+                        validation::r#struct(
+                            "license_identifier",
+                            validation::r#enum(
+                                "Name",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            )
+                        )
+                    )
+                )]
+            )
         );
-        */
     }
 
     #[test]
@@ -221,29 +214,22 @@ mod test {
         })])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "SPDX identifier is not valid".to_string(),
-                    context: ValidationContext(vec![
-                        ValidationPathComponent::Array { index: 0 },
-                        ValidationPathComponent::EnumVariant {
-                            variant_name: "License".to_string()
-                        },
-                        ValidationPathComponent::Struct {
-                            struct_name: "License".to_string(),
-                            field_name: "license_identifier".to_string(),
-                        },
-                        ValidationPathComponent::EnumVariant {
-                            variant_name: "SpdxId".to_string()
-                        },
-                    ])
-                }]
-            }
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    validation::r#struct(
+                        "license",
+                        validation::r#struct(
+                            "license_identifier",
+                            validation::r#enum("SpdxId", "SPDX identifier is not valid")
+                        )
+                    )
+                )]
+            )
         );
-        */
     }
 
     #[test]
@@ -253,22 +239,16 @@ mod test {
         ))])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "SPDX expression is not valid".to_string(),
-                    context: ValidationContext(vec![
-                        ValidationPathComponent::Array { index: 0 },
-                        ValidationPathComponent::EnumVariant {
-                            variant_name: "Expression".to_string()
-                        }
-                    ])
-                }]
-            }
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    validation::r#enum("expression", "SPDX expression is not valid")
+                )],
+            )
         );
-        */
     }
 
     #[test]
@@ -296,49 +276,34 @@ mod test {
         ])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 1 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "License".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "License".to_string(),
-                                field_name: "license_identifier".to_string(),
-                            },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "SPDX identifier is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 2 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "License".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "License".to_string(),
-                                field_name: "license_identifier".to_string(),
-                            },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "SpdxId".to_string()
-                            },
-                        ])
-                    }
-                ]
-            }
+            validation::list(
+                "inner",
+                [(
+                    1,
+                    validation::r#struct(
+                        "license",
+                        validation::r#struct(
+                            "license_identifier",
+                            validation::r#enum(
+                                "Name",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            )
+                        )
+                    )
+                ), (
+                    2,
+                    validation::r#struct(
+                        "license",
+                        validation::r#struct(
+                            "license_identifier",
+                            validation::r#enum("SpdxId", "SPDX identifier is not valid")
+                        )
+                    )
+                )]
+            )
         );
-        */
     }
 
     #[test]
@@ -350,32 +315,21 @@ mod test {
         ])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message: "SPDX expression is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 1 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Expression".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "SPDX expression is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 2 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Expression".to_string()
-                            }
-                        ])
-                    }
+            validation::list(
+                "inner",
+                [
+                    (
+                        1,
+                        validation::r#enum("expression", "SPDX expression is not valid"),
+                    ),
+                    (
+                        2,
+                        validation::r#enum("expression", "SPDX expression is not valid"),
+                    )
                 ]
-            }
+            )
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -54,10 +54,10 @@ impl Validate for LicenseChoice {
 
         match self {
             LicenseChoice::License(license) => {
-                context.add_struct("license", license, version);
+                context = context.add_struct("license", license, version);
             }
             LicenseChoice::Expression(expression) => {
-                context.add_enum("expression", expression, validate_spdx_expression);
+                context = context.add_enum("expression", expression, validate_spdx_expression);
             }
         }
 
@@ -148,17 +148,15 @@ pub enum LicenseIdentifier {
 }
 
 impl Validate for LicenseIdentifier {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut context = ValidationContext::new();
+    fn validate(&self, _version: SpecVersion) -> ValidationResult {
         match self {
-            LicenseIdentifier::Name(name) => {
-                context.add_enum("Name", name, validate_normalized_string);
-            }
-            LicenseIdentifier::SpdxId(id) => {
-                context.add_field("SpdxId", id, validate_spdx_identifier);
-            }
+            LicenseIdentifier::Name(name) => ValidationContext::new()
+                .add_enum("Name", name, validate_normalized_string)
+                .into(),
+            LicenseIdentifier::SpdxId(id) => ValidationContext::new()
+                .add_field("SpdxId", id, validate_spdx_identifier)
+                .into(),
         }
-        context.into()
     }
 }
 

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -49,7 +49,7 @@ impl LicenseChoice {
 }
 
 impl Validate for LicenseChoice {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         let mut context = ValidationContext::new();
 
         match self {
@@ -108,7 +108,7 @@ impl License {
 }
 
 impl Validate for License {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field(
                 "license_identifier",
@@ -125,9 +125,9 @@ impl Validate for License {
 pub struct Licenses(pub Vec<LicenseChoice>);
 
 impl Validate for Licenses {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |choice| choice.validate(version))
+            .add_list("inner", &self.0, |choice| choice.validate_version(version))
             .into()
     }
 }
@@ -148,7 +148,7 @@ pub enum LicenseIdentifier {
 }
 
 impl Validate for LicenseIdentifier {
-    fn validate(&self, _version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         match self {
             LicenseIdentifier::Name(name) => ValidationContext::new()
                 .add_enum("Name", name, validate_normalized_string)
@@ -170,7 +170,7 @@ mod test {
         let validation_result = Licenses(vec![LicenseChoice::Expression(SpdxExpression(
             "MIT OR Apache-2.0".to_string(),
         ))])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -184,7 +184,7 @@ mod test {
             text: None,
             url: None,
         })])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(
@@ -219,7 +219,7 @@ mod test {
             text: None,
             url: None,
         })])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(
@@ -251,7 +251,7 @@ mod test {
         let validation_result = Licenses(vec![LicenseChoice::Expression(SpdxExpression(
             "MIT OR".to_string(),
         ))])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(
@@ -294,7 +294,7 @@ mod test {
                 url: None,
             }),
         ])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(
@@ -348,7 +348,7 @@ mod test {
             LicenseChoice::Expression(SpdxExpression("MIT OR".to_string())),
             LicenseChoice::Expression(SpdxExpression("MIT OR".to_string())),
         ])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -43,7 +43,7 @@ impl LicenseChoice {
 }
 
 impl Validate for LicenseChoice {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         match self {
@@ -116,7 +116,7 @@ impl License {
 }
 
 impl Validate for License {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let license_identifier_context = context.with_struct("License", "license_identifier");
@@ -148,7 +148,7 @@ impl Validate for License {
 pub struct Licenses(pub Vec<LicenseChoice>);
 
 impl Validate for Licenses {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, license_choice) in self.0.iter().enumerate() {
@@ -172,7 +172,7 @@ pub enum LicenseIdentifier {
 }
 
 impl Validate for LicenseIdentifier {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             LicenseIdentifier::Name(name) => {
                 let name_context =

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -102,6 +102,7 @@ mod test {
         models::{
             component::Classification, license::LicenseChoice, property::Property, tool::Tool,
         },
+        validation,
     };
 
     use super::*;
@@ -232,125 +233,85 @@ mod test {
         }
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message: "DateTime does not conform to ISO 8601".to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "Metadata".to_string(),
-                            field_name: "timestamp".to_string()
-                        }])
-                    },
-                    FailureReason {
-                        message:
+            vec![
+                validation::field("timestamp", "DateTime does not conform to ISO 8601"),
+                validation::list(
+                    "tools",
+                    [(
+                        0,
+                        validation::list(
+                            "inner",
+                            [(
+                                0,
+                                validation::field(
+                                    "vendor",
+                                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                )
+                            )]
+                        )
+                    )]
+                ),
+                validation::list(
+                    "authors",
+                    [(
+                        0,
+                        validation::field(
+                            "name",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "tools".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Tool".to_string(),
-                                field_name: "vendor".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "authors".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalContact".to_string(),
-                                field_name: "name".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown classification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "component".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Component".to_string(),
-                                field_name: "component_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "manufacture".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "name".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "supplier".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "name".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "SPDX expression is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "licenses".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Expression".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "Metadata".to_string(),
-                                field_name: "properties".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Property".to_string(),
-                                field_name: "value".to_string()
-                            }
-                        ])
-                    },
-                ]
-            }
+                        )
+                    )]
+                ),
+                validation::r#struct(
+                    "component",
+                    validation::field("component_type", "Unknown classification")
+                ),
+                validation::r#struct(
+                    "manufacture",
+                    validation::field(
+                        "name",
+                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                    )
+                ),
+                validation::r#struct(
+                    "supplier",
+                    validation::field(
+                        "name",
+                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                    )
+                ),
+                validation::list(
+                    "licenses",
+                    [(
+                        0,
+                        validation::list(
+                            "inner",
+                            [(
+                                0,
+                                validation::r#enum("expression", "SPDX expression is not valid")
+                            )]
+                        )
+                    )]
+                ),
+                validation::list(
+                    "properties",
+                    [(
+                        0,
+                        validation::list(
+                            "inner",
+                            [(
+                                0,
+                                validation::field(
+                                    "value",
+                                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                )
+                            )]
+                        )
+                    )]
+                )
+            ]
+            .into()
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -67,23 +67,23 @@ impl Metadata {
 }
 
 impl Validate for Metadata {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("timestamp", self.timestamp.as_ref(), validate_date_time)
             .add_list("tools", self.tools.as_ref(), |tools| {
-                tools.validate(version)
+                tools.validate_version(version)
             })
             .add_list_option("authors", self.authors.as_ref(), |author| {
-                author.validate(version)
+                author.validate_version(version)
             })
             .add_struct_option("component", self.component.as_ref(), version)
             .add_struct_option("manufacture", self.manufacture.as_ref(), version)
             .add_struct_option("supplier", self.supplier.as_ref(), version)
             .add_list("licenses", self.licenses.as_ref(), |license| {
-                license.validate(version)
+                license.validate_version(version)
             })
             .add_list("properties", self.properties.as_ref(), |property| {
-                property.validate(version)
+                property.validate_version(version)
             })
             .into()
     }
@@ -166,7 +166,7 @@ mod test {
                 value: NormalizedString::new("value"),
             }])),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -230,7 +230,7 @@ mod test {
                 value: NormalizedString("invalid\tvalue".to_string()),
             }])),
         }
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -64,7 +64,7 @@ impl Metadata {
 }
 
 impl Validate for Metadata {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -150,13 +150,13 @@ mod test {
             }),
             manufacture: Some(OrganizationalEntity {
                 name: Some(NormalizedString::new("name")),
-                url: vec![],
-                contact: vec![],
+                url: None,
+                contact: None,
             }),
             supplier: Some(OrganizationalEntity {
                 name: Some(NormalizedString::new("name")),
-                url: vec![],
-                contact: vec![],
+                url: None,
+                contact: None,
             }),
             licenses: Some(Licenses(vec![LicenseChoice::Expression(SpdxExpression(
                 "MIT".to_string(),
@@ -214,13 +214,13 @@ mod test {
             }),
             manufacture: Some(OrganizationalEntity {
                 name: Some(NormalizedString("invalid\tname".to_string())),
-                url: vec![],
-                contact: vec![],
+                url: None,
+                contact: None,
             }),
             supplier: Some(OrganizationalEntity {
                 name: Some(NormalizedString("invalid\tname".to_string())),
-                url: vec![],
-                contact: vec![],
+                url: None,
+                contact: None,
             }),
             licenses: Some(Licenses(vec![LicenseChoice::Expression(SpdxExpression(
                 "invalid license".to_string(),

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -19,12 +19,15 @@
 use thiserror::Error;
 
 use crate::external_models::date_time::{DateTime, DateTimeError};
+use crate::external_models::validate_date_time;
 use crate::models::component::Component;
 use crate::models::license::Licenses;
 use crate::models::organization::{OrganizationalContact, OrganizationalEntity};
 use crate::models::property::Properties;
 use crate::models::tool::Tools;
-use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Represents additional information about a BOM
 ///
@@ -65,6 +68,11 @@ impl Metadata {
 
 impl Validate for Metadata {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
+        ValidationContext::new()
+            .add_field("timestamp", self.timestamp.as_deref(), validate_date_time)
+            .into()
+
+        /*
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(timestamp) = &self.timestamp {
@@ -125,6 +133,7 @@ impl Validate for Metadata {
         results
             .into_iter()
             .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        */
     }
 }
 

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -168,7 +168,7 @@ mod test {
         }
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -48,7 +48,7 @@ impl OrganizationalContact {
 }
 
 impl Validate for OrganizationalContact {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut name_result = ValidationResult::default();
         if let Some(name) = &self.name {
             let name_context = context.with_struct("OrganizationalContact", "name");
@@ -85,7 +85,7 @@ pub struct OrganizationalEntity {
 }
 
 impl Validate for OrganizationalEntity {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -53,7 +53,7 @@ impl OrganizationalContact {
 }
 
 impl Validate for OrganizationalContact {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("email", self.email.as_ref(), validate_normalized_string)

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -102,7 +102,7 @@ mod test {
             phone: None,
         };
         let actual = contact.validate();
-        assert_eq!(actual, ValidationResult::Passed);
+        assert!(actual.passed());
     }
 
     #[test]
@@ -115,11 +115,11 @@ mod test {
         let actual = contact.validate();
 
         assert_eq!(
-            actual.errors(),
-            Some(validation::field(
+            actual,
+            validation::field(
                 "name",
                 "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-            ))
+            )
         );
     }
 

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -53,7 +53,7 @@ impl OrganizationalContact {
 }
 
 impl Validate for OrganizationalContact {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("email", self.email.as_ref(), validate_normalized_string)
@@ -73,12 +73,12 @@ pub struct OrganizationalEntity {
 }
 
 impl Validate for OrganizationalEntity {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_list_option("url", self.url.as_ref(), validate_uri)
             .add_list_option("contact", self.contact.as_ref(), |contact| {
-                contact.validate(version)
+                contact.validate_version(version)
             })
             .into()
     }
@@ -101,7 +101,7 @@ mod test {
             email: None,
             phone: None,
         };
-        let actual = contact.validate_default();
+        let actual = contact.validate();
         assert_eq!(actual, ValidationResult::Passed);
     }
 
@@ -112,7 +112,7 @@ mod test {
             email: None,
             phone: None,
         };
-        let actual = contact.validate_default();
+        let actual = contact.validate();
 
         assert_eq!(
             actual.errors(),
@@ -134,7 +134,7 @@ mod test {
                 "invalid\tphone".to_string(),
             )),
         };
-        let actual = contact.validate_default();
+        let actual = contact.validate();
 
         /*
         assert_eq!(
@@ -181,7 +181,7 @@ mod test {
             url: None,
             contact: None,
         };
-        let actual = entity.validate_default();
+        let actual = entity.validate();
 
         /*
         assert_eq!(
@@ -211,7 +211,7 @@ mod test {
                 phone: None,
             }]),
         };
-        let actual = entity.validate_default();
+        let actual = entity.validate();
         /*
         assert_eq!(
             actual,

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -178,8 +178,8 @@ mod test {
     fn it_should_validate_an_invalid_entity_as_failed() {
         let entity = OrganizationalEntity {
             name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
-            url: vec![],
-            contact: vec![],
+            url: None,
+            contact: None,
         };
         let actual = entity.validate_default();
 
@@ -204,12 +204,12 @@ mod test {
     fn it_should_validate_an_entity_with_multiple_validation_issues_as_failed() {
         let entity = OrganizationalEntity {
             name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
-            url: vec![Uri("invalid uri".to_string())],
-            contact: vec![OrganizationalContact {
+            url: Some(vec![Uri("invalid uri".to_string())]),
+            contact: Some(vec![OrganizationalContact {
                 name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
                 email: None,
                 phone: None,
-            }],
+            }]),
         };
         let actual = entity.validate_default();
         /*

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -90,7 +90,7 @@ mod test {
 
     use crate::{
         models::organization::{OrganizationalContact, OrganizationalEntity},
-        prelude::{NormalizedString, Uri, Validate, ValidationResult},
+        prelude::{NormalizedString, Uri, Validate},
         validation,
     };
 
@@ -136,42 +136,24 @@ mod test {
         };
         let actual = contact.validate();
 
-        /*
         assert_eq!(
             actual,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "OrganizationalContact".to_string(),
-                            field_name: "name".to_string()
-                        }])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "OrganizationalContact".to_string(),
-                            field_name: "email".to_string()
-                        }])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "OrganizationalContact".to_string(),
-                            field_name: "phone".to_string()
-                        }])
-                    }
-                ]
-            }
-        )
-        */
+            vec![
+                validation::field(
+                    "name",
+                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                ),
+                validation::field(
+                    "email",
+                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                ),
+                validation::field(
+                    "phone",
+                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                )
+            ]
+            .into()
+        );
     }
 
     #[test]
@@ -183,21 +165,13 @@ mod test {
         };
         let actual = entity.validate();
 
-        /*
         assert_eq!(
             actual,
-            ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                        .to_string(),
-                    context: ValidationContext(vec![ValidationPathComponent::Struct {
-                        struct_name: "OrganizationalEntity".to_string(),
-                        field_name: "name".to_string()
-                    }])
-                }]
-            }
-        )
-        */
+            validation::field(
+                "name",
+                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+            )
+        );
     }
 
     #[test]
@@ -212,49 +186,33 @@ mod test {
             }]),
         };
         let actual = entity.validate();
-        /*
+
         assert_eq!(
             actual,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
+            vec![
+                validation::field(
+                    "name",
+                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                ),
+                validation::list(
+                    "url",
+                    [(
+                        0,
+                        validation::custom("", ["Uri does not conform to RFC 3986"])
+                    )]
+                ),
+                validation::list(
+                    "contact",
+                    [(
+                        0,
+                        validation::field(
+                            "name",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "OrganizationalEntity".to_string(),
-                            field_name: "name".to_string()
-                        }])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "url".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "contact".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalContact".to_string(),
-                                field_name: "name".to_string()
-                            }
-                        ])
-                    }
-                ]
-            }
-        )
-        */
+                        )
+                    )]
+                )
+            ]
+            .into()
+        );
     }
 }

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -104,7 +104,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "Property",
-                &[(
+                [(
                     0,
                     validation::field(
                         "value",

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -30,7 +30,7 @@ use crate::{
 pub struct Properties(pub Vec<Property>);
 
 impl Validate for Properties {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, property) in self.0.iter().enumerate() {
@@ -70,7 +70,7 @@ impl Property {
 }
 
 impl Validate for Property {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let value_context = context.with_struct("Property", "value");

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -32,9 +32,9 @@ use super::bom::SpecVersion;
 pub struct Properties(pub Vec<Property>);
 
 impl Validate for Properties {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |property| property.validate(version))
+            .add_list("inner", &self.0, |property| property.validate_version(version))
             .into()
     }
 }
@@ -64,7 +64,7 @@ impl Property {
 }
 
 impl Validate for Property {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("value", &self.value, validate_normalized_string)
             .into()
@@ -87,7 +87,7 @@ mod test {
             name: "property name".to_string(),
             value: NormalizedString("property value".to_string()),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -98,7 +98,7 @@ mod test {
             name: "property name".to_string(),
             value: NormalizedString("spaces and \ttabs".to_string()),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -66,7 +66,7 @@ impl Property {
 }
 
 impl Validate for Property {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("value", &self.value, validate_normalized_string)
             .into()

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -79,7 +79,7 @@ mod test {
         validation,
     };
     use pretty_assertions::assert_eq;
-    use validation::ValidationResult;
+    use validation::{Validate, ValidationResult};
 
     #[test]
     fn it_should_pass_validation() {

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -103,7 +103,7 @@ mod test {
         assert_eq!(
             validation_result.errors(),
             Some(validation::list(
-                "Property",
+                "inner",
                 [(
                     0,
                     validation::field(

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -34,7 +34,9 @@ pub struct Properties(pub Vec<Property>);
 impl Validate for Properties {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |property| property.validate_version(version))
+            .add_list("inner", &self.0, |property| {
+                property.validate_version(version)
+            })
             .into()
     }
 }
@@ -79,7 +81,7 @@ mod test {
         validation,
     };
     use pretty_assertions::assert_eq;
-    use validation::{Validate, ValidationResult};
+    use validation::Validate;
 
     #[test]
     fn it_should_pass_validation() {
@@ -89,7 +91,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -101,8 +103,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -111,7 +113,7 @@ mod test {
                         "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
                     )
                 )]
-            )),
+            ),
         );
     }
 }

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -17,6 +17,7 @@
  */
 
 use crate::external_models::normalized_string::validate_normalized_string;
+use crate::external_models::uri::validate_uri;
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
 use crate::models::external_reference::ExternalReferences;
 use crate::models::license::Licenses;
@@ -90,9 +91,7 @@ impl Validate for Service {
                 self.description.as_ref(),
                 validate_normalized_string,
             )
-            .add_list_option("endpoints", self.endpoints.as_ref(), |e| {
-                e.validate(version)
-            })
+            .add_list_option("endpoints", self.endpoints.as_ref(), validate_uri)
             .add_list_option("data", self.data.as_ref(), |data| data.validate(version))
             .add_struct_option("licenses", self.licenses.as_ref(), version)
             .add_struct_option(

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -250,7 +250,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -80,7 +80,7 @@ impl Service {
 }
 
 impl Validate for Service {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option("provider", self.provider.as_ref(), version)
             .add_field_option("group", self.group.as_ref(), validate_normalized_string)
@@ -92,7 +92,7 @@ impl Validate for Service {
                 validate_normalized_string,
             )
             .add_list_option("endpoints", self.endpoints.as_ref(), validate_uri)
-            .add_list_option("data", self.data.as_ref(), |data| data.validate(version))
+            .add_list_option("data", self.data.as_ref(), |data| data.validate_version(version))
             .add_struct_option("licenses", self.licenses.as_ref(), version)
             .add_struct_option(
                 "external_references",
@@ -109,9 +109,9 @@ impl Validate for Service {
 pub struct Services(pub Vec<Service>);
 
 impl Validate for Services {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |service| service.validate(version))
+            .add_list("inner", &self.0, |service| service.validate_version(version))
             .into()
     }
 }
@@ -133,7 +133,7 @@ pub struct DataClassification {
 }
 
 impl Validate for DataClassification {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_enum("flow", &self.flow, validate_data_flow_type)
             .into()
@@ -248,7 +248,7 @@ mod test {
             services: Some(Services(vec![])),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -307,7 +307,7 @@ mod test {
             }])),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -138,7 +138,6 @@ pub struct DataClassification {
 
 impl Validate for DataClassification {
     fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
-        // TODO implement
         ValidationContext::new()
             .add_enum("flow", &self.flow, validate_data_flow_type)
             .add_enum(

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -21,9 +21,7 @@ use crate::models::external_reference::ExternalReferences;
 use crate::models::license::Licenses;
 use crate::models::organization::OrganizationalEntity;
 use crate::models::property::Properties;
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationResult};
 
 use super::signature::Signature;
 

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -79,7 +79,7 @@ impl Service {
 }
 
 impl Validate for Service {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(provider) = &self.provider {
@@ -170,7 +170,7 @@ impl Validate for Service {
 pub struct Services(pub Vec<Service>);
 
 impl Validate for Services {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, service) in self.0.iter().enumerate() {
@@ -194,7 +194,7 @@ pub struct DataClassification {
 }
 
 impl Validate for DataClassification {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let flow_context = context.with_struct("DataClassification", "flow");
@@ -253,7 +253,7 @@ impl DataFlowType {
 }
 
 impl Validate for DataFlowType {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             DataFlowType::UnknownDataFlow(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -92,7 +92,9 @@ impl Validate for Service {
                 validate_normalized_string,
             )
             .add_list_option("endpoints", self.endpoints.as_ref(), validate_uri)
-            .add_list_option("data", self.data.as_ref(), |data| data.validate_version(version))
+            .add_list_option("data", self.data.as_ref(), |data| {
+                data.validate_version(version)
+            })
             .add_struct_option("licenses", self.licenses.as_ref(), version)
             .add_struct_option(
                 "external_references",
@@ -111,7 +113,9 @@ pub struct Services(pub Vec<Service>);
 impl Validate for Services {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |service| service.validate_version(version))
+            .add_list("inner", &self.0, |service| {
+                service.validate_version(version)
+            })
             .into()
     }
 }
@@ -137,26 +141,12 @@ impl Validate for DataClassification {
         // TODO implement
         ValidationContext::new()
             .add_enum("flow", &self.flow, validate_data_flow_type)
+            .add_enum(
+                "classification",
+                &self.classification,
+                validate_normalized_string,
+            )
             .into()
-
-        /*
-        let mut results: Vec<ValidationResult> = vec![];
-
-        let flow_context = context.with_struct("DataClassification", "flow");
-
-        results.push(self.flow.validate_with_context(flow_context));
-
-        let classification_context = context.with_struct("DataClassification", "classification");
-
-        results.push(
-            self.classification
-                .validate_with_context(classification_context),
-        );
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-        */
     }
 }
 
@@ -208,6 +198,7 @@ mod test {
             property::Property,
             signature::Algorithm,
         },
+        validation,
     };
 
     use super::*;
@@ -310,184 +301,116 @@ mod test {
         }])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "provider".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "group".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "version".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "description".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "endpoints".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown data flow type".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "data".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "DataClassification".to_string(),
-                                field_name: "flow".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "data".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "DataClassification".to_string(),
-                                field_name: "classification".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "SPDX expression is not valid".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "licenses".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::EnumVariant {
-                                variant_name: "Expression".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Unknown external reference type".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "external_references".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "ExternalReference".to_string(),
-                                field_name: "external_reference_type".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "properties".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Property".to_string(),
-                                field_name: "value".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "services".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Service".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                ]
-            }
+            vec![
+                validation::list(
+                    "inner",
+                    [(
+                        0,
+                        vec![
+                            validation::r#struct(
+                                "provider",
+                                validation::field(
+                                    "name",
+                                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                )
+                            ),
+                            validation::field(
+                                "group",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            ),
+                            validation::field(
+                                "name",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            ),
+                            validation::field(
+                                "version",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            ),
+                            validation::field(
+                                "description",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            ),
+                            validation::list(
+                                "endpoints",
+                                [(
+                                    0,
+                                    validation::custom("", ["Uri does not conform to RFC 3986"])
+                                )]
+                            ),
+                            validation::list(
+                                "data",
+                                [(
+                                    0,
+                                    vec![
+                                        validation::r#enum(
+                                            "flow",
+                                            "Unknown data flow type"
+                                        ),
+                                        validation::r#enum(
+                                            "classification",
+                                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                        )
+                                    ]
+                                )]
+                            ),
+                            validation::r#struct(
+                                "licenses",
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::r#enum(
+                                            "expression",
+                                            "SPDX expression is not valid"
+                                        )
+                                    )]
+                                )
+                            ),
+                            validation::r#struct(
+                                "external_references",
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::field(
+                                            "external_reference_type",
+                                            "Unknown external reference type"
+                                        )
+                                    )]
+                                )
+                            ),
+                            validation::r#struct(
+                                "properties",
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::field(
+                                            "value",
+                                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                        )
+                                    )]
+                                )
+                            ),
+                            validation::r#struct(
+                                "services",
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::field(
+                                            "name",
+                                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                        )
+                                    )]
+                                )
+                            )
+                        ]
+                    )]
+                )
+            ].into()
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -133,7 +133,8 @@ pub struct DataClassification {
 }
 
 impl Validate for DataClassification {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
+        // TODO implement
         ValidationContext::new()
             .add_enum("flow", &self.flow, validate_data_flow_type)
             .into()

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -109,7 +109,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[(
+                [(
                     0,
                     validation::field(
                         "vendor",
@@ -148,22 +148,20 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[
-                    (
-                        1,
-                        validation::field(
-                            "vendor",
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                        )
-                    ),
-                    (
-                        2,
-                        validation::field(
-                            "name",
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                        )
+                [(
+                    1,
+                    validation::field(
+                        "vendor",
+                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
                     )
-                ]
+                ),
+                (
+                    2,
+                    validation::field(
+                        "name",
+                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                    )
+                )]
             ))
         );
     }

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -49,7 +49,7 @@ impl Tool {
 }
 
 impl Validate for Tool {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vendor) = &self.vendor {
@@ -86,7 +86,7 @@ impl Validate for Tool {
 pub struct Tools(pub Vec<Tool>);
 
 impl Validate for Tools {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, tool) in self.0.iter().enumerate() {

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -56,7 +56,9 @@ impl Validate for Tool {
             .add_field_option("vendor", self.vendor.as_ref(), validate_normalized_string)
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("version", self.version.as_ref(), validate_normalized_string)
-            .add_list("hashes", &self.hashes, |hashes| hashes.validate_version(version))
+            .add_list("hashes", &self.hashes, |hashes| {
+                hashes.validate_version(version)
+            })
             .into()
     }
 }
@@ -92,7 +94,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -106,8 +108,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -116,7 +118,7 @@ mod test {
                         "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
                     )
                 )]
-            ))
+            )
         );
     }
 
@@ -145,24 +147,26 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
-                [(
-                    1,
-                    validation::field(
-                        "vendor",
-                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                [
+                    (
+                        1,
+                        validation::field(
+                            "vendor",
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                        )
+                    ),
+                    (
+                        2,
+                        validation::field(
+                            "name",
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                        )
                     )
-                ),
-                (
-                    2,
-                    validation::field(
-                        "name",
-                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                    )
-                )]
-            ))
+                ]
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -51,12 +51,12 @@ impl Tool {
 }
 
 impl Validate for Tool {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("vendor", self.vendor.as_ref(), validate_normalized_string)
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("version", self.version.as_ref(), validate_normalized_string)
-            .add_list("hashes", &self.hashes, |hashes| hashes.validate(version))
+            .add_list("hashes", &self.hashes, |hashes| hashes.validate_version(version))
             .into()
     }
 }
@@ -65,9 +65,9 @@ impl Validate for Tool {
 pub struct Tools(pub Vec<Tool>);
 
 impl Validate for Tools {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |tool| tool.validate(version))
+            .add_list("inner", &self.0, |tool| tool.validate_version(version))
             .into()
     }
 }
@@ -90,7 +90,7 @@ mod test {
             version: None,
             hashes: None,
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -103,7 +103,7 @@ mod test {
             version: None,
             hashes: None,
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),
@@ -142,7 +142,7 @@ mod test {
                 hashes: None,
             },
         ])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -80,7 +80,7 @@ mod test {
 
     use crate::{
         models::tool::{Tool, Tools},
-        prelude::{NormalizedString, Validate, ValidationResult},
+        prelude::{NormalizedString, Validate},
         validation,
     };
 

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -85,7 +85,7 @@ impl Vulnerability {
 }
 
 impl Validate for Vulnerability {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(id) = &self.id {
@@ -176,7 +176,7 @@ impl Validate for Vulnerability {
 pub struct Vulnerabilities(pub Vec<Vulnerability>);
 
 impl Validate for Vulnerabilities {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability) in self.0.iter().enumerate() {

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -113,44 +113,24 @@ impl Validate for Vulnerability {
             .add_field_option("created", self.created.as_ref(), validate_date_time)
             .add_field_option("published", self.published.as_ref(), validate_date_time)
             .add_field_option("updated", self.updated.as_ref(), validate_date_time)
+            .add_struct_option(
+                "vulnerability_credits",
+                self.vulnerability_credits.as_ref(),
+                version,
+            )
+            .add_struct_option("tools", self.tools.as_ref(), version)
+            .add_struct_option(
+                "vulnerability_analysis",
+                self.vulnerability_analysis.as_ref(),
+                version,
+            )
+            .add_struct_option(
+                "vulnerability_targets",
+                self.vulnerability_targets.as_ref(),
+                version,
+            )
+            .add_struct_option("properties", self.properties.as_ref(), version)
             .into()
-
-        /*
-
-        if let Some(vulnerability_credits) = &self.vulnerability_credits {
-            let context = context.with_struct("Vulnerability", "vulnerability_credits");
-
-            results.push(vulnerability_credits.validate_with_context(context));
-        }
-
-        if let Some(tools) = &self.tools {
-            let context = context.with_struct("Vulnerability", "tools");
-
-            results.push(tools.validate_with_context(context));
-        }
-
-        if let Some(vulnerability_analysis) = &self.vulnerability_analysis {
-            let context = context.with_struct("Vulnerability", "vulnerability_analysis");
-
-            results.push(vulnerability_analysis.validate_with_context(context));
-        }
-
-        if let Some(vulnerability_targets) = &self.vulnerability_targets {
-            let context = context.with_struct("Vulnerability", "vulnerability_targets");
-
-            results.push(vulnerability_targets.validate_with_context(context));
-        }
-
-        if let Some(properties) = &self.properties {
-            let context = context.with_struct("Vulnerability", "properties");
-
-            results.push(properties.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-            */
     }
 }
 
@@ -170,6 +150,8 @@ impl Validate for Vulnerabilities {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
+
     use crate::{
         external_models::uri::Uri,
         models::{
@@ -183,6 +165,7 @@ mod test {
             vulnerability_reference::VulnerabilityReference,
             vulnerability_target::{Status, Version, VersionRange, Versions, VulnerabilityTarget},
         },
+        validation,
     };
 
     #[test]
@@ -317,227 +300,117 @@ mod test {
         }])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "id".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_source".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilitySource".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_source".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilitySource".to_string(),
-                                field_name: "url".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_references".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityReference".to_string(),
-                                field_name: "id".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Undefined severity".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_ratings".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityRating".to_string(),
-                                field_name: "severity".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_ratings".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityRating".to_string(),
-                                field_name: "vector".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "advisories".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Advisory".to_string(),
-                                field_name: "title".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "advisories".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Advisory".to_string(),
-                                field_name: "url".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "DateTime does not conform to ISO 8601".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "created".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "DateTime does not conform to ISO 8601".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "published".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "DateTime does not conform to ISO 8601".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "updated".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Undefined impact analysis state".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_analysis".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityAnalysis".to_string(),
-                                field_name: "state".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Undefined impact analysis justification".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_analysis".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityAnalysis".to_string(),
-                                field_name: "justification".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message: "Undefined response".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "vulnerability_analysis".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityAnalysis".to_string(),
-                                field_name: "responses".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Vulnerability".to_string(),
-                                field_name: "properties".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "Property".to_string(),
-                                field_name: "value".to_string()
-                            }
-                        ])
-                    },
-                ]
-            }
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    vec![
+                        validation::field("id", "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"),
+                        validation::r#struct(
+                            "vulnerability_source",
+                            vec![
+                                validation::field(
+                                    "name",
+                                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                ),
+                                validation::field(
+                                    "url",
+                                    "Uri does not conform to RFC 3986"
+                                )
+                            ]
+                        ),
+                        validation::list(
+                            "vulnerability_references",
+                            [(
+                                0,
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        validation::field(
+                                            "id",
+                                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                        )
+                                    )]
+                                )
+                            )]
+                        ),
+                        validation::list(
+                            "vulnerability_ratings",
+                            [(
+                                0,
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        vec![
+                                            validation::r#enum("severity", "Undefined severity"),
+                                            validation::field(
+                                                "vector",
+                                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                            )
+                                        ]
+                                    )]
+                                )
+                            )]
+                        ),
+                        validation::list(
+                            "advisories",
+                            [(
+                                0,
+                                validation::list(
+                                    "inner",
+                                    [(
+                                        0,
+                                        vec![
+                                            validation::field(
+                                                "title",
+                                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                            ),
+                                            validation::field(
+                                                "url",
+                                                "Uri does not conform to RFC 3986"
+                                            )
+                                        ]
+                                    )]
+                                )
+                            )]
+                        ),
+                        validation::field("created", "DateTime does not conform to ISO 8601"),
+                        validation::field("published", "DateTime does not conform to ISO 8601"),
+                        validation::field("updated", "DateTime does not conform to ISO 8601"),
+                        validation::r#struct(
+                            "vulnerability_analysis",
+                            vec![
+                                validation::r#enum("state", "Undefined impact analysis state"),
+                                validation::r#enum("justification", "Undefined impact analysis justification"),
+                                validation::list(
+                                    "responses",
+                                    [(
+                                        0,
+                                        validation::custom("", ["Undefined response"])
+                                    )]
+                                ),
+                            ]
+                        ),
+                        validation::r#struct(
+                            "properties",
+                            validation::list(
+                                "inner",
+                                [(
+                                    0,
+                                    validation::field(
+                                        "value",
+                                        "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                    )
+                                )]
+                            )
+                        )
+                    ]
+                )]
+            )
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -95,7 +95,7 @@ impl Validate for Vulnerability {
             .add_struct_option(
                 "vulnerability_source",
                 self.vulnerability_source.as_ref(),
-                |source| source.validate(version),
+                version,
             )
             .add_list(
                 "vulnerability_references",
@@ -111,26 +111,11 @@ impl Validate for Vulnerability {
                 advisories.validate(version)
             })
             .add_field_option("created", self.created.as_ref(), validate_date_time)
+            .add_field_option("published", self.published.as_ref(), validate_date_time)
+            .add_field_option("updated", self.updated.as_ref(), validate_date_time)
             .into()
 
         /*
-        if let Some(created) = &self.created {
-            let context = context.with_struct("Vulnerability", "created");
-
-            results.push(created.validate_with_context(context));
-        }
-
-        if let Some(published) = &self.published {
-            let context = context.with_struct("Vulnerability", "published");
-
-            results.push(published.validate_with_context(context));
-        }
-
-        if let Some(updated) = &self.updated {
-            let context = context.with_struct("Vulnerability", "updated");
-
-            results.push(updated.validate_with_context(context));
-        }
 
         if let Some(vulnerability_credits) = &self.vulnerability_credits {
             let context = context.with_struct("Vulnerability", "vulnerability_credits");

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -89,7 +89,7 @@ impl Vulnerability {
 }
 
 impl Validate for Vulnerability {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("id", self.id.as_ref(), validate_normalized_string)
             .add_struct_option(
@@ -100,15 +100,15 @@ impl Validate for Vulnerability {
             .add_list(
                 "vulnerability_references",
                 self.vulnerability_references.as_ref(),
-                |references| references.validate(version),
+                |references| references.validate_version(version),
             )
             .add_list(
                 "vulnerability_ratings",
                 self.vulnerability_ratings.as_ref(),
-                |ratings| ratings.validate(version),
+                |ratings| ratings.validate_version(version),
             )
             .add_list("advisories", self.advisories.as_ref(), |advisories| {
-                advisories.validate(version)
+                advisories.validate_version(version)
             })
             .add_field_option("created", self.created.as_ref(), validate_date_time)
             .add_field_option("published", self.published.as_ref(), validate_date_time)
@@ -158,10 +158,10 @@ impl Validate for Vulnerability {
 pub struct Vulnerabilities(pub Vec<Vulnerability>);
 
 impl Validate for Vulnerabilities {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_list("inner", &self.0, |vulnerability| {
-                vulnerability.validate(version)
+                vulnerability.validate_version(version)
             })
             .into()
     }
@@ -250,7 +250,7 @@ mod test {
                 value: NormalizedString::new("value"),
             }])),
         }])
-        .validate(SpecVersion::default());
+        .validate_version(SpecVersion::default());
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -315,7 +315,7 @@ mod test {
                 value: NormalizedString("invalid\tvalue".to_string()),
             }])),
         }])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::external_models::normalized_string::validate_normalized_string;
+use crate::external_models::validate_date_time;
 use crate::external_models::{date_time::DateTime, normalized_string::NormalizedString};
 use crate::models::advisory::Advisories;
 use crate::models::property::Properties;
@@ -26,7 +28,9 @@ use crate::models::vulnerability_rating::VulnerabilityRatings;
 use crate::models::vulnerability_reference::VulnerabilityReferences;
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::models::vulnerability_target::VulnerabilityTargets;
-use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Represents a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -86,38 +90,30 @@ impl Vulnerability {
 
 impl Validate for Vulnerability {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
+        ValidationContext::new()
+            .add_field_option("id", self.id.as_ref(), validate_normalized_string)
+            .add_struct_option(
+                "vulnerability_source",
+                self.vulnerability_source.as_ref(),
+                |source| source.validate(version),
+            )
+            .add_list(
+                "vulnerability_references",
+                self.vulnerability_references.as_ref(),
+                |references| references.validate(version),
+            )
+            .add_list(
+                "vulnerability_ratings",
+                self.vulnerability_ratings.as_ref(),
+                |ratings| ratings.validate(version),
+            )
+            .add_list("advisories", self.advisories.as_ref(), |advisories| {
+                advisories.validate(version)
+            })
+            .add_field_option("created", self.created.as_ref(), validate_date_time)
+            .into()
 
-        if let Some(id) = &self.id {
-            let context = context.with_struct("Vulnerability", "id");
-
-            results.push(id.validate_with_context(context));
-        }
-
-        if let Some(vulnerability_source) = &self.vulnerability_source {
-            let context = context.with_struct("Vulnerability", "vulnerability_source");
-
-            results.push(vulnerability_source.validate_with_context(context));
-        }
-
-        if let Some(vulnerability_references) = &self.vulnerability_references {
-            let context = context.with_struct("Vulnerability", "vulnerability_references");
-
-            results.push(vulnerability_references.validate_with_context(context));
-        }
-
-        if let Some(vulnerability_ratings) = &self.vulnerability_ratings {
-            let context = context.with_struct("Vulnerability", "vulnerability_ratings");
-
-            results.push(vulnerability_ratings.validate_with_context(context));
-        }
-
-        if let Some(advisories) = &self.advisories {
-            let context = context.with_struct("Vulnerability", "advisories");
-
-            results.push(advisories.validate_with_context(context));
-        }
-
+        /*
         if let Some(created) = &self.created {
             let context = context.with_struct("Vulnerability", "created");
 
@@ -169,6 +165,7 @@ impl Validate for Vulnerability {
         results
             .into_iter()
             .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+            */
     }
 }
 
@@ -177,16 +174,11 @@ pub struct Vulnerabilities(pub Vec<Vulnerability>);
 
 impl Validate for Vulnerabilities {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, vulnerability) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", &self.0, |vulnerability| {
+                vulnerability.validate(version)
+            })
+            .into()
     }
 }
 
@@ -206,7 +198,6 @@ mod test {
             vulnerability_reference::VulnerabilityReference,
             vulnerability_target::{Status, Version, VersionRange, Versions, VulnerabilityTarget},
         },
-        validation::FailureReason,
     };
 
     #[test]
@@ -264,17 +255,17 @@ mod test {
             }),
             vulnerability_targets: Some(VulnerabilityTargets(vec![VulnerabilityTarget {
                 bom_ref: "bom ref".to_string(),
-                versions: Some(Versions(vec![Version {
+                versions: Versions(vec![Version {
                     version_range: VersionRange::Version(NormalizedString::new("version")),
                     status: Status::Affected,
-                }])),
+                }]),
             }])),
             properties: Some(Properties(vec![Property {
                 name: "name".to_string(),
                 value: NormalizedString::new("value"),
             }])),
         }])
-        .validate();
+        .validate(SpecVersion::default());
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -339,8 +330,9 @@ mod test {
                 value: NormalizedString("invalid\tvalue".to_string()),
             }])),
         }])
-        .validate();
+        .validate_default();
 
+        /*
         assert_eq!(
             validation_result,
             ValidationResult::Failed {
@@ -561,5 +553,6 @@ mod test {
                 ]
             }
         );
+        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -252,7 +252,7 @@ mod test {
         }])
         .validate_version(SpecVersion::default());
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -240,10 +240,10 @@ mod test {
             }),
             vulnerability_targets: Some(VulnerabilityTargets(vec![VulnerabilityTarget {
                 bom_ref: "bom ref".to_string(),
-                versions: Versions(vec![Version {
+                versions: Some(Versions(vec![Version {
                     version_range: VersionRange::Version(NormalizedString::new("version")),
                     status: Status::Affected,
-                }]),
+                }])),
             }])),
             properties: Some(Properties(vec![Property {
                 name: "name".to_string(),

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -57,7 +57,7 @@ impl VulnerabilityAnalysis {
 }
 
 impl Validate for VulnerabilityAnalysis {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_enum_option("state", self.state.as_ref(), validate_impact_analysis_state)
             .add_enum_option(
@@ -255,7 +255,7 @@ mod test {
             responses: Some(vec![ImpactAnalysisResponse::Update]),
             detail: Some("detail".to_string()),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -276,7 +276,7 @@ mod test {
             )]),
             detail: Some("detail".to_string()),
         }
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Represents a vulnerability's analysis as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -58,37 +58,25 @@ impl VulnerabilityAnalysis {
 
 impl Validate for VulnerabilityAnalysis {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(state) = &self.state {
-            let context = context.with_struct("VulnerabilityAnalysis", "state");
-
-            results.push(state.validate_with_context(context));
-        }
-
-        if let Some(justification) = &self.justification {
-            let context = context.with_struct("VulnerabilityAnalysis", "justification");
-
-            results.push(justification.validate_with_context(context));
-        }
-
-        if let Some(responses) = &self.responses {
-            for (index, response) in responses.iter().enumerate() {
-                let context = context.extend_context(vec![
-                    ValidationPathComponent::Struct {
-                        struct_name: "VulnerabilityAnalysis".to_string(),
-                        field_name: "responses".to_string(),
-                    },
-                    ValidationPathComponent::Array { index },
-                ]);
-                results.push(response.validate_with_context(context));
-            }
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_enum_option("state", self.state.as_ref(), validate_impact_analysis_state)
+            .add_enum_option(
+                "justification",
+                self.justification.as_ref(),
+                validate_impact_analysis_justification,
+            )
+            .add_list_option("responses", self.responses.as_ref(), |response| {
+                validate_impact_analysis_response(response)
+            })
+            .into()
     }
+}
+
+pub fn validate_impact_analysis_state(state: &ImpactAnalysisState) -> Result<(), ValidationError> {
+    if matches!(state, ImpactAnalysisState::UndefinedImpactAnalysisState(_)) {
+        return Err(ValidationError::new("Undefined impact analysis state"));
+    }
+    Ok(())
 }
 
 /// Specifies a vulnerability's state according to impact analysis.
@@ -120,20 +108,6 @@ impl ImpactAnalysisState {
     }
 }
 
-impl Validate for ImpactAnalysisState {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            ImpactAnalysisState::UndefinedImpactAnalysisState(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Undefined impact analysis state".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
-        }
-    }
-}
-
 impl ToString for ImpactAnalysisState {
     fn to_string(&self) -> String {
         match self {
@@ -147,6 +121,18 @@ impl ToString for ImpactAnalysisState {
         }
         .to_string()
     }
+}
+
+pub fn validate_impact_analysis_justification(
+    justification: &ImpactAnalysisJustification,
+) -> Result<(), ValidationError> {
+    if matches!(
+        justification,
+        ImpactAnalysisJustification::UndefinedImpactAnalysisJustification(_)
+    ) {
+        return Err("Undefined impact analysis justification".into());
+    }
+    Ok(())
 }
 
 /// Justifies the vulnerability's state according to impact analysis.
@@ -184,22 +170,6 @@ impl ImpactAnalysisJustification {
     }
 }
 
-impl Validate for ImpactAnalysisJustification {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            ImpactAnalysisJustification::UndefinedImpactAnalysisJustification(_) => {
-                ValidationResult::Failed {
-                    reasons: vec![FailureReason {
-                        message: "Undefined impact analysis justification".to_string(),
-                        context,
-                    }],
-                }
-            }
-            _ => ValidationResult::Passed,
-        }
-    }
-}
-
 impl ToString for ImpactAnalysisJustification {
     fn to_string(&self) -> String {
         match self {
@@ -220,6 +190,15 @@ impl ToString for ImpactAnalysisJustification {
         }
         .to_string()
     }
+}
+
+pub fn validate_impact_analysis_response(
+    response: &ImpactAnalysisResponse,
+) -> Result<(), ValidationError> {
+    if matches!(response, ImpactAnalysisResponse::UndefinedResponse(_)) {
+        return Err("Undefined response".into());
+    }
+    Ok(())
 }
 
 /// Provides a response to the vulnerability according to impact analysis.
@@ -245,20 +224,6 @@ impl ImpactAnalysisResponse {
             "rollback" => Self::Rollback,
             "workaround_available" => Self::WorkaroundAvailable,
             undefined => Self::UndefinedResponse(undefined.to_string()),
-        }
-    }
-}
-
-impl Validate for ImpactAnalysisResponse {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            ImpactAnalysisResponse::UndefinedResponse(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Undefined response".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
         }
     }
 }
@@ -290,7 +255,7 @@ mod test {
             responses: Some(vec![ImpactAnalysisResponse::Update]),
             detail: Some("detail".to_string()),
         }
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -311,8 +276,9 @@ mod test {
             )]),
             detail: Some("detail".to_string()),
         }
-        .validate();
+        .validate_default();
 
+        /*
         assert_eq!(
             validation_result,
             ValidationResult::Failed {
@@ -344,5 +310,6 @@ mod test {
                 ]
             }
         );
+        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -57,7 +57,7 @@ impl VulnerabilityAnalysis {
 }
 
 impl Validate for VulnerabilityAnalysis {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_enum_option("state", self.state.as_ref(), validate_impact_analysis_state)
             .add_enum_option(

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -244,6 +244,8 @@ impl ToString for ImpactAnalysisResponse {
 
 #[cfg(test)]
 mod test {
+    use crate::validation;
+
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -278,38 +280,17 @@ mod test {
         }
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message: "Undefined impact analysis state".to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "VulnerabilityAnalysis".to_string(),
-                            field_name: "state".to_string()
-                        },])
-                    },
-                    FailureReason {
-                        message: "Undefined impact analysis justification".to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "VulnerabilityAnalysis".to_string(),
-                            field_name: "justification".to_string()
-                        },])
-                    },
-                    FailureReason {
-                        message: "Undefined response".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityAnalysis".to_string(),
-                                field_name: "responses".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                        ])
-                    },
-                ]
-            }
+            vec![
+                validation::r#enum("state", "Undefined impact analysis state"),
+                validation::r#enum("justification", "Undefined impact analysis justification"),
+                validation::list(
+                    "responses",
+                    [(0, validation::custom("", ["Undefined response"]))]
+                )
+            ]
+            .into()
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -257,7 +257,7 @@ mod test {
         }
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -57,7 +57,7 @@ impl VulnerabilityAnalysis {
 }
 
 impl Validate for VulnerabilityAnalysis {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(state) = &self.state {
@@ -121,7 +121,7 @@ impl ImpactAnalysisState {
 }
 
 impl Validate for ImpactAnalysisState {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             ImpactAnalysisState::UndefinedImpactAnalysisState(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -185,7 +185,7 @@ impl ImpactAnalysisJustification {
 }
 
 impl Validate for ImpactAnalysisJustification {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             ImpactAnalysisJustification::UndefinedImpactAnalysisJustification(_) => {
                 ValidationResult::Failed {
@@ -250,7 +250,7 @@ impl ImpactAnalysisResponse {
 }
 
 impl Validate for ImpactAnalysisResponse {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             ImpactAnalysisResponse::UndefinedResponse(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -27,7 +27,7 @@ pub struct VulnerabilityCredits {
 }
 
 impl Validate for VulnerabilityCredits {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(organizations) = &self.organizations {

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -64,7 +64,7 @@ mod test {
         }
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -84,25 +84,30 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(
-                vec![
-                    validation::list(
-                        "organizations",
-                        [(
-                            0,
-                            validation::field(
-                                "name",
-                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                            )
-                        )]
-                    ),validation::list(
-                        "individuals",
-                        [(0, validation::field("name", "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"))]
-                    )
-                ]
-                .into()
-            )
+            validation_result,
+            vec![
+                validation::list(
+                    "organizations",
+                    [(
+                        0,
+                        validation::field(
+                            "name",
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                        )
+                    )]
+                ),
+                validation::list(
+                    "individuals",
+                    [(
+                        0,
+                        validation::field(
+                            "name",
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                        )
+                    )]
+                )
+            ]
+            .into()
         );
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -29,13 +29,13 @@ pub struct VulnerabilityCredits {
 }
 
 impl Validate for VulnerabilityCredits {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_list_option("organizations", self.organizations.as_ref(), |org| {
-                org.validate(version)
+                org.validate_version(version)
             })
             .add_list_option("individuals", self.individuals.as_ref(), |individual| {
-                individual.validate(version)
+                individual.validate_version(version)
             })
             .into()
     }
@@ -62,7 +62,7 @@ mod test {
                 phone: None,
             }]),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -81,7 +81,7 @@ mod test {
                 phone: None,
             }]),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -89,7 +89,7 @@ mod test {
                 vec![
                     validation::list(
                         "organizations",
-                        &[(
+                        [(
                             0,
                             validation::field(
                                 "name",
@@ -98,7 +98,7 @@ mod test {
                         )]
                     ),validation::list(
                         "individuals",
-                        &[(0, validation::field("name", "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"))]
+                        [(0, validation::field("name", "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"))]
                     )
                 ]
                 .into()

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -53,8 +53,8 @@ mod test {
         let validation_result = VulnerabilityCredits {
             organizations: Some(vec![OrganizationalEntity {
                 name: Some(NormalizedString::new("name")),
-                url: vec![],
-                contact: vec![],
+                url: None,
+                contact: None,
             }]),
             individuals: Some(vec![OrganizationalContact {
                 name: Some(NormalizedString::new("name")),
@@ -72,8 +72,8 @@ mod test {
         let validation_result = VulnerabilityCredits {
             organizations: Some(vec![OrganizationalEntity {
                 name: Some(NormalizedString("invalid\tname".to_string())),
-                url: vec![],
-                contact: vec![],
+                url: None,
+                contact: None,
             }]),
             individuals: Some(vec![OrganizationalContact {
                 name: Some(NormalizedString("invalid\tname".to_string())),

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -17,7 +17,9 @@
  */
 
 use crate::models::organization::{OrganizationalContact, OrganizationalEntity};
-use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Provides credits to organizations or individuals who contributed to a vulnerability.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -28,43 +30,20 @@ pub struct VulnerabilityCredits {
 
 impl Validate for VulnerabilityCredits {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(organizations) = &self.organizations {
-            for (index, organization) in organizations.iter().enumerate() {
-                let uri_context = context.extend_context(vec![
-                    ValidationPathComponent::Struct {
-                        struct_name: "VulnerabilityCredits".to_string(),
-                        field_name: "organizations".to_string(),
-                    },
-                    ValidationPathComponent::Array { index },
-                ]);
-                results.push(organization.validate_with_context(uri_context));
-            }
-        }
-
-        if let Some(individuals) = &self.individuals {
-            for (index, individual) in individuals.iter().enumerate() {
-                let uri_context = context.extend_context(vec![
-                    ValidationPathComponent::Struct {
-                        struct_name: "VulnerabilityCredits".to_string(),
-                        field_name: "individuals".to_string(),
-                    },
-                    ValidationPathComponent::Array { index },
-                ]);
-                results.push(individual.validate_with_context(uri_context));
-            }
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list_option("organizations", self.organizations.as_ref(), |org| {
+                org.validate(version)
+            })
+            .add_list_option("individuals", self.individuals.as_ref(), |individual| {
+                individual.validate(version)
+            })
+            .into()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{external_models::normalized_string::NormalizedString, validation::FailureReason};
+    use crate::{external_models::normalized_string::NormalizedString, validation};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -74,8 +53,8 @@ mod test {
         let validation_result = VulnerabilityCredits {
             organizations: Some(vec![OrganizationalEntity {
                 name: Some(NormalizedString::new("name")),
-                url: None,
-                contact: None,
+                url: vec![],
+                contact: vec![],
             }]),
             individuals: Some(vec![OrganizationalContact {
                 name: Some(NormalizedString::new("name")),
@@ -83,7 +62,7 @@ mod test {
                 phone: None,
             }]),
         }
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -93,8 +72,8 @@ mod test {
         let validation_result = VulnerabilityCredits {
             organizations: Some(vec![OrganizationalEntity {
                 name: Some(NormalizedString("invalid\tname".to_string())),
-                url: None,
-                contact: None,
+                url: vec![],
+                contact: vec![],
             }]),
             individuals: Some(vec![OrganizationalContact {
                 name: Some(NormalizedString("invalid\tname".to_string())),
@@ -102,46 +81,28 @@ mod test {
                 phone: None,
             }]),
         }
-        .validate();
+        .validate_default();
 
         assert_eq!(
-            validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityCredits".to_string(),
-                                field_name: "organizations".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalEntity".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityCredits".to_string(),
-                                field_name: "individuals".to_string()
-                            },
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "OrganizationalContact".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
+            validation_result.errors(),
+            Some(
+                vec![
+                    validation::list(
+                        "organizations",
+                        &[(
+                            0,
+                            validation::field(
+                                "name",
+                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            )
+                        )]
+                    ),validation::list(
+                        "individuals",
+                        &[(0, validation::field("name", "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"))]
+                    )
                 ]
-            }
+                .into()
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -62,7 +62,7 @@ impl VulnerabilityRating {
 
 // todo: how to decide what to validate, check this
 impl Validate for VulnerabilityRating {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
@@ -93,7 +93,7 @@ impl Validate for VulnerabilityRating {
 pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 
 impl Validate for VulnerabilityRatings {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_rating) in self.0.iter().enumerate() {
@@ -175,7 +175,7 @@ impl Severity {
 }
 
 impl Validate for Severity {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             Severity::UndefinedSeverity(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -98,7 +98,7 @@ pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 impl Validate for VulnerabilityRatings {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", self.0.as_ref(), |rating| rating.validate(version))
+            .add_list("inner", &self.0, |rating| rating.validate(version))
             .into()
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -276,7 +276,7 @@ mod test {
             validation_result.errors(),
             Some(validation::list(
                 "inner",
-                &[(
+                [(
                     0,
                     validation::r#struct(
                         "vulnerability_source",

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -62,7 +62,7 @@ impl VulnerabilityRating {
 
 // todo: how to decide what to validate, check this
 impl Validate for VulnerabilityRating {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option(
                 "vulnerability_source",
@@ -79,9 +79,9 @@ impl Validate for VulnerabilityRating {
 pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 
 impl Validate for VulnerabilityRatings {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |rating| rating.validate(version))
+            .add_list("inner", &self.0, |rating| rating.validate_version(version))
             .into()
     }
 }
@@ -235,7 +235,7 @@ mod test {
             vector: Some(NormalizedString::new("vector")),
             justification: None,
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -253,7 +253,7 @@ mod test {
             vector: Some(NormalizedString("invalid\tvector".to_string())),
             justification: None,
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(
             validation_result.errors(),

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -18,7 +18,7 @@
 
 use ordered_float::OrderedFloat;
 
-use crate::external_models::normalized_string::NormalizedString;
+use crate::external_models::normalized_string::{validate_normalized_string, NormalizedString};
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
 
@@ -63,32 +63,15 @@ impl VulnerabilityRating {
 // todo: how to decide what to validate, check this
 impl Validate for VulnerabilityRating {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        ValidationContext::new().into()
-        /*
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(vulnerability_source) = &self.vulnerability_source {
-            let context = context.with_struct("VulnerabilityRating", "vulnerability_source");
-
-            results.push(vulnerability_source.validate_with_context(context));
-        }
-
-        if let Some(severity) = &self.severity {
-            let context = context.with_struct("VulnerabilityRating", "severity");
-
-            results.push(severity.validate_with_context(context));
-        }
-
-        if let Some(vector) = &self.vector {
-            let context = context.with_struct("VulnerabilityRating", "vector");
-
-            results.push(vector.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-        */
+        ValidationContext::new()
+            .add_struct_option(
+                "vulnerability_source",
+                self.vulnerability_source.as_ref(),
+                version,
+            )
+            .add_enum_option("severity", self.severity.as_ref(), validate_severity)
+            .add_field_option("vector", self.vector.as_ref(), validate_normalized_string)
+            .into()
     }
 }
 
@@ -278,77 +261,26 @@ mod test {
                 "inner",
                 [(
                     0,
-                    validation::r#struct(
-                        "vulnerability_source",
-                        vec![validation::field(
+                    vec![
+                        validation::r#struct(
+                            "vulnerability_source",
+                            vec![validation::field(
                             "name",
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n",
+                        ),
+                        validation::field(
+                            "url",
+                            "Uri does not conform to RFC 3986",
                         )]
-                    )
+                        ),
+                        validation::r#enum("severity", "Undefined severity"),
+                        validation::field(
+                            "vector",
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                        )
+                    ],
                 )]
             ))
         );
-
-        /*
-        assert_eq!(
-            validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityRating".to_string(),
-                                field_name: "vulnerability_source".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilitySource".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityRating".to_string(),
-                                field_name: "vulnerability_source".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilitySource".to_string(),
-                                field_name: "url".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Undefined severity".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityRating".to_string(),
-                                field_name: "severity".to_string()
-                            }
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityRating".to_string(),
-                                field_name: "vector".to_string()
-                            },
-                        ])
-                    },
-                ]
-            }
-        );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -20,9 +20,9 @@ use ordered_float::OrderedFloat;
 
 use crate::external_models::normalized_string::NormalizedString;
 use crate::models::vulnerability_source::VulnerabilitySource;
-use crate::validation::{
-    FailureReason, Validate, ValidationContext, ValidationPathComponent, ValidationResult,
-};
+use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Represents a vulnerability's rating as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -63,6 +63,8 @@ impl VulnerabilityRating {
 // todo: how to decide what to validate, check this
 impl Validate for VulnerabilityRating {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
+        ValidationContext::new().into()
+        /*
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(vulnerability_source) = &self.vulnerability_source {
@@ -86,6 +88,7 @@ impl Validate for VulnerabilityRating {
         results
             .into_iter()
             .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        */
     }
 }
 
@@ -94,16 +97,9 @@ pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 
 impl Validate for VulnerabilityRatings {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, vulnerability_rating) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability_rating.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", self.0.as_ref(), |rating| rating.validate(version))
+            .into()
     }
 }
 
@@ -143,6 +139,13 @@ impl From<Score> for f32 {
     }
 }
 
+pub fn validate_severity(severity: &Severity) -> Result<(), ValidationError> {
+    if matches!(severity, Severity::UndefinedSeverity(_)) {
+        return Err("Undefined severity".into());
+    }
+    Ok(())
+}
+
 /// Specifies a vulnerability's severity adopted by the analysis method.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_severityType)
@@ -170,20 +173,6 @@ impl Severity {
             "none" => Self::None,
             "unknown" => Self::Unknown,
             undefined => Self::UndefinedSeverity(undefined.to_string()),
-        }
-    }
-}
-
-impl Validate for Severity {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            Severity::UndefinedSeverity(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Undefined severity".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
         }
     }
 }
@@ -245,8 +234,7 @@ impl ToString for ScoreMethod {
 mod test {
     use super::*;
     use crate::{
-        external_models::uri::Uri, models::vulnerability_source::VulnerabilitySource,
-        validation::FailureReason,
+        external_models::uri::Uri, models::vulnerability_source::VulnerabilitySource, validation,
     };
 
     use pretty_assertions::assert_eq;
@@ -264,7 +252,7 @@ mod test {
             vector: Some(NormalizedString::new("vector")),
             justification: None,
         }])
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -282,8 +270,26 @@ mod test {
             vector: Some(NormalizedString("invalid\tvector".to_string())),
             justification: None,
         }])
-        .validate();
+        .validate_default();
 
+        assert_eq!(
+            validation_result.errors(),
+            Some(validation::list(
+                "inner",
+                &[(
+                    0,
+                    validation::r#struct(
+                        "vulnerability_source",
+                        vec![validation::field(
+                            "name",
+                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                        )]
+                    )
+                )]
+            ))
+        );
+
+        /*
         assert_eq!(
             validation_result,
             ValidationResult::Failed {
@@ -343,5 +349,6 @@ mod test {
                 ]
             }
         );
+        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -237,7 +237,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]
@@ -256,8 +256,8 @@ mod test {
         .validate();
 
         assert_eq!(
-            validation_result.errors(),
-            Some(validation::list(
+            validation_result,
+            validation::list(
                 "inner",
                 [(
                     0,
@@ -280,7 +280,7 @@ mod test {
                         )
                     ],
                 )]
-            ))
+            )
         );
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -54,7 +54,7 @@ impl VulnerabilityReference {
 }
 
 impl Validate for VulnerabilityReference {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("id", &self.id, validate_normalized_string)
             .add_struct("vulnerability_source", &self.vulnerability_source, version)
@@ -66,9 +66,9 @@ impl Validate for VulnerabilityReference {
 pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 
 impl Validate for VulnerabilityReferences {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |reference| reference.validate(version))
+            .add_list("inner", &self.0, |reference| reference.validate_version(version))
             .into()
     }
 }
@@ -92,7 +92,7 @@ mod test {
                 url: Some(Uri("https://www.example.com".to_string())),
             },
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -106,7 +106,7 @@ mod test {
                 url: Some(Uri("invalid url".to_string())),
             },
         }])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -57,11 +57,7 @@ impl Validate for VulnerabilityReference {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field("id", &self.id, validate_normalized_string)
-            .add_struct(
-                "vulnerability_source",
-                self.vulnerability_source.as_ref(),
-                version,
-            )
+            .add_struct("vulnerability_source", &self.vulnerability_source, version)
             .into()
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -94,7 +94,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -16,9 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::external_models::normalized_string::NormalizedString;
+use crate::external_models::normalized_string::{validate_normalized_string, NormalizedString};
 use crate::models::vulnerability_source::VulnerabilitySource;
-use crate::validation::{Validate, ValidationContext, ValidationPathComponent, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// References a vulnerability equivalent to the vulnerability specified, e.g.
 /// to correlate vulnerabilities across multiple sources of vulnerability intelligence.
@@ -53,22 +55,14 @@ impl VulnerabilityReference {
 
 impl Validate for VulnerabilityReference {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        let id_context = context.with_struct("VulnerabilityReference", "id");
-
-        results.push(self.id.validate_with_context(id_context));
-
-        let source_context = context.with_struct("VulnerabilityReference", "vulnerability_source");
-
-        results.push(
-            self.vulnerability_source
-                .validate_with_context(source_context),
-        );
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_field("id", &self.id, validate_normalized_string)
+            .add_struct(
+                "vulnerability_source",
+                &self.vulnerability_source.as_ref(),
+                |source| source.validate(version),
+            )
+            .into()
     }
 }
 
@@ -77,16 +71,9 @@ pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 
 impl Validate for VulnerabilityReferences {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, vulnerability_reference) in self.0.iter().enumerate() {
-            let context = context.extend_context(vec![ValidationPathComponent::Array { index }]);
-            results.push(vulnerability_reference.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", &self.0, |reference| reference.validate(version))
+            .into()
     }
 }
 
@@ -95,7 +82,6 @@ mod test {
     use crate::{
         external_models::{normalized_string::NormalizedString, uri::Uri},
         models::vulnerability_source::VulnerabilitySource,
-        validation::FailureReason,
     };
 
     use super::*;
@@ -110,7 +96,7 @@ mod test {
                 url: Some(Uri("https://www.example.com".to_string())),
             },
         }])
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -124,8 +110,9 @@ mod test {
                 url: Some(Uri("invalid url".to_string())),
             },
         }])
-        .validate();
+        .validate_default();
 
+        /*
         assert_eq!(
             validation_result,
             ValidationResult::Failed {
@@ -175,5 +162,6 @@ mod test {
                 ]
             }
         );
+        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -52,7 +52,7 @@ impl VulnerabilityReference {
 }
 
 impl Validate for VulnerabilityReference {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let id_context = context.with_struct("VulnerabilityReference", "id");
@@ -76,7 +76,7 @@ impl Validate for VulnerabilityReference {
 pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 
 impl Validate for VulnerabilityReferences {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_reference) in self.0.iter().enumerate() {

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -59,8 +59,8 @@ impl Validate for VulnerabilityReference {
             .add_field("id", &self.id, validate_normalized_string)
             .add_struct(
                 "vulnerability_source",
-                &self.vulnerability_source.as_ref(),
-                |source| source.validate(version),
+                self.vulnerability_source.as_ref(),
+                version,
             )
             .into()
     }

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -68,7 +68,9 @@ pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 impl Validate for VulnerabilityReferences {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |reference| reference.validate_version(version))
+            .add_list("inner", &self.0, |reference| {
+                reference.validate_version(version)
+            })
             .into()
     }
 }
@@ -78,6 +80,7 @@ mod test {
     use crate::{
         external_models::{normalized_string::NormalizedString, uri::Uri},
         models::vulnerability_source::VulnerabilitySource,
+        validation,
     };
 
     use super::*;
@@ -108,56 +111,33 @@ mod test {
         }])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    vec![
+                        validation::field(
+                            "id",
                             "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityReference".to_string(),
-                                field_name: "id".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityReference".to_string(),
-                                field_name: "vulnerability_source".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilitySource".to_string(),
-                                field_name: "name".to_string()
-                            },
-                        ])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![
-                            ValidationPathComponent::Array { index: 0 },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilityReference".to_string(),
-                                field_name: "vulnerability_source".to_string()
-                            },
-                            ValidationPathComponent::Struct {
-                                struct_name: "VulnerabilitySource".to_string(),
-                                field_name: "url".to_string()
-                            },
-                        ])
-                    },
-                ]
-            }
+                        ),
+                        validation::r#struct(
+                            "vulnerability_source",
+                            vec![
+                                validation::field(
+                                    "name",
+                                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                                ),
+                                validation::field(
+                                    "url",
+                                    "Uri does not conform to RFC 3986"
+                                )
+                            ]
+                        ),
+                    ]
+                )]
+            )
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -16,8 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::external_models::normalized_string::validate_normalized_string;
+use crate::external_models::uri::validate_uri;
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Defines a source related to the vulnerability, e.g. who published or calculated the severity or risk rating the vulnerability.
 ///
@@ -52,32 +56,16 @@ impl VulnerabilitySource {
 
 impl Validate for VulnerabilitySource {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(name) = &self.name {
-            let context = context.with_struct("VulnerabilitySource", "name");
-
-            results.push(name.validate_with_context(context));
-        }
-
-        if let Some(url) = &self.url {
-            let context = context.with_struct("VulnerabilitySource", "url");
-
-            results.push(url.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_field_option("name", self.name.as_ref(), validate_normalized_string)
+            .add_field_option("url", self.url.as_ref(), validate_uri)
+            .into()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        external_models::uri::Uri,
-        validation::{FailureReason, ValidationPathComponent},
-    };
+    use crate::external_models::uri::Uri;
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -88,7 +76,7 @@ mod test {
             name: Some(NormalizedString::new("name")),
             url: Some(Uri("url".to_string())),
         }
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -99,8 +87,9 @@ mod test {
             name: Some(NormalizedString("invalid\tname".to_string())),
             url: Some(Uri("invalid url".to_string())),
         }
-        .validate();
+        .validate_default();
 
+        /*
         assert_eq!(
             validation_result,
             ValidationResult::Failed {
@@ -124,5 +113,6 @@ mod test {
                 ]
             }
         );
+        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -65,7 +65,7 @@ impl Validate for VulnerabilitySource {
 
 #[cfg(test)]
 mod test {
-    use crate::external_models::uri::Uri;
+    use crate::{external_models::uri::Uri, validation};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -89,30 +89,16 @@ mod test {
         }
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason {
-                        message:
-                            "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                                .to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "VulnerabilitySource".to_string(),
-                            field_name: "name".to_string()
-                        },])
-                    },
-                    FailureReason {
-                        message: "Uri does not conform to RFC 3986".to_string(),
-                        context: ValidationContext(vec![ValidationPathComponent::Struct {
-                            struct_name: "VulnerabilitySource".to_string(),
-                            field_name: "url".to_string()
-                        },])
-                    },
-                ]
-            }
+            vec![
+                validation::field(
+                    "name",
+                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
+                ),
+                validation::field("url", "Uri does not conform to RFC 3986"),
+            ]
+            .into()
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -55,7 +55,7 @@ impl VulnerabilitySource {
 }
 
 impl Validate for VulnerabilitySource {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("url", self.url.as_ref(), validate_uri)
@@ -76,7 +76,7 @@ mod test {
             name: Some(NormalizedString::new("name")),
             url: Some(Uri("url".to_string())),
         }
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -87,7 +87,7 @@ mod test {
             name: Some(NormalizedString("invalid\tname".to_string())),
             url: Some(Uri("invalid url".to_string())),
         }
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -78,7 +78,7 @@ mod test {
         }
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -55,7 +55,7 @@ impl VulnerabilitySource {
 }
 
 impl Validate for VulnerabilitySource {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_field_option("name", self.name.as_ref(), validate_normalized_string)
             .add_field_option("url", self.url.as_ref(), validate_uri)

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -51,7 +51,7 @@ impl VulnerabilitySource {
 }
 
 impl Validate for VulnerabilitySource {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         if let Some(name) = &self.name {

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -49,7 +49,7 @@ impl VulnerabilityTarget {
 }
 
 impl Validate for VulnerabilityTarget {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_struct_option("versions", self.versions.as_ref(), version)
             .into()
@@ -60,9 +60,9 @@ impl Validate for VulnerabilityTarget {
 pub struct VulnerabilityTargets(pub Vec<VulnerabilityTarget>);
 
 impl Validate for VulnerabilityTargets {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |target| target.validate(version))
+            .add_list("inner", &self.0, |target| target.validate_version(version))
             .into()
     }
 }
@@ -71,9 +71,9 @@ impl Validate for VulnerabilityTargets {
 pub struct Versions(pub Vec<Version>);
 
 impl Validate for Versions {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list("inner", &self.0, |v| v.validate(version))
+            .add_list("inner", &self.0, |v| v.validate_version(version))
             .into()
     }
 }
@@ -100,7 +100,7 @@ impl Version {
 }
 
 impl Validate for Version {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_enum("version_range", &self.version_range, validate_version_range)
             .add_enum("status", &self.status, validate_status)
@@ -228,7 +228,7 @@ mod test {
                 status: Status::Affected,
             }])),
         }])
-        .validate_default();
+        .validate();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -242,7 +242,7 @@ mod test {
                 status: Status::UndefinedStatus("invalid\tstatus".to_string()),
             }])),
         }])
-        .validate_default();
+        .validate();
 
         /*
         assert_eq!(

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -230,7 +230,7 @@ mod test {
         }])
         .validate();
 
-        assert_eq!(validation_result, ValidationResult::Passed);
+        assert!(validation_result.passed());
     }
 
     #[test]

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -20,7 +20,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::external_models::normalized_string::NormalizedString;
-use crate::validation::{Validate, ValidationContext, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
 
 use super::bom::SpecVersion;
 
@@ -51,11 +51,7 @@ impl VulnerabilityTarget {
 impl Validate for VulnerabilityTarget {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_struct(
-                "vulnerability_target",
-                self.versions.as_deref(),
-                |tools: &[_]| tools.into_iter().map(|tool| tool.validate(version)).collect(),
-            )
+            .add_list_option("versions", self.versions.as_ref(), |v| v.validate(version))
             .into()
     }
 }
@@ -65,16 +61,9 @@ pub struct VulnerabilityTargets(pub Vec<VulnerabilityTarget>);
 
 impl Validate for VulnerabilityTargets {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, vulnerability_target) in self.0.iter().enumerate() {
-            let context = context.with_index(index);
-            results.push(vulnerability_target.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", &self.0, |target| target.validate(version))
+            .into()
     }
 }
 
@@ -83,16 +72,9 @@ pub struct Versions(pub Vec<Version>);
 
 impl Validate for Versions {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        for (index, version) in self.0.iter().enumerate() {
-            let context = context.with_index(index);
-            results.push(version.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        ValidationContext::new()
+            .add_list("inner", &self.0, |v| v.validate(version))
+            .into()
     }
 }
 
@@ -119,14 +101,12 @@ impl Version {
 
 impl Validate for Version {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
+        ValidationContext::new()
+            .add_enum("version_range", &self.version_range, validate_version_range)
+            .add_enum("status", &self.status, validate_status)
+            .into()
 
-        let version_range_context = context.with_struct("Version", "version_range");
-
-        results.push(
-            self.version_range
-                .validate_with_context(version_range_context),
-        );
+        /*
 
         let status_context = context.with_struct("Version", "status");
 
@@ -135,7 +115,15 @@ impl Validate for Version {
         results
             .into_iter()
             .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+        */
     }
+}
+
+pub fn validate_version_range(range: &VersionRange) -> Result<(), ValidationError> {
+    if matches!(range, VersionRange::UndefinedVersionRange(_)) {
+        return Err(ValidationError::new("Undefined version range"));
+    }
+    Ok(())
 }
 
 /// Specifies a single version or a version range.
@@ -159,20 +147,6 @@ impl VersionRange {
     }
 }
 
-impl Validate for VersionRange {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            VersionRange::UndefinedVersionRange(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Undefined version range".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
-        }
-    }
-}
-
 impl ToString for VersionRange {
     fn to_string(&self) -> String {
         match self {
@@ -188,6 +162,13 @@ fn matches_purl_version_range_regex(value: &str) -> bool {
         Lazy::new(|| Regex::new(r"^vers:.*$").expect("Failed to compile regex."));
 
     PURL_VERSION_RANGE_REGEX.is_match(value)
+}
+
+pub fn validate_status(status: &Status) -> Result<(), ValidationError> {
+    if matches!(status, Status::UndefinedStatus(_)) {
+        return Err(ValidationError::new("Undefined status"));
+    }
+    Ok(())
 }
 
 /// Specifies if a vulnerability affects a component or service.
@@ -209,20 +190,6 @@ impl Status {
             "unaffected" => Self::Unaffected,
             "unknown" => Self::Unknown,
             undefined => Self::UndefinedStatus(undefined.to_string()),
-        }
-    }
-}
-
-impl Validate for Status {
-    fn validate(&self, version: SpecVersion) -> ValidationResult {
-        match self {
-            Status::UndefinedStatus(_) => ValidationResult::Failed {
-                reasons: vec![FailureReason {
-                    message: "Undefined status".to_string(),
-                    context,
-                }],
-            },
-            _ => ValidationResult::Passed,
         }
     }
 }
@@ -261,7 +228,7 @@ mod test {
                 status: Status::Affected,
             }])),
         }])
-        .validate();
+        .validate_default();
 
         assert_eq!(validation_result, ValidationResult::Passed);
     }
@@ -275,7 +242,7 @@ mod test {
                 status: Status::UndefinedStatus("invalid\tstatus".to_string()),
             }])),
         }])
-        .validate();
+        .validate_default();
 
         assert_eq!(
             validation_result,

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -100,7 +100,7 @@ impl Version {
 }
 
 impl Validate for Version {
-    fn validate_version(&self, version: SpecVersion) -> ValidationResult {
+    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
             .add_enum("version_range", &self.version_range, validate_version_range)
             .add_enum("status", &self.status, validate_status)

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -30,7 +30,7 @@ use super::bom::SpecVersion;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityTarget {
     pub bom_ref: String,
-    pub versions: Option<Vec<Version>>,
+    pub versions: Option<Versions>,
 }
 
 impl VulnerabilityTarget {
@@ -51,7 +51,7 @@ impl VulnerabilityTarget {
 impl Validate for VulnerabilityTarget {
     fn validate(&self, version: SpecVersion) -> ValidationResult {
         ValidationContext::new()
-            .add_list_option("versions", self.versions.as_ref(), |v| v.validate(version))
+            .add_struct_option("versions", self.versions.as_ref(), version)
             .into()
     }
 }
@@ -244,6 +244,7 @@ mod test {
         }])
         .validate_default();
 
+        /*
         assert_eq!(
             validation_result,
             ValidationResult::Failed {
@@ -267,5 +268,6 @@ mod test {
                 ]
             }
         );
+        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -105,17 +105,6 @@ impl Validate for Version {
             .add_enum("version_range", &self.version_range, validate_version_range)
             .add_enum("status", &self.status, validate_status)
             .into()
-
-        /*
-
-        let status_context = context.with_struct("Version", "status");
-
-        results.push(self.status.validate_with_context(status_context));
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
-        */
     }
 }
 
@@ -208,6 +197,8 @@ impl ToString for Status {
 
 #[cfg(test)]
 mod test {
+    use crate::validation;
+
     use super::*;
     use pretty_assertions::assert_eq;
 
@@ -244,30 +235,27 @@ mod test {
         }])
         .validate();
 
-        /*
         assert_eq!(
             validation_result,
-            ValidationResult::Failed {
-                reasons: vec![
-                    FailureReason::new(
-                        "Undefined version range",
-                        ValidationContext::new()
-                            .with_index(0)
-                            .with_struct("VulnerabilityTarget", "versions")
-                            .with_index(0)
-                            .with_struct("Version", "version_range")
-                    ),
-                    FailureReason::new(
-                        "Undefined status",
-                        ValidationContext::new()
-                            .with_index(0)
-                            .with_struct("VulnerabilityTarget", "versions")
-                            .with_index(0)
-                            .with_struct("Version", "status")
+            validation::list(
+                "inner",
+                [(
+                    0,
+                    validation::r#struct(
+                        "versions",
+                        validation::list(
+                            "inner",
+                            [(
+                                0,
+                                vec![
+                                    validation::r#enum("version_range", "Undefined version range"),
+                                    validation::r#enum("status", "Undefined status"),
+                                ]
+                            )]
+                        )
                     )
-                ]
-            }
+                )]
+            )
         );
-        */
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -20,7 +20,9 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::external_models::normalized_string::NormalizedString;
-use crate::validation::{FailureReason, Validate, ValidationContext, ValidationResult};
+use crate::validation::{Validate, ValidationContext, ValidationResult};
+
+use super::bom::SpecVersion;
 
 /// Defines how a component or service is affected by a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -28,7 +30,7 @@ use crate::validation::{FailureReason, Validate, ValidationContext, ValidationRe
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VulnerabilityTarget {
     pub bom_ref: String,
-    pub versions: Option<Versions>,
+    pub versions: Option<Vec<Version>>,
 }
 
 impl VulnerabilityTarget {
@@ -47,18 +49,14 @@ impl VulnerabilityTarget {
 }
 
 impl Validate for VulnerabilityTarget {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
-        let mut results: Vec<ValidationResult> = vec![];
-
-        if let Some(versions) = &self.versions {
-            let context = context.with_struct("VulnerabilityTarget", "versions");
-
-            results.push(versions.validate_with_context(context));
-        }
-
-        results
-            .into_iter()
-            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
+        ValidationContext::new()
+            .add_struct(
+                "vulnerability_target",
+                self.versions.as_deref(),
+                |tools: &[_]| tools.into_iter().map(|tool| tool.validate(version)).collect(),
+            )
+            .into()
     }
 }
 
@@ -66,7 +64,7 @@ impl Validate for VulnerabilityTarget {
 pub struct VulnerabilityTargets(pub Vec<VulnerabilityTarget>);
 
 impl Validate for VulnerabilityTargets {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, vulnerability_target) in self.0.iter().enumerate() {
@@ -84,7 +82,7 @@ impl Validate for VulnerabilityTargets {
 pub struct Versions(pub Vec<Version>);
 
 impl Validate for Versions {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         for (index, version) in self.0.iter().enumerate() {
@@ -120,7 +118,7 @@ impl Version {
 }
 
 impl Validate for Version {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         let mut results: Vec<ValidationResult> = vec![];
 
         let version_range_context = context.with_struct("Version", "version_range");
@@ -162,7 +160,7 @@ impl VersionRange {
 }
 
 impl Validate for VersionRange {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             VersionRange::UndefinedVersionRange(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {
@@ -216,7 +214,7 @@ impl Status {
 }
 
 impl Validate for Status {
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
+    fn validate(&self, version: SpecVersion) -> ValidationResult {
         match self {
             Status::UndefinedStatus(_) => ValidationResult::Failed {
                 reasons: vec![FailureReason {

--- a/cyclonedx-bom/src/validation.rs
+++ b/cyclonedx-bom/src/validation.rs
@@ -15,117 +15,479 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+use std::{collections::BTreeMap, fmt::Display};
 
-pub trait Validate {
-    fn validate(&self) -> ValidationResult {
-        self.validate_with_context(ValidationContext::default())
-    }
+use indexmap::{
+    map::{Entry::Vacant, IntoIter},
+    IndexMap,
+};
 
-    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult;
-}
+use crate::models::bom::SpecVersion;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ValidationContext(pub(crate) Vec<ValidationPathComponent>);
-
-#[allow(dead_code)]
-impl ValidationContext {
-    pub(crate) fn new() -> Self {
-        ValidationContext::default()
-    }
-
-    pub(crate) fn extend_context(&self, components: Vec<ValidationPathComponent>) -> Self {
-        let mut extended_context = self.0.clone();
-        extended_context.extend(components);
-        Self(extended_context)
-    }
-
-    /// Extends the [`ValidationContext`] with an index, e.g. to specify the index in array.
-    pub(crate) fn with_index(&self, index: usize) -> Self {
-        let component = vec![ValidationPathComponent::Array { index }];
-        self.extend_context(component)
-    }
-
-    /// Extends the [`ValidationContext`] with a struct field.
-    pub(crate) fn with_struct(
-        &self,
-        struct_name: impl ToString,
-        field_name: impl ToString,
-    ) -> Self {
-        let component = vec![ValidationPathComponent::Struct {
-            struct_name: struct_name.to_string(),
-            field_name: field_name.to_string(),
-        }];
-        self.extend_context(component)
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ValidationPathComponent {
-    Struct {
-        struct_name: String,
-        field_name: String,
-    },
-    Array {
-        index: usize,
-    },
-    EnumVariant {
-        variant_name: String,
-    },
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ValidationResult {
-    Passed,
-    Failed { reasons: Vec<FailureReason> },
-}
-
-impl ValidationResult {
-    pub fn merge(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Passed, Self::Passed) => Self::Passed,
-            (Self::Passed, Self::Failed { reasons }) => Self::Failed { reasons },
-            (Self::Failed { reasons }, Self::Passed) => Self::Failed { reasons },
-            (
-                Self::Failed {
-                    reasons: mut left_reasons,
-                },
-                Self::Failed {
-                    reasons: mut right_reasons,
-                },
-            ) => {
-                left_reasons.append(&mut right_reasons);
-                Self::Failed {
-                    reasons: left_reasons,
-                }
-            }
-        }
-    }
-
-    /// Returns a [`ValidationResult::Failed`] with a single failure.
-    pub fn failure(reason: &str, context: ValidationContext) -> Self {
-        Self::Failed {
-            reasons: vec![FailureReason::new(reason, context)],
-        }
-    }
+/// Contains all collected validation errors.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationResult {
+    /// Maps names to validation errors.
+    pub(crate) inner: IndexMap<String, ValidationErrorsKind>,
 }
 
 impl Default for ValidationResult {
     fn default() -> Self {
-        Self::Passed
+        ValidationResult::new()
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct FailureReason {
-    pub message: String,
-    pub context: ValidationContext,
+impl From<Vec<ValidationResult>> for ValidationResult {
+    fn from(errors: Vec<ValidationResult>) -> Self {
+        // merge all errors into one struct.
+        let mut result = ValidationResult::new();
+        for error in errors.into_iter() {
+            for (key, value) in error.inner.into_iter() {
+                result.inner.insert(key, value);
+            }
+        }
+        result
+    }
 }
 
-impl FailureReason {
-    pub fn new(message: &str, context: ValidationContext) -> Self {
+impl From<Result<(), ValidationError>> for ValidationResult {
+    fn from(value: Result<(), ValidationError>) -> Self {
+        match value {
+            Ok(()) => ValidationResult::default(),
+            Err(error) => {
+                let mut result = ValidationResult::default();
+                result.add_custom("", error);
+                result
+            }
+        }
+    }
+}
+
+impl ValidationResult {
+    pub fn new() -> Self {
+        Self {
+            inner: IndexMap::new(),
+        }
+    }
+
+    /// Returns `true` if there are no errors.
+    pub fn passed(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Returns `true` if there are errors.
+    pub fn has_errors(&self) -> bool {
+        !self.inner.is_empty()
+    }
+
+    /// Returns the error with given name, if available
+    pub fn error(&self, field: &str) -> Option<&ValidationErrorsKind> {
+        self.inner.get(&field.to_string())
+    }
+
+    pub fn has_error(&self, field: &str) -> bool {
+        self.inner.contains_key(field)
+    }
+
+    /// Returns an Iterator over all errors, consumes the [`ValidationResult`].
+    pub fn errors(self) -> IntoIter<String, ValidationErrorsKind> {
+        self.inner.into_iter()
+    }
+
+    /// Adds a nested object kind
+    fn add_nested(&mut self, nested_name: &str, errors_kind: ValidationErrorsKind) {
+        if let Vacant(entry) = self.inner.entry(nested_name.to_string()) {
+            entry.insert(errors_kind);
+        } else {
+            panic!("Attempt to replace non-empty nested entry")
+        }
+    }
+
+    /// Adds a single [`ValidationError`] for an enum variant.
+    fn add_enum(&mut self, enum_name: &str, validation_error: ValidationError) {
+        if let Vacant(entry) = self.inner.entry(enum_name.to_string()) {
+            entry.insert(ValidationErrorsKind::Enum(validation_error));
+        } else {
+            panic!("Attempt to replace non-empty enum entry")
+        }
+    }
+
+    /// Adds a single field [`ValidationError`].
+    fn add_field(&mut self, field_name: &str, validation_error: ValidationError) {
+        if let ValidationErrorsKind::Field(ref mut vec) = self
+            .inner
+            .entry(field_name.to_string())
+            .or_insert_with(|| ValidationErrorsKind::Field(vec![]))
+        {
+            vec.push(validation_error);
+        } else {
+            panic!("Found a non-field ValidationErrorsKind");
+        }
+    }
+
+    /// Adds a list of validation errors for a custom entry.
+    fn add_custom(&mut self, custom_name: &str, validation_error: ValidationError) {
+        if let ValidationErrorsKind::Custom(ref mut vec) = self
+            .inner
+            .entry(custom_name.to_string())
+            .or_insert_with(|| ValidationErrorsKind::Custom(vec![]))
+        {
+            vec.push(validation_error);
+        } else {
+            panic!("Found a non-custom ValidationErrorsKind");
+        }
+    }
+}
+
+/// Collects validation results in a hierarchy, recommended to use in `Validate` implementations.
+#[derive(Debug)]
+pub struct ValidationContext {
+    state: ValidationResult,
+}
+
+impl Default for ValidationContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ValidationContext {
+    pub fn new() -> Self {
+        Self {
+            state: ValidationResult::default(),
+        }
+    }
+
+    pub fn add_field<T>(
+        &mut self,
+        field_name: &str,
+        field: T,
+        validation: impl FnOnce(T) -> Result<(), ValidationError>,
+    ) -> &mut Self {
+        if let Err(validation_error) = validation(field) {
+            self.state.add_field(field_name, validation_error);
+        }
+        self
+    }
+
+    pub fn add_field_option<T>(
+        &mut self,
+        field_name: &str,
+        field: Option<T>,
+        validation: impl FnOnce(T) -> Result<(), ValidationError>,
+    ) -> &mut Self {
+        if let Some(field) = field {
+            self.add_field(field_name, field, validation);
+        }
+        self
+    }
+
+    pub fn add_enum<T>(
+        &mut self,
+        enum_name: &str,
+        enum_type: &T,
+        validation: impl FnOnce(&T) -> Result<(), ValidationError>,
+    ) -> &mut Self {
+        if let Err(error) = validation(enum_type) {
+            self.state.add_enum(enum_name, error);
+        }
+        self
+    }
+
+    pub fn add_enum_option<T>(
+        &mut self,
+        enum_name: &str,
+        enum_type: Option<&T>,
+        validation: impl FnOnce(&T) -> Result<(), ValidationError>,
+    ) -> &mut Self {
+        if let Some(enum_type) = enum_type {
+            self.add_enum(enum_name, enum_type, validation);
+        }
+        self
+    }
+
+    pub fn add_list<'a, T, I, Output>(
+        &mut self,
+        field_name: &str,
+        list: T,
+        validation: impl Fn(&'a I) -> Output,
+    ) -> &mut Self
+    where
+        I: 'a,
+        T: IntoIterator<Item = &'a I>,
+        Output: Into<ValidationResult>,
+    {
+        let child_errors = list
+            .into_iter()
+            .map(|item| validation(item).into())
+            .enumerate()
+            .filter_map(|(index, result)| {
+                if result.has_errors() {
+                    Some((index, result))
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeMap<usize, ValidationResult>>();
+
+        if !child_errors.is_empty() {
+            self.state
+                .add_nested(field_name, ValidationErrorsKind::List(child_errors));
+        }
+        self
+    }
+
+    pub fn add_list_option<'a, T, I, Output>(
+        &mut self,
+        list_name: &str,
+        list: Option<T>,
+        validation: impl Fn(&'a I) -> Output,
+    ) -> &mut Self
+    where
+        I: 'a,
+        T: IntoIterator<Item = &'a I>,
+        Output: Into<ValidationResult>,
+    {
+        if let Some(list) = list {
+            self.add_list(list_name, list, validation);
+        }
+        self
+    }
+
+    pub fn add_struct<T>(
+        &mut self,
+        struct_name: &str,
+        r#struct: &T,
+        version: SpecVersion,
+    ) -> &mut Self
+    where
+        T: Validate,
+    {
+        let result = r#struct.validate_version(version);
+        if result.has_errors() {
+            self.state
+                .add_nested(struct_name, ValidationErrorsKind::Struct(result));
+        }
+        self
+    }
+
+    pub fn add_struct_option<T: Validate>(
+        &mut self,
+        struct_name: &str,
+        r#struct: Option<&T>,
+        version: SpecVersion,
+    ) -> &mut Self {
+        if let Some(r#struct) = r#struct {
+            self.add_struct(struct_name, r#struct, version);
+        }
+        self
+    }
+
+    /// Adds a custom validation error.
+    ///
+    /// A custom field is useful for properties that are not directly part of the Bom hierarchy, but
+    /// should be validated too, for example: dependencies between fields, e.g. bom-ref.
+    pub fn add_custom(
+        &mut self,
+        custom_name: &str,
+        error: impl Into<ValidationError>,
+    ) -> &mut Self {
+        self.state.add_custom(custom_name, error.into());
+        self
+    }
+}
+
+impl From<ValidationContext> for ValidationResult {
+    fn from(context: ValidationContext) -> Self {
+        context.state
+    }
+}
+
+impl From<&mut ValidationContext> for ValidationResult {
+    fn from(context: &mut ValidationContext) -> Self {
+        context.state.clone()
+    }
+}
+
+/// The trait that SBOM structs need to implement to validate their content.
+pub trait Validate {
+    fn validate_version(&self, version: SpecVersion) -> ValidationResult;
+
+    fn validate(&self) -> ValidationResult {
+        self.validate_version(SpecVersion::default())
+    }
+}
+
+/// A single validation error with a message, useful to log / display for user.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationError {
+    pub message: String,
+}
+
+impl From<String> for ValidationError {
+    fn from(message: String) -> Self {
+        ValidationError { message }
+    }
+}
+
+impl From<&str> for ValidationError {
+    fn from(message: &str) -> Self {
+        ValidationError::new(message)
+    }
+}
+
+impl ValidationError {
+    pub fn new<D: Display>(message: D) -> Self {
         Self {
             message: message.to_string(),
-            context,
         }
+    }
+}
+
+/// Implements possible hierarchy of a structured SBOM to collect all [`ValidationError`] in.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValidationErrorsKind {
+    /// Collects all field validation errors in context of a struct
+    Struct(ValidationResult),
+    /// Collects all child elements in context of a list, the key is the index into the list, e.g. `Vec`
+    List(BTreeMap<usize, ValidationResult>),
+    /// Contains the list of validation errors for a single field, e.g. struct field.
+    Field(Vec<ValidationError>),
+    /// Represents a single error for an Enum variant.
+    Enum(ValidationError),
+    /// A list validation errors for a custom field.
+    Custom(Vec<ValidationError>),
+}
+
+// --------------------------- Helper functions for tests -------------------------
+
+/// Function to create an enum based error.
+#[cfg(test)]
+pub(crate) fn r#enum(enum_name: &str, error: impl Into<ValidationError>) -> ValidationResult {
+    let mut result = ValidationResult::default();
+    result.add_enum(enum_name, error.into());
+    result
+}
+
+#[cfg(test)]
+pub(crate) fn r#struct(struct_name: &str, errors: impl Into<ValidationResult>) -> ValidationResult {
+    let mut result = ValidationResult::default();
+    result.add_nested(struct_name, ValidationErrorsKind::Struct(errors.into()));
+    result
+}
+
+#[cfg(test)]
+pub(crate) fn list<T>(
+    field_name: &str,
+    validation_errors: impl IntoIterator<Item = (usize, T)>,
+) -> ValidationResult
+where
+    T: Into<ValidationResult>,
+{
+    let list = validation_errors
+        .into_iter()
+        .map(|(index, errors)| (index, errors.into()))
+        .collect::<BTreeMap<usize, ValidationResult>>();
+
+    let mut result = ValidationResult::default();
+    result.add_nested(field_name, ValidationErrorsKind::List(list));
+    result
+}
+
+#[cfg(test)]
+pub(crate) fn field(field_name: &str, error: impl Into<ValidationError>) -> ValidationResult {
+    let mut result = ValidationResult::default();
+    result.add_field(field_name, error.into());
+    result
+}
+
+#[cfg(test)]
+pub(crate) fn custom<I, T>(custom_name: &str, validation_errors: I) -> ValidationResult
+where
+    I: IntoIterator<Item = T>,
+    T: Into<ValidationError>,
+{
+    let validation_errors = validation_errors
+        .into_iter()
+        .map(|i| i.into())
+        .collect::<Vec<ValidationError>>();
+    let mut result = ValidationResult::default();
+    for error in validation_errors {
+        result.add_custom(custom_name, error);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        models::bom::SpecVersion,
+        validation::{field, r#enum, r#struct, Validate, ValidationErrorsKind, ValidationResult},
+    };
+
+    use super::{ValidationContext, ValidationError};
+
+    #[test]
+    fn has_error() {
+        let mut result = ValidationResult::new();
+        result.add_field("test", ValidationError::new("missing"));
+
+        assert!(result.has_error("test"));
+        assert!(!result.has_error("haha"));
+    }
+
+    #[test]
+    fn has_errors() {
+        let mut result = ValidationResult::new();
+        assert!(!result.has_errors());
+
+        result.add_field("hello", ValidationError::new("again"));
+        assert!(result.has_errors());
+    }
+
+    #[test]
+    fn build_validation_errors_enum() {
+        let result = r#enum("hello", "world");
+        assert_eq!(
+            result.error("hello"),
+            Some(&ValidationErrorsKind::Enum("world".into()))
+        );
+    }
+
+    #[test]
+    fn build_validation_errors_hierarchy() {
+        struct Nested {
+            name: String,
+        }
+
+        impl Validate for Nested {
+            fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
+                ValidationContext::new()
+                    .add_field("name", &self.name, |_name| {
+                        Err(ValidationError::new("Failed"))
+                    })
+                    .into()
+            }
+        }
+
+        let validation_result: ValidationResult = ValidationContext::new()
+            .add_enum("test", &2, |_| Err("not a variant".into()))
+            .add_struct(
+                "nested",
+                &Nested {
+                    name: "hello".to_string(),
+                },
+                SpecVersion::V1_3,
+            )
+            .into();
+
+        assert_eq!(
+            validation_result,
+            vec![
+                r#enum("test", "not a variant"),
+                r#struct("nested", field("name", "Failed")),
+            ]
+            .into()
+        );
     }
 }

--- a/cyclonedx-bom/tests/examples_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/examples_tests_v1_4.rs
@@ -13,7 +13,7 @@ mod examples {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
+                let validation_result = bom.validate_default();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -40,7 +40,7 @@ mod examples {
             insta::glob!("examples/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate();
+                    let validation_result = bom.validate_default();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/examples_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/examples_tests_v1_4.rs
@@ -1,6 +1,6 @@
 mod examples {
-    use cyclonedx_bom::models::bom::Bom;
-    use cyclonedx_bom::validation::{Validate, ValidationResult};
+    use cyclonedx_bom::models::bom::{Bom, SpecVersion};
+    use cyclonedx_bom::validation::Validate;
 
     #[ignore]
     #[test]
@@ -13,10 +13,9 @@ mod examples {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
-                assert_eq!(
-                    validation_result,
-                    ValidationResult::Passed,
+                let validation_result = bom.validate_version(SpecVersion::V1_4);
+                assert!(
+                    validation_result.passed(),
                     "{path:?} unexpectedly failed validation"
                 );
 
@@ -40,10 +39,9 @@ mod examples {
             insta::glob!("examples/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate();
-                    assert_ne!(
-                        validation_result,
-                        ValidationResult::Passed,
+                    let validation_result = bom.validate_version(SpecVersion::V1_4);
+                    assert!(
+                        validation_result.has_errors(),
                         "{path:?} unexpectedly passed validation"
                     );
                 }

--- a/cyclonedx-bom/tests/examples_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/examples_tests_v1_4.rs
@@ -13,7 +13,7 @@ mod examples {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate_default();
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -40,7 +40,7 @@ mod examples {
             insta::glob!("examples/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate_default();
+                    let validation_result = bom.validate();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/specification_tests_v1_3.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_3.rs
@@ -12,7 +12,7 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
+                let validation_result = bom.validate_default();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -39,7 +39,7 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
+                let validation_result = bom.validate_default();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -65,7 +65,7 @@ mod v1_3 {
             insta::glob!("spec/1.3/invalid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_3(file) {
-                    let validation_result = bom.validate();
+                    let validation_result = bom.validate_default();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,
@@ -85,7 +85,7 @@ mod v1_3 {
             insta::glob!("spec/1.3/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_3(file) {
-                    let validation_result = bom.validate();
+                    let validation_result = bom.validate_default();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/specification_tests_v1_3.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_3.rs
@@ -1,6 +1,6 @@
 mod v1_3 {
     use cyclonedx_bom::models::bom::{Bom, SpecVersion};
-    use cyclonedx_bom::validation::{Validate, ValidationResult};
+    use cyclonedx_bom::validation::Validate;
 
     #[test]
     fn it_should_parse_all_of_the_valid_xml_specifications() {
@@ -12,10 +12,9 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
-                assert_eq!(
-                    validation_result,
-                    ValidationResult::Passed,
+                let validation_result = bom.validate_version(SpecVersion::V1_3);
+                assert!(
+                    validation_result.passed(),
                     "{path:?} unexpectedly failed validation"
                 );
 
@@ -39,10 +38,9 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
-                assert_eq!(
-                    validation_result,
-                    ValidationResult::Passed,
+                let validation_result = bom.validate_version(SpecVersion::V1_3);
+                assert!(
+                    validation_result.passed(),
                     "{path:?} unexpectedly failed validation"
                 );
 
@@ -66,9 +64,8 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_3(file) {
                     let validation_result = bom.validate_version(SpecVersion::V1_3);
-                    assert_ne!(
-                        validation_result,
-                        ValidationResult::Passed,
+                    assert!(
+                        validation_result.has_errors(),
                         "{path:?} unexpectedly passed validation"
                     );
                 }
@@ -86,9 +83,8 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_3(file) {
                     let validation_result = bom.validate_version(SpecVersion::V1_3);
-                    assert_ne!(
-                        validation_result,
-                        ValidationResult::Passed,
+                    assert!(
+                        validation_result.has_errors(),
                         "{path:?} unexpectedly passed validation"
                     );
                 }

--- a/cyclonedx-bom/tests/specification_tests_v1_3.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_3.rs
@@ -1,5 +1,5 @@
 mod v1_3 {
-    use cyclonedx_bom::models::bom::Bom;
+    use cyclonedx_bom::models::bom::{Bom, SpecVersion};
     use cyclonedx_bom::validation::{Validate, ValidationResult};
 
     #[test]
@@ -12,7 +12,7 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate_default();
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -39,7 +39,7 @@ mod v1_3 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_3(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate_default();
+                let validation_result = bom.validate();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -65,7 +65,7 @@ mod v1_3 {
             insta::glob!("spec/1.3/invalid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_3(file) {
-                    let validation_result = bom.validate_default();
+                    let validation_result = bom.validate_version(SpecVersion::V1_3);
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,
@@ -85,7 +85,7 @@ mod v1_3 {
             insta::glob!("spec/1.3/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_3(file) {
-                    let validation_result = bom.validate_default();
+                    let validation_result = bom.validate_version(SpecVersion::V1_3);
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/specification_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_4.rs
@@ -1,5 +1,5 @@
 mod v1_4 {
-    use cyclonedx_bom::models::bom::Bom;
+    use cyclonedx_bom::models::bom::{Bom, SpecVersion};
     use cyclonedx_bom::validation::{Validate, ValidationResult};
 
     #[test]
@@ -12,7 +12,7 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate_default();
+                let validation_result = bom.validate_version(SpecVersion::V1_4);
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -39,7 +39,7 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate_default();
+                let validation_result = bom.validate_version(SpecVersion::V1_4);
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -65,7 +65,7 @@ mod v1_4 {
             insta::glob!("spec/1.4/invalid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_4(file) {
-                    let validation_result = bom.validate_default();
+                    let validation_result = bom.validate_version(SpecVersion::V1_4);
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,
@@ -85,7 +85,7 @@ mod v1_4 {
             insta::glob!("spec/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate_default();
+                    let validation_result = bom.validate_version(SpecVersion::V1_4);
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,

--- a/cyclonedx-bom/tests/specification_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_4.rs
@@ -13,9 +13,8 @@ mod v1_4 {
                 let bom = Bom::parse_from_xml_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
                 let validation_result = bom.validate_version(SpecVersion::V1_4);
-                assert_eq!(
-                    validation_result,
-                    ValidationResult::Passed,
+                assert!(
+                    validation_result.passed(),
                     "{path:?} unexpectedly failed validation"
                 );
 
@@ -40,9 +39,8 @@ mod v1_4 {
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
                 let validation_result = bom.validate_version(SpecVersion::V1_4);
-                assert_eq!(
-                    validation_result,
-                    ValidationResult::Passed,
+                assert!(
+                    validation_result.passed(),
                     "{path:?} unexpectedly failed validation"
                 );
 
@@ -66,9 +64,8 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_4(file) {
                     let validation_result = bom.validate_version(SpecVersion::V1_4);
-                    assert_ne!(
-                        validation_result,
-                        ValidationResult::Passed,
+                    assert!(
+                        validation_result.has_errors(),
                         "{path:?} unexpectedly passed validation"
                     );
                 }
@@ -86,9 +83,8 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
                     let validation_result = bom.validate_version(SpecVersion::V1_4);
-                    assert_ne!(
-                        validation_result,
-                        ValidationResult::Passed,
+                    assert!(
+                        validation_result.has_errors(),
                         "{path:?} unexpectedly passed validation"
                     );
                 }

--- a/cyclonedx-bom/tests/specification_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_4.rs
@@ -1,6 +1,6 @@
 mod v1_4 {
     use cyclonedx_bom::models::bom::{Bom, SpecVersion};
-    use cyclonedx_bom::validation::{Validate, ValidationResult};
+    use cyclonedx_bom::validation::Validate;
 
     #[test]
     fn it_should_parse_all_of_the_valid_xml_specifications() {

--- a/cyclonedx-bom/tests/specification_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_4.rs
@@ -12,7 +12,7 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_xml_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
+                let validation_result = bom.validate_default();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -39,7 +39,7 @@ mod v1_4 {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 let bom = Bom::parse_from_json_v1_4(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
 
-                let validation_result = bom.validate();
+                let validation_result = bom.validate_default();
                 assert_eq!(
                     validation_result,
                     ValidationResult::Passed,
@@ -65,7 +65,7 @@ mod v1_4 {
             insta::glob!("spec/1.4/invalid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_xml_v1_4(file) {
-                    let validation_result = bom.validate();
+                    let validation_result = bom.validate_default();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,
@@ -85,7 +85,7 @@ mod v1_4 {
             insta::glob!("spec/1.4/invalid*.json", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
                 if let Ok(bom) = Bom::parse_from_json_v1_4(file) {
-                    let validation_result = bom.validate();
+                    let validation_result = bom.validate_default();
                     assert_ne!(
                         validation_result,
                         ValidationResult::Passed,


### PR DESCRIPTION
This PR refactors the current validation logic with the following goals in mind.

* to allow implementations to handle differences in specifications (e.g. license from 1.4 to 1.5), the `SpecVersion` is passed as a parameter to the `validate` method
* to prepare the output of validation errors to improve error diagnostics
* to remove a lot of boiler plate code to handle `ValidationContext`, merging results is now done implicitely
* to keep the hierarchy of validation errors intact without specifying their nesting level explicitely, this avoids constructing paths via `PathComponent`s. Validation was already nested, it's now apparent how the tree hierarchy is built
* to keep hierarchy of validation errors intact, before this change paths were constructed in an inconsistent manner

There are other crates available that were considered, the best candidate was the [validator](https://github.com/Keats/validator) crate. Unfortunately it has seen little activity over the last two years[^1] & did not fully met the requirements, e.g. no ability to pass in a version or handle certain types well. The crate also did not guarantee the order in which validatiion errors occurred. The latter is covered in this PR by using [indexmap](https://crates.io/crates/indexmap).

### Validation Example

To give an example, before this change a validate method would look like:

```rust 
impl Validate for Advisory {
    fn validate_with_context(&self, context: ValidationContext) -> ValidationResult {
        let mut results: Vec<ValidationResult> = vec![];

        if let Some(title) = &self.title {
            let context = context.with_struct("Advisory", "title");

            results.push(title.validate_with_context(context));
        }

        let url_context = context.with_struct("Advisory", "url");
        results.push(self.url.validate_with_context(url_context));

        results
            .into_iter()
            .fold(ValidationResult::default(), |acc, result| acc.merge(result))
    }
}
```

the updated version is now:

```rust 
impl Validate for Advisory {
    fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
        ValidationContext::new()
            .add_field_option("title", self.title.as_ref(), validate_normalized_string)
            .add_field("url", &self.url, validate_uri)
            .into()
    }
}
```

Thankfully there are a few test helpers that allow to write more concise tests to build the hierarchy. To give an example, an assertion previously looked as

```rust 
#[test]
fn invalid_attached_text_should_fail_validation() {
    // ..
    assert_eq!(
        validation_result,
        ValidationResult::Failed {
            reasons: vec![
                FailureReason::new(
                    "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n",
                    ValidationContext::new().with_struct("AttachedText", "content_type")
                ),
                FailureReason::new(
                    "Content is not Base64 encoded",
                    ValidationContext::new().with_struct("AttachedText", "content")
                )
            ]
        }
    );
}
```

which is now written as

```rust 
#[test]
fn invalid_attached_text_should_fail_validation() {
    // ..
    assert_eq!(
        validation_result,
        vec![
            validation::field(
                "content_type",
                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
            ),
            validation::field("content", "Content is not Base64 encoded")
        ]
        .into()
    );
}
```

A few test helper exists to build / describe the hierarchy of validation errors, in particular for the `Bom` the hierarchy becomes quite complex.

### Drawbacks

This approach has a few minor drawbacks:

* handling of types using the NewType pattern, e.g. `pub struct Versions(pub Vec<Version>);` adds an extra nesting level, which is currently marked with the string `"inner"`. When validation diagnostics are added these should be omitted.
* testing dependencies between different fields, e.g. bom-ref, did not improve much. These validation errors have to be added using the `add_custom` function(s) to indicate validation errors between separate fields.

----

[^1]: funny enough, hours before this PR was opened the repository received a number of new commits

