### PR TITLE
Adds a method to parse a generic serde_json::Value

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -95,7 +95,11 @@ impl Bom {
         mut reader: R,
     ) -> Result<Self, crate::errors::JsonReadError> {
         let json: serde_json::Value = serde_json::from_reader(&mut reader)?;
+        Self::parse_from_json_value(json)
+    }
 
+    /// General function to parse a JSON file, fetches the `specVersion` field first then applies the right conversion.
+    pub fn parse_from_json_value(json: Value) -> Result<Self, crate::errors::JsonReadError> {
         if let Some(version) = json.get("specVersion") {
             let version = version
                 .as_str()


### PR DESCRIPTION
This adds a method to be able to parse a generic json_serde::Value
This is not currently possible because the specs are private.