### PR TITLE
Expand & refactor `Tools` types for version 1.5

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -469,7 +469,7 @@ impl SbomGenerator {
 
         let tool = Tool::new("CycloneDX", "cargo-cyclonedx", env!("CARGO_PKG_VERSION"));
 
-        metadata.tools = Some(Tools::Tools(vec![tool]));
+        metadata.tools = Some(Tools::List(vec![tool]));
 
         Ok((metadata, target_kinds))
     }

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -469,7 +469,7 @@ impl SbomGenerator {
 
         let tool = Tool::new("CycloneDX", "cargo-cyclonedx", env!("CARGO_PKG_VERSION"));
 
-        metadata.tools = Some(Tools(vec![tool]));
+        metadata.tools = Some(Tools::Tools(vec![tool]));
 
         Ok((metadata, target_kinds))
     }

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -67,7 +67,7 @@
 //!             .expect("Failed to create UrnUuid"),
 //!     ),
 //!     metadata: Some(Metadata {
-//!         tools: Some(Tools::Tools(vec![Tool {
+//!         tools: Some(Tools::List(vec![Tool {
 //!             name: Some(NormalizedString::new("my_tool")),
 //!             ..Tool::default()
 //!         }])),

--- a/cyclonedx-bom/src/lib.rs
+++ b/cyclonedx-bom/src/lib.rs
@@ -67,7 +67,7 @@
 //!             .expect("Failed to create UrnUuid"),
 //!     ),
 //!     metadata: Some(Metadata {
-//!         tools: Some(Tools(vec![Tool {
+//!         tools: Some(Tools::Tools(vec![Tool {
 //!             name: Some(NormalizedString::new("my_tool")),
 //!             ..Tool::default()
 //!         }])),

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -119,7 +119,7 @@ mod test {
     fn valid_metadata_should_pass_validation() {
         let validation_result = Metadata {
             timestamp: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
-            tools: Some(Tools::Tools(vec![Tool {
+            tools: Some(Tools::List(vec![Tool {
                 vendor: Some(NormalizedString::new("vendor")),
                 name: None,
                 version: None,
@@ -184,7 +184,7 @@ mod test {
     fn invalid_metadata_should_fail_validation() {
         let validation_result = Metadata {
             timestamp: Some(DateTime("invalid date".to_string())),
-            tools: Some(Tools::Tools(vec![Tool {
+            tools: Some(Tools::List(vec![Tool {
                 vendor: Some(NormalizedString("invalid\tvendor".to_string())),
                 name: None,
                 version: None,

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -119,7 +119,7 @@ mod test {
     fn valid_metadata_should_pass_validation() {
         let validation_result = Metadata {
             timestamp: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
-            tools: Some(Tools(vec![Tool {
+            tools: Some(Tools::Tools(vec![Tool {
                 vendor: Some(NormalizedString::new("vendor")),
                 name: None,
                 version: None,
@@ -184,7 +184,7 @@ mod test {
     fn invalid_metadata_should_fail_validation() {
         let validation_result = Metadata {
             timestamp: Some(DateTime("invalid date".to_string())),
-            tools: Some(Tools(vec![Tool {
+            tools: Some(Tools::Tools(vec![Tool {
                 vendor: Some(NormalizedString("invalid\tvendor".to_string())),
                 name: None,
                 version: None,

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -31,9 +31,13 @@ use super::service::Services;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Tools {
     /// Legacy https://cyclonedx.org/docs/1.4/json/#metadata_tools
-    Tools(Vec<Tool>),
-    Components(Components),
-    Services(Services),
+    List(Vec<Tool>),
+
+    /// Added in 1.5
+    Object {
+        services: Services,
+        components: Components,
+    },
 }
 
 impl Validate for Tools {
@@ -41,7 +45,7 @@ impl Validate for Tools {
         let mut context = ValidationContext::new();
 
         if version <= SpecVersion::V1_4 {
-            if !matches!(self, Tools::Tools(_)) {
+            if !matches!(self, Tools::List(_)) {
                 return ValidationContext::new()
                     .add_custom("inner", "Unsupported tools type found.")
                     .into();
@@ -49,16 +53,17 @@ impl Validate for Tools {
         }
 
         match self {
-            Tools::Tools(tools) => {
+            Tools::List(tools) => {
                 context.add_list("inner", tools, |tool| tool.validate_version(version));
             }
-            Tools::Components(components) => {
-                context.add_list("inner", &components.0, |component| {
+            Tools::Object {
+                services,
+                components,
+            } => {
+                context.add_list("components", &components.0, |component| {
                     component.validate_version(version)
                 });
-            }
-            Tools::Services(services) => {
-                context.add_list("inner", &services.0, |service| {
+                context.add_list("services", &services.0, |service| {
                     service.validate_version(version)
                 });
             }
@@ -116,16 +121,17 @@ mod test {
     use crate::{
         models::{
             bom::SpecVersion,
-            service::Services,
+            component::Classification,
+            service::{Service, Services},
             tool::{Tool, Tools},
         },
-        prelude::{Components, NormalizedString, Validate},
+        prelude::{Component, Components, NormalizedString, Validate},
         validation,
     };
 
     #[test]
     fn it_should_pass_validation() {
-        let validation_result = Tools::Tools(vec![Tool {
+        let validation_result = Tools::List(vec![Tool {
             vendor: Some(NormalizedString("no_whitespace".to_string())),
             name: None,
             version: None,
@@ -138,7 +144,7 @@ mod test {
 
     #[test]
     fn it_should_fail_validation() {
-        let validation_result = Tools::Tools(vec![Tool {
+        let validation_result = Tools::List(vec![Tool {
             vendor: Some(NormalizedString("spaces and\ttabs".to_string())),
             name: None,
             version: None,
@@ -163,7 +169,7 @@ mod test {
 
     #[test]
     fn it_should_merge_validations_correctly() {
-        let validation_result = Tools::Tools(vec![
+        let validation_result = Tools::List(vec![
             Tool {
                 vendor: Some(NormalizedString("no_whitespace".to_string())),
                 name: None,
@@ -211,17 +217,31 @@ mod test {
 
     #[test]
     fn it_should_handle_different_tools() {
-        assert!(!Tools::Services(Services(vec![]))
+        let tool = Tool::new("A vendor", "cargo-cyclonedx", "0.1");
+        let service = Service::new("service-x", Some("bom-ref".to_string()));
+        let component = Component::new(Classification::Application, "lib-x", "0.1.0", None);
+
+        assert!(Tools::List(vec![tool.clone()])
             .validate_version(SpecVersion::V1_3)
             .passed());
-        assert!(!Tools::Services(Services(vec![]))
+        assert!(Tools::List(vec![tool.clone()])
             .validate_version(SpecVersion::V1_4)
             .passed());
-        assert!(Tools::Services(Services(vec![]))
+        assert!(Tools::List(vec![tool])
             .validate_version(SpecVersion::V1_5)
             .passed());
-        assert!(Tools::Components(Components(vec![]))
-            .validate_version(SpecVersion::V1_5)
-            .passed());
+
+        assert!(Tools::Object {
+            services: Services(vec![service.clone()]),
+            components: Components(vec![component.clone()])
+        }
+        .validate_version(SpecVersion::V1_4)
+        .has_errors());
+        assert!(Tools::Object {
+            services: Services(vec![service.clone()]),
+            components: Components(vec![component.clone()])
+        }
+        .validate_version(SpecVersion::V1_5)
+        .passed());
     }
 }

--- a/cyclonedx-bom/src/specs/common/hash.rs
+++ b/cyclonedx-bom/src/specs/common/hash.rs
@@ -27,7 +27,7 @@ use xml::writer;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(transparent)]
-pub(crate) struct Hashes(Vec<Hash>);
+pub(crate) struct Hashes(pub(crate) Vec<Hash>);
 
 impl From<models::hash::Hashes> for Hashes {
     fn from(other: models::hash::Hashes) -> Self {
@@ -79,8 +79,8 @@ impl FromXml for Hashes {
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Hash {
-    alg: String,
-    content: HashValue,
+    pub(crate) alg: String,
+    pub(crate) content: HashValue,
 }
 
 impl From<models::hash::Hash> for Hash {
@@ -144,7 +144,7 @@ impl FromXml for Hash {
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
-pub(crate) struct HashValue(String);
+pub(crate) struct HashValue(pub(crate) String);
 
 impl From<models::hash::HashValue> for HashValue {
     fn from(other: models::hash::HashValue) -> Self {

--- a/cyclonedx-bom/src/specs/common/mod.rs
+++ b/cyclonedx-bom/src/specs/common/mod.rs
@@ -26,4 +26,3 @@ pub(crate) mod organization;
 pub(crate) mod property;
 pub(crate) mod service;
 pub(crate) mod signature;
-pub(crate) mod tool;

--- a/cyclonedx-bom/src/specs/common/service.rs
+++ b/cyclonedx-bom/src/specs/common/service.rs
@@ -51,7 +51,7 @@ pub(crate) mod base {
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(transparent)]
-    pub(crate) struct Services(Vec<Service>);
+    pub(crate) struct Services(pub Vec<Service>);
 
     impl From<models::service::Services> for Services {
         fn from(other: models::service::Services) -> Self {
@@ -105,38 +105,38 @@ pub(crate) mod base {
     #[serde(rename_all = "camelCase")]
     pub(crate) struct Service {
         #[serde(rename = "bom-ref", skip_serializing_if = "Option::is_none")]
-        bom_ref: Option<String>,
+        pub(crate) bom_ref: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        provider: Option<OrganizationalEntity>,
+        pub(crate) provider: Option<OrganizationalEntity>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        group: Option<String>,
-        name: String,
+        pub(crate) group: Option<String>,
+        pub(crate) name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<String>,
+        pub(crate) version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        description: Option<String>,
+        pub(crate) description: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        endpoints: Option<Vec<String>>,
+        pub(crate) endpoints: Option<Vec<String>>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        authenticated: Option<bool>,
+        pub(crate) authenticated: Option<bool>,
         #[serde(rename = "x-trust-boundary", skip_serializing_if = "Option::is_none")]
-        x_trust_boundary: Option<bool>,
+        pub(crate) x_trust_boundary: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        data: Option<Vec<DataClassification>>,
+        pub(crate) data: Option<Vec<DataClassification>>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        licenses: Option<Licenses>,
+        pub(crate) licenses: Option<Licenses>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        external_references: Option<ExternalReferences>,
+        pub(crate) external_references: Option<ExternalReferences>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        properties: Option<Properties>,
+        pub(crate) properties: Option<Properties>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        services: Option<Services>,
+        pub(crate) services: Option<Services>,
         #[versioned("1.4", "1.5")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        signature: Option<Signature>,
+        pub(crate) signature: Option<Signature>,
         #[versioned("1.5")]
         #[serde(skip_serializing_if = "Option::is_none")]
-        trust_zone: Option<String>,
+        pub(crate) trust_zone: Option<String>,
     }
 
     impl From<models::service::Service> for Service {
@@ -505,7 +505,7 @@ pub(crate) mod base {
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(rename_all = "camelCase")]
-    struct DataClassification {
+    pub(crate) struct DataClassification {
         flow: String,
         classification: String,
     }

--- a/cyclonedx-bom/src/specs/v1_3/metadata.rs
+++ b/cyclonedx-bom/src/specs/v1_3/metadata.rs
@@ -22,9 +22,9 @@ use crate::{
     models,
     specs::common::{
         organization::OrganizationalContact, organization::OrganizationalEntity,
-        property::Properties, tool::Tools,
+        property::Properties,
     },
-    specs::v1_3::{component::Component, license::Licenses},
+    specs::v1_3::{component::Component, license::Licenses, tool::Tools},
     utilities::{convert_optional, convert_optional_vec, try_convert_optional},
     xml::{
         read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
@@ -285,11 +285,11 @@ pub(crate) mod test {
                 corresponding_contact, corresponding_entity, example_contact, example_entity,
             },
             property::test::{corresponding_properties, example_properties},
-            tool::test::{corresponding_tools, example_tools},
         },
         specs::v1_3::{
             component::test::{corresponding_component, example_component},
             license::test::{corresponding_licenses, example_licenses},
+            tool::test::{corresponding_tools, example_tools},
         },
         xml::test::{read_element_from_string, write_element_to_string},
     };

--- a/cyclonedx-bom/src/specs/v1_3/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_3/mod.rs
@@ -21,5 +21,6 @@ pub(crate) mod component;
 pub(crate) mod composition;
 pub(crate) mod license;
 pub(crate) mod metadata;
+pub(crate) mod tool;
 
 pub(crate) use crate::specs::common::service::v1_3 as service;

--- a/cyclonedx-bom/src/specs/v1_3/snapshots/cyclonedx_bom__specs__v1_3__tool__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/v1_3/snapshots/cyclonedx_bom__specs__v1_3__tool__test__it_should_write_xml_full.snap
@@ -1,0 +1,16 @@
+---
+source: cyclonedx-bom/src/specs/v1_3/tool.rs
+assertion_line: 263
+expression: xml_output
+---
+<?xml version="1.0" encoding="utf-8"?>
+<tools>
+  <tool>
+    <vendor>vendor</vendor>
+    <name>name</name>
+    <version>version</version>
+    <hashes>
+      <hash alg="algorithm">hash value</hash>
+    </hashes>
+  </tool>
+</tools>

--- a/cyclonedx-bom/src/specs/v1_3/tool.rs
+++ b/cyclonedx-bom/src/specs/v1_3/tool.rs
@@ -36,18 +36,16 @@ pub(crate) struct Tools(Vec<Tool>);
 
 impl From<models::tool::Tools> for Tools {
     fn from(other: models::tool::Tools) -> Self {
-        // Tools(convert_vec(other.0))
         match other {
-            models::tool::Tools::Tools(tools) => Tools(convert_vec(tools)),
-            models::tool::Tools::Components(_) => todo!(),
-            models::tool::Tools::Services(_) => todo!(),
+            models::tool::Tools::List(tools) => Tools(convert_vec(tools)),
+            models::tool::Tools::Object { .. } => Tools(vec![]),
         }
     }
 }
 
 impl From<Tools> for models::tool::Tools {
     fn from(other: Tools) -> Self {
-        models::tool::Tools::Tools(convert_vec(other.0))
+        models::tool::Tools::List(convert_vec(other.0))
     }
 }
 
@@ -236,7 +234,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn corresponding_tools() -> models::tool::Tools {
-        models::tool::Tools::Tools(vec![corresponding_tool()])
+        models::tool::Tools::List(vec![corresponding_tool()])
     }
 
     pub(crate) fn example_tool() -> Tool {

--- a/cyclonedx-bom/src/specs/v1_3/tool.rs
+++ b/cyclonedx-bom/src/specs/v1_3/tool.rs
@@ -1,0 +1,284 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::{
+    errors::XmlReadError,
+    external_models::normalized_string::NormalizedString,
+    specs::common::hash::Hashes,
+    utilities::convert_vec,
+    xml::{
+        read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
+        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+    },
+};
+use crate::{models, utilities::convert_optional};
+use serde::{Deserialize, Serialize};
+use xml::{reader, writer};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(transparent)]
+pub(crate) struct Tools(Vec<Tool>);
+
+impl From<models::tool::Tools> for Tools {
+    fn from(other: models::tool::Tools) -> Self {
+        // Tools(convert_vec(other.0))
+        match other {
+            models::tool::Tools::Tools(tools) => Tools(convert_vec(tools)),
+            models::tool::Tools::Components(_) => todo!(),
+            models::tool::Tools::Services(_) => todo!(),
+        }
+    }
+}
+
+impl From<Tools> for models::tool::Tools {
+    fn from(other: Tools) -> Self {
+        models::tool::Tools::Tools(convert_vec(other.0))
+    }
+}
+
+const TOOLS_TAG: &str = "tools";
+
+impl ToXml for Tools {
+    fn write_xml_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        writer
+            .write(writer::XmlEvent::start_element(TOOLS_TAG))
+            .map_err(to_xml_write_error(TOOLS_TAG))?;
+
+        for tool in &self.0 {
+            tool.write_xml_element(writer)?;
+        }
+
+        writer
+            .write(writer::XmlEvent::end_element())
+            .map_err(to_xml_write_error(TOOLS_TAG))?;
+        Ok(())
+    }
+}
+
+impl FromXml for Tools {
+    fn read_xml_element<R: std::io::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        _attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, XmlReadError>
+    where
+        Self: Sized,
+    {
+        read_list_tag(event_reader, element_name, TOOL_TAG).map(Tools)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Tool {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vendor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hashes: Option<Hashes>,
+}
+
+impl From<models::tool::Tool> for Tool {
+    fn from(other: models::tool::Tool) -> Self {
+        Self {
+            vendor: other.vendor.map(|v| v.to_string()),
+            name: other.name.map(|n| n.to_string()),
+            version: other.version.map(|v| v.to_string()),
+            hashes: convert_optional(other.hashes),
+        }
+    }
+}
+
+impl From<Tool> for models::tool::Tool {
+    fn from(other: Tool) -> Self {
+        Self {
+            vendor: other.vendor.map(NormalizedString::new_unchecked),
+            name: other.name.map(NormalizedString::new_unchecked),
+            version: other.version.map(NormalizedString::new_unchecked),
+            hashes: convert_optional(other.hashes),
+        }
+    }
+}
+
+const TOOL_TAG: &str = "tool";
+const VENDOR_TAG: &str = "vendor";
+const NAME_TAG: &str = "name";
+const VERSION_TAG: &str = "version";
+
+impl ToXml for Tool {
+    fn write_xml_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        writer
+            .write(writer::XmlEvent::start_element(TOOL_TAG))
+            .map_err(to_xml_write_error(TOOL_TAG))?;
+
+        if let Some(vendor) = &self.vendor {
+            write_simple_tag(writer, VENDOR_TAG, vendor)?;
+        }
+
+        if let Some(name) = &self.name {
+            write_simple_tag(writer, NAME_TAG, name)?;
+        }
+
+        if let Some(version) = &self.version {
+            write_simple_tag(writer, VERSION_TAG, version)?;
+        }
+
+        if let Some(hashes) = &self.hashes {
+            if hashes.will_write() {
+                hashes.write_xml_element(writer)?;
+            }
+        }
+
+        writer
+            .write(writer::XmlEvent::end_element())
+            .map_err(to_xml_write_error(TOOL_TAG))?;
+
+        Ok(())
+    }
+
+    fn will_write(&self) -> bool {
+        self.vendor.is_some()
+            || self.name.is_some()
+            || self.version.is_some()
+            || self.hashes.is_some()
+    }
+}
+
+const HASHES_TAG: &str = "hashes";
+
+impl FromXml for Tool {
+    fn read_xml_element<R: std::io::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        _attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, XmlReadError>
+    where
+        Self: Sized,
+    {
+        let mut vendor: Option<String> = None;
+        let mut tool_name: Option<String> = None;
+        let mut version: Option<String> = None;
+        let mut hashes: Option<Hashes> = None;
+
+        let mut got_end_tag = false;
+        while !got_end_tag {
+            let next_element = event_reader.next().map_err(to_xml_read_error(TOOL_TAG))?;
+            match next_element {
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == VENDOR_TAG => {
+                    vendor = Some(read_simple_tag(event_reader, &name)?)
+                }
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == NAME_TAG => {
+                    tool_name = Some(read_simple_tag(event_reader, &name)?)
+                }
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == VERSION_TAG => {
+                    version = Some(read_simple_tag(event_reader, &name)?)
+                }
+                reader::XmlEvent::StartElement {
+                    name, attributes, ..
+                } if name.local_name == HASHES_TAG => {
+                    hashes = Some(Hashes::read_xml_element(event_reader, &name, &attributes)?)
+                }
+                // lax validation of any elements from a different schema
+                reader::XmlEvent::StartElement { name, .. } => {
+                    read_lax_validation_tag(event_reader, &name)?
+                }
+                reader::XmlEvent::EndElement { name } if &name == element_name => {
+                    got_end_tag = true;
+                }
+                unexpected => return Err(unexpected_element_error(element_name, unexpected)),
+            }
+        }
+
+        Ok(Self {
+            vendor,
+            name: tool_name,
+            version,
+            hashes,
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::{
+        specs::common::hash::test::{corresponding_hashes, example_hashes},
+        xml::test::{read_element_from_string, write_element_to_string},
+    };
+
+    use super::*;
+
+    pub(crate) fn example_tools() -> Tools {
+        Tools(vec![example_tool()])
+    }
+
+    pub(crate) fn corresponding_tools() -> models::tool::Tools {
+        models::tool::Tools::Tools(vec![corresponding_tool()])
+    }
+
+    pub(crate) fn example_tool() -> Tool {
+        Tool {
+            vendor: Some("vendor".to_string()),
+            name: Some("name".to_string()),
+            version: Some("version".to_string()),
+            hashes: Some(example_hashes()),
+        }
+    }
+
+    pub(crate) fn corresponding_tool() -> models::tool::Tool {
+        models::tool::Tool {
+            vendor: Some(NormalizedString::new_unchecked("vendor".to_string())),
+            name: Some(NormalizedString::new_unchecked("name".to_string())),
+            version: Some(NormalizedString::new_unchecked("version".to_string())),
+            hashes: Some(corresponding_hashes()),
+        }
+    }
+
+    #[test]
+    fn it_should_write_xml_full() {
+        let xml_output = write_element_to_string(example_tools());
+        insta::assert_snapshot!(xml_output);
+    }
+
+    #[test]
+    fn it_should_read_xml_full() {
+        let input = r#"
+<tools>
+  <tool>
+    <vendor>vendor</vendor>
+    <name>name</name>
+    <version>version</version>
+    <hashes>
+      <hash alg="algorithm">hash value</hash>
+    </hashes>
+  </tool>
+</tools>
+"#;
+        let actual: Tools = read_element_from_string(input);
+        let expected = example_tools();
+        assert_eq!(actual, expected);
+    }
+}

--- a/cyclonedx-bom/src/specs/v1_4/metadata.rs
+++ b/cyclonedx-bom/src/specs/v1_4/metadata.rs
@@ -21,9 +21,9 @@ use crate::{
     models,
     specs::common::{
         organization::OrganizationalContact, organization::OrganizationalEntity,
-        property::Properties, tool::Tools,
+        property::Properties,
     },
-    specs::v1_4::{component::Component, license::Licenses},
+    specs::v1_4::{component::Component, license::Licenses, tool::Tools},
     utilities::{convert_optional, convert_optional_vec},
     xml::{
         read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
@@ -281,11 +281,11 @@ pub(crate) mod test {
                 corresponding_contact, corresponding_entity, example_contact, example_entity,
             },
             property::test::{corresponding_properties, example_properties},
-            tool::test::{corresponding_tools, example_tools},
         },
         specs::v1_4::{
             component::test::{corresponding_component, example_component},
             license::test::{corresponding_licenses, example_licenses},
+            tool::test::{corresponding_tools, example_tools},
         },
         xml::test::{read_element_from_string, write_element_to_string},
     };

--- a/cyclonedx-bom/src/specs/v1_4/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_4/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod component;
 pub(crate) mod composition;
 pub(crate) mod license;
 pub(crate) mod metadata;
+pub(crate) mod tool;
 pub(crate) mod vulnerability;
 pub(crate) mod vulnerability_analysis;
 pub(crate) mod vulnerability_credits;

--- a/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__tool__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/v1_4/snapshots/cyclonedx_bom__specs__v1_4__tool__test__it_should_write_xml_full.snap
@@ -1,0 +1,16 @@
+---
+source: cyclonedx-bom/src/specs/v1_4/tool.rs
+assertion_line: 263
+expression: xml_output
+---
+<?xml version="1.0" encoding="utf-8"?>
+<tools>
+  <tool>
+    <vendor>vendor</vendor>
+    <name>name</name>
+    <version>version</version>
+    <hashes>
+      <hash alg="algorithm">hash value</hash>
+    </hashes>
+  </tool>
+</tools>

--- a/cyclonedx-bom/src/specs/v1_4/tool.rs
+++ b/cyclonedx-bom/src/specs/v1_4/tool.rs
@@ -36,18 +36,16 @@ pub(crate) struct Tools(Vec<Tool>);
 
 impl From<models::tool::Tools> for Tools {
     fn from(other: models::tool::Tools) -> Self {
-        // Tools(convert_vec(other.0))
         match other {
-            models::tool::Tools::Tools(tools) => Tools(convert_vec(tools)),
-            models::tool::Tools::Components(_) => todo!(),
-            models::tool::Tools::Services(_) => todo!(),
+            models::tool::Tools::List(tools) => Tools(convert_vec(tools)),
+            models::tool::Tools::Object { .. } => Tools(vec![]),
         }
     }
 }
 
 impl From<Tools> for models::tool::Tools {
     fn from(other: Tools) -> Self {
-        models::tool::Tools::Tools(convert_vec(other.0))
+        models::tool::Tools::List(convert_vec(other.0))
     }
 }
 
@@ -236,7 +234,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn corresponding_tools() -> models::tool::Tools {
-        models::tool::Tools::Tools(vec![corresponding_tool()])
+        models::tool::Tools::List(vec![corresponding_tool()])
     }
 
     pub(crate) fn example_tool() -> Tool {

--- a/cyclonedx-bom/src/specs/v1_4/tool.rs
+++ b/cyclonedx-bom/src/specs/v1_4/tool.rs
@@ -1,0 +1,284 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::{
+    errors::XmlReadError,
+    external_models::normalized_string::NormalizedString,
+    specs::common::hash::Hashes,
+    utilities::convert_vec,
+    xml::{
+        read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
+        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+    },
+};
+use crate::{models, utilities::convert_optional};
+use serde::{Deserialize, Serialize};
+use xml::{reader, writer};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(transparent)]
+pub(crate) struct Tools(Vec<Tool>);
+
+impl From<models::tool::Tools> for Tools {
+    fn from(other: models::tool::Tools) -> Self {
+        // Tools(convert_vec(other.0))
+        match other {
+            models::tool::Tools::Tools(tools) => Tools(convert_vec(tools)),
+            models::tool::Tools::Components(_) => todo!(),
+            models::tool::Tools::Services(_) => todo!(),
+        }
+    }
+}
+
+impl From<Tools> for models::tool::Tools {
+    fn from(other: Tools) -> Self {
+        models::tool::Tools::Tools(convert_vec(other.0))
+    }
+}
+
+const TOOLS_TAG: &str = "tools";
+
+impl ToXml for Tools {
+    fn write_xml_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        writer
+            .write(writer::XmlEvent::start_element(TOOLS_TAG))
+            .map_err(to_xml_write_error(TOOLS_TAG))?;
+
+        for tool in &self.0 {
+            tool.write_xml_element(writer)?;
+        }
+
+        writer
+            .write(writer::XmlEvent::end_element())
+            .map_err(to_xml_write_error(TOOLS_TAG))?;
+        Ok(())
+    }
+}
+
+impl FromXml for Tools {
+    fn read_xml_element<R: std::io::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        _attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, XmlReadError>
+    where
+        Self: Sized,
+    {
+        read_list_tag(event_reader, element_name, TOOL_TAG).map(Tools)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct Tool {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vendor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hashes: Option<Hashes>,
+}
+
+impl From<models::tool::Tool> for Tool {
+    fn from(other: models::tool::Tool) -> Self {
+        Self {
+            vendor: other.vendor.map(|v| v.to_string()),
+            name: other.name.map(|n| n.to_string()),
+            version: other.version.map(|v| v.to_string()),
+            hashes: convert_optional(other.hashes),
+        }
+    }
+}
+
+impl From<Tool> for models::tool::Tool {
+    fn from(other: Tool) -> Self {
+        Self {
+            vendor: other.vendor.map(NormalizedString::new_unchecked),
+            name: other.name.map(NormalizedString::new_unchecked),
+            version: other.version.map(NormalizedString::new_unchecked),
+            hashes: convert_optional(other.hashes),
+        }
+    }
+}
+
+const TOOL_TAG: &str = "tool";
+const VENDOR_TAG: &str = "vendor";
+const NAME_TAG: &str = "name";
+const VERSION_TAG: &str = "version";
+
+impl ToXml for Tool {
+    fn write_xml_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        writer
+            .write(writer::XmlEvent::start_element(TOOL_TAG))
+            .map_err(to_xml_write_error(TOOL_TAG))?;
+
+        if let Some(vendor) = &self.vendor {
+            write_simple_tag(writer, VENDOR_TAG, vendor)?;
+        }
+
+        if let Some(name) = &self.name {
+            write_simple_tag(writer, NAME_TAG, name)?;
+        }
+
+        if let Some(version) = &self.version {
+            write_simple_tag(writer, VERSION_TAG, version)?;
+        }
+
+        if let Some(hashes) = &self.hashes {
+            if hashes.will_write() {
+                hashes.write_xml_element(writer)?;
+            }
+        }
+
+        writer
+            .write(writer::XmlEvent::end_element())
+            .map_err(to_xml_write_error(TOOL_TAG))?;
+
+        Ok(())
+    }
+
+    fn will_write(&self) -> bool {
+        self.vendor.is_some()
+            || self.name.is_some()
+            || self.version.is_some()
+            || self.hashes.is_some()
+    }
+}
+
+const HASHES_TAG: &str = "hashes";
+
+impl FromXml for Tool {
+    fn read_xml_element<R: std::io::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        _attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, XmlReadError>
+    where
+        Self: Sized,
+    {
+        let mut vendor: Option<String> = None;
+        let mut tool_name: Option<String> = None;
+        let mut version: Option<String> = None;
+        let mut hashes: Option<Hashes> = None;
+
+        let mut got_end_tag = false;
+        while !got_end_tag {
+            let next_element = event_reader.next().map_err(to_xml_read_error(TOOL_TAG))?;
+            match next_element {
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == VENDOR_TAG => {
+                    vendor = Some(read_simple_tag(event_reader, &name)?)
+                }
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == NAME_TAG => {
+                    tool_name = Some(read_simple_tag(event_reader, &name)?)
+                }
+                reader::XmlEvent::StartElement { name, .. } if name.local_name == VERSION_TAG => {
+                    version = Some(read_simple_tag(event_reader, &name)?)
+                }
+                reader::XmlEvent::StartElement {
+                    name, attributes, ..
+                } if name.local_name == HASHES_TAG => {
+                    hashes = Some(Hashes::read_xml_element(event_reader, &name, &attributes)?)
+                }
+                // lax validation of any elements from a different schema
+                reader::XmlEvent::StartElement { name, .. } => {
+                    read_lax_validation_tag(event_reader, &name)?
+                }
+                reader::XmlEvent::EndElement { name } if &name == element_name => {
+                    got_end_tag = true;
+                }
+                unexpected => return Err(unexpected_element_error(element_name, unexpected)),
+            }
+        }
+
+        Ok(Self {
+            vendor,
+            name: tool_name,
+            version,
+            hashes,
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::{
+        specs::common::hash::test::{corresponding_hashes, example_hashes},
+        xml::test::{read_element_from_string, write_element_to_string},
+    };
+
+    use super::*;
+
+    pub(crate) fn example_tools() -> Tools {
+        Tools(vec![example_tool()])
+    }
+
+    pub(crate) fn corresponding_tools() -> models::tool::Tools {
+        models::tool::Tools::Tools(vec![corresponding_tool()])
+    }
+
+    pub(crate) fn example_tool() -> Tool {
+        Tool {
+            vendor: Some("vendor".to_string()),
+            name: Some("name".to_string()),
+            version: Some("version".to_string()),
+            hashes: Some(example_hashes()),
+        }
+    }
+
+    pub(crate) fn corresponding_tool() -> models::tool::Tool {
+        models::tool::Tool {
+            vendor: Some(NormalizedString::new_unchecked("vendor".to_string())),
+            name: Some(NormalizedString::new_unchecked("name".to_string())),
+            version: Some(NormalizedString::new_unchecked("version".to_string())),
+            hashes: Some(corresponding_hashes()),
+        }
+    }
+
+    #[test]
+    fn it_should_write_xml_full() {
+        let xml_output = write_element_to_string(example_tools());
+        insta::assert_snapshot!(xml_output);
+    }
+
+    #[test]
+    fn it_should_read_xml_full() {
+        let input = r#"
+<tools>
+  <tool>
+    <vendor>vendor</vendor>
+    <name>name</name>
+    <version>version</version>
+    <hashes>
+      <hash alg="algorithm">hash value</hash>
+    </hashes>
+  </tool>
+</tools>
+"#;
+        let actual: Tools = read_element_from_string(input);
+        let expected = example_tools();
+        assert_eq!(actual, expected);
+    }
+}

--- a/cyclonedx-bom/src/specs/v1_4/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/v1_4/vulnerability.rs
@@ -30,11 +30,12 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use xml::{reader, writer::XmlEvent};
 
-use crate::specs::common::{advisory::Advisories, property::Properties, tool::Tools};
+use crate::specs::common::{advisory::Advisories, property::Properties};
 use crate::specs::v1_4::{
-    vulnerability_analysis::VulnerabilityAnalysis, vulnerability_credits::VulnerabilityCredits,
-    vulnerability_rating::VulnerabilityRatings, vulnerability_reference::VulnerabilityReferences,
-    vulnerability_source::VulnerabilitySource, vulnerability_target::VulnerabilityTargets,
+    tool::Tools, vulnerability_analysis::VulnerabilityAnalysis,
+    vulnerability_credits::VulnerabilityCredits, vulnerability_rating::VulnerabilityRatings,
+    vulnerability_reference::VulnerabilityReferences, vulnerability_source::VulnerabilitySource,
+    vulnerability_target::VulnerabilityTargets,
 };
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -500,9 +501,9 @@ pub(crate) mod test {
         specs::common::{
             advisory::test::{corresponding_advisories, example_advisories},
             property::test::{corresponding_properties, example_properties},
-            tool::test::{corresponding_tools, example_tools},
         },
         specs::v1_4::{
+            tool::test::{corresponding_tools, example_tools},
             vulnerability_analysis::test::{
                 corresponding_vulnerability_analysis, example_vulnerability_analysis,
             },

--- a/cyclonedx-bom/src/specs/v1_5/component.rs
+++ b/cyclonedx-bom/src/specs/v1_5/component.rs
@@ -50,7 +50,7 @@ use xml::{reader, writer::XmlEvent};
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(transparent)]
-pub(crate) struct Components(Vec<Component>);
+pub(crate) struct Components(pub(crate) Vec<Component>);
 
 impl From<models::component::Components> for Components {
     fn from(other: models::component::Components) -> Self {
@@ -113,53 +113,53 @@ impl FromXml for Components {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Component {
     #[serde(rename = "type")]
-    component_type: String,
+    pub(crate) component_type: String,
     #[serde(rename = "mime-type", skip_serializing_if = "Option::is_none")]
-    mime_type: Option<MimeType>,
+    pub(crate) mime_type: Option<MimeType>,
     #[serde(rename = "bom-ref", skip_serializing_if = "Option::is_none")]
-    bom_ref: Option<String>,
+    pub(crate) bom_ref: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    supplier: Option<OrganizationalEntity>,
+    pub(crate) supplier: Option<OrganizationalEntity>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    author: Option<String>,
+    pub(crate) author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    publisher: Option<String>,
+    pub(crate) publisher: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    group: Option<String>,
-    name: String,
+    pub(crate) group: Option<String>,
+    pub(crate) name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    version: Option<String>,
+    pub(crate) version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    pub(crate) description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    scope: Option<String>,
+    pub(crate) scope: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    hashes: Option<Hashes>,
+    pub(crate) hashes: Option<Hashes>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    licenses: Option<Licenses>,
+    pub(crate) licenses: Option<Licenses>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    copyright: Option<String>,
+    pub(crate) copyright: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cpe: Option<Cpe>,
+    pub(crate) cpe: Option<Cpe>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    purl: Option<String>,
+    pub(crate) purl: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    swid: Option<Swid>,
+    pub(crate) swid: Option<Swid>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    modified: Option<bool>,
+    pub(crate) modified: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pedigree: Option<Pedigree>,
+    pub(crate) pedigree: Option<Pedigree>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    external_references: Option<ExternalReferences>,
+    pub(crate) external_references: Option<ExternalReferences>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    properties: Option<Properties>,
+    pub(crate) properties: Option<Properties>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    components: Option<Components>,
+    pub(crate) components: Option<Components>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    evidence: Option<ComponentEvidence>,
+    pub(crate) evidence: Option<ComponentEvidence>,
     /// Available since version 1.4
     #[serde(skip_serializing_if = "Option::is_none")]
-    signature: Option<Signature>,
+    pub(crate) signature: Option<Signature>,
 }
 
 impl From<models::component::Component> for Component {
@@ -588,7 +588,7 @@ impl FromXml for Component {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-struct Swid {
+pub(crate) struct Swid {
     tag_id: String,
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -752,7 +752,7 @@ impl FromXml for Swid {
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
-struct Cpe(String);
+pub(crate) struct Cpe(String);
 
 impl From<models::component::Cpe> for Cpe {
     fn from(other: models::component::Cpe) -> Self {
@@ -792,7 +792,7 @@ impl FromXml for Cpe {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-struct ComponentEvidence {
+pub(crate) struct ComponentEvidence {
     #[serde(skip_serializing_if = "Option::is_none")]
     licenses: Option<Licenses>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -900,7 +900,7 @@ impl FromXml for ComponentEvidence {
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-struct Pedigree {
+pub(crate) struct Pedigree {
     #[serde(skip_serializing_if = "Option::is_none")]
     ancestors: Option<Components>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1185,7 +1185,7 @@ impl FromXml for CopyrightTexts {
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
-struct MimeType(String);
+pub(crate) struct MimeType(String);
 
 impl From<models::component::MimeType> for MimeType {
     fn from(other: models::component::MimeType) -> Self {

--- a/cyclonedx-bom/src/specs/v1_5/metadata.rs
+++ b/cyclonedx-bom/src/specs/v1_5/metadata.rs
@@ -21,9 +21,9 @@ use crate::{
     models,
     specs::common::{
         organization::OrganizationalContact, organization::OrganizationalEntity,
-        property::Properties, tool::Tools,
+        property::Properties,
     },
-    specs::v1_5::{component::Component, license::Licenses, lifecycles::Lifecycles},
+    specs::v1_5::{component::Component, license::Licenses, lifecycles::Lifecycles, tool::Tools},
     utilities::{convert_optional, convert_optional_vec},
     xml::{
         read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
@@ -301,12 +301,12 @@ pub(crate) mod test {
                     corresponding_contact, corresponding_entity, example_contact, example_entity,
                 },
                 property::test::{corresponding_properties, example_properties},
-                tool::test::{corresponding_tools, example_tools},
             },
             v1_5::{
                 component::test::{corresponding_component, example_component},
                 license::test::{corresponding_licenses, example_licenses},
                 lifecycles::test::{corresponding_lifecycles, example_lifecycles},
+                tool::test::{corresponding_tools, example_tools},
             },
         },
         xml::test::{read_element_from_string, write_element_to_string},

--- a/cyclonedx-bom/src/specs/v1_5/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_5/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod composition;
 pub(crate) mod license;
 pub(crate) mod lifecycles;
 pub(crate) mod metadata;
+pub(crate) mod tool;
 pub(crate) mod vulnerability;
 pub(crate) mod vulnerability_analysis;
 pub(crate) mod vulnerability_credits;

--- a/cyclonedx-bom/src/specs/v1_5/snapshots/cyclonedx_bom__specs__v1_5__bom__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/v1_5/snapshots/cyclonedx_bom__specs__v1_5__bom__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/v1_5/bom.rs
-assertion_line: 490
+assertion_line: 507
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>

--- a/cyclonedx-bom/src/specs/v1_5/tool.rs
+++ b/cyclonedx-bom/src/specs/v1_5/tool.rs
@@ -36,13 +36,18 @@ pub(crate) struct Tools(Vec<Tool>);
 
 impl From<models::tool::Tools> for Tools {
     fn from(other: models::tool::Tools) -> Self {
-        Tools(convert_vec(other.0))
+        // Tools(convert_vec(other.0))
+        match other {
+            models::tool::Tools::Tools(tools) => Tools(convert_vec(tools)),
+            models::tool::Tools::Components(_) => todo!(),
+            models::tool::Tools::Services(_) => todo!(),
+        }
     }
 }
 
 impl From<Tools> for models::tool::Tools {
     fn from(other: Tools) -> Self {
-        models::tool::Tools(convert_vec(other.0))
+        models::tool::Tools::Tools(convert_vec(other.0))
     }
 }
 
@@ -231,7 +236,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn corresponding_tools() -> models::tool::Tools {
-        models::tool::Tools(vec![corresponding_tool()])
+        models::tool::Tools::Tools(vec![corresponding_tool()])
     }
 
     pub(crate) fn example_tool() -> Tool {
@@ -275,5 +280,45 @@ pub(crate) mod test {
         let actual: Tools = read_element_from_string(input);
         let expected = example_tools();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn it_should_read_xml_with_services_and_components() {
+        let input = r#"
+<tools>
+  <components>
+    <component type="application">
+      <group>Awesome Vendor</group>
+      <name>Awesome Tool</name>
+      <version>9.1.2</version>
+      <hashes>
+        <hash alg="SHA-1">abcdefgh</hash>
+      </hashes>
+    </component>
+  </components>
+  <services>
+    <service>
+      <provider>Acme Org</provider>
+      <url>https://example.com</url>
+      <group>com.example</group>
+      <name>Acme Signing Server</name>
+      <description>Signs artifacts</description>
+    </service>
+  </services>
+</tools>
+"#;
+        /*
+        let actual: Tools = read_element_from_string(input);
+        let expected = Tools(vec![
+            Tool::Components(Components(vec![Component::new(
+                Classification::Application,
+                "Awesome Tool",
+                "9.1.2",
+                None,
+            )])),
+            Tool::Services(vec![Service::new("Acme Signing Server")]),
+        ]);
+        assert_eq!(actual, expected);
+        */
     }
 }

--- a/cyclonedx-bom/src/specs/v1_5/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/v1_5/vulnerability.rs
@@ -30,11 +30,12 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use xml::{reader, writer::XmlEvent};
 
-use crate::specs::common::{advisory::Advisories, property::Properties, tool::Tools};
+use crate::specs::common::{advisory::Advisories, property::Properties};
 use crate::specs::v1_5::{
-    vulnerability_analysis::VulnerabilityAnalysis, vulnerability_credits::VulnerabilityCredits,
-    vulnerability_rating::VulnerabilityRatings, vulnerability_reference::VulnerabilityReferences,
-    vulnerability_source::VulnerabilitySource, vulnerability_target::VulnerabilityTargets,
+    tool::Tools, vulnerability_analysis::VulnerabilityAnalysis,
+    vulnerability_credits::VulnerabilityCredits, vulnerability_rating::VulnerabilityRatings,
+    vulnerability_reference::VulnerabilityReferences, vulnerability_source::VulnerabilitySource,
+    vulnerability_target::VulnerabilityTargets,
 };
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -502,9 +503,9 @@ pub(crate) mod test {
         specs::common::{
             advisory::test::{corresponding_advisories, example_advisories},
             property::test::{corresponding_properties, example_properties},
-            tool::test::{corresponding_tools, example_tools},
         },
         specs::v1_5::{
+            tool::test::{corresponding_tools, example_tools},
             vulnerability_analysis::test::{
                 corresponding_vulnerability_analysis, example_vulnerability_analysis,
             },

--- a/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.json
+++ b/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.json
@@ -4,23 +4,44 @@
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
   "version": 1,
   "metadata": {
-    "tools": [
-      {
-        "vendor": "Awesome Vendor",
-        "name": "Awesome Tool",
-        "version": "9.1.2",
-        "hashes": [
-          {
-            "alg": "SHA-1",
-            "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "Awesome Vendor",
+          "name": "Awesome Tool",
+          "version": "9.1.2",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "provider": {
+            "name": "Acme Org",
+            "url": [
+              "https://example.com"
+            ]
           },
-          {
-            "alg": "SHA-256",
-            "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
-          }
-        ]
-      }
-    ]
+          "group": "com.example",
+          "name": "Acme Signing Server",
+          "description": "Signs artifacts",
+          "endpoints": [
+            "https://example.com/sign",
+            "https://example.com/verify",
+            "https://example.com/tsa"
+          ]
+        }
+      ]
+    }
   },
   "components": []
 }

--- a/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.xml
+++ b/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.xml
@@ -2,15 +2,33 @@
 <bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
     <metadata>
         <tools>
-            <tool>
-                <vendor>Awesome Vendor</vendor>
-                <name>Awesome Tool</name>
-                <version>9.1.2</version>
-                <hashes>
-                    <hash alg="SHA-1">25ed8e31b995bb927966616df2a42b979a2717f0</hash>
-                    <hash alg="SHA-256">a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df</hash>
-                </hashes>
-            </tool>
+            <components>
+                <component type="application">
+                    <group>Awesome Vendor</group>
+                    <name>Awesome Tool</name>
+                    <version>9.1.2</version>
+                    <hashes>
+                        <hash alg="SHA-1">25ed8e31b995bb927966616df2a42b979a2717f0</hash>
+                        <hash alg="SHA-256">a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df</hash>
+                    </hashes>
+                </component>
+            </components>
+            <services>
+                <service>
+                    <provider>
+                        <name>Acme Org</name>
+                        <url>https://example.com</url>
+                    </provider>
+                    <group>com.example</group>
+                    <name>Acme Signing Server</name>
+                    <description>Signs artifacts</description>
+                    <endpoints>
+                        <endpoint>https://example.com/sign</endpoint>
+                        <endpoint>https://example.com/verify</endpoint>
+                        <endpoint>https://example.com/tsa</endpoint>
+                    </endpoints>
+                </service>
+            </services>
         </tools>
     </metadata>
     <components />

--- a/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-legacy-1.5.json
+++ b/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-legacy-1.5.json
@@ -1,0 +1,26 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "Awesome Vendor",
+        "name": "Awesome Tool",
+        "version": "9.1.2",
+        "hashes": [
+          {
+            "alg": "SHA-1",
+            "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+          },
+          {
+            "alg": "SHA-256",
+            "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
+          }
+        ]
+      }
+    ]
+  },
+  "components": []
+}

--- a/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-legacy-1.5.xml
+++ b/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-legacy-1.5.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.5">
+    <metadata>
+        <tools>
+            <tool>
+                <vendor>Awesome Vendor</vendor>
+                <name>Awesome Tool</name>
+                <version>9.1.2</version>
+                <hashes>
+                    <hash alg="SHA-1">25ed8e31b995bb927966616df2a42b979a2717f0</hash>
+                    <hash alg="SHA-256">a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df</hash>
+                </hashes>
+            </tool>
+        </tools>
+    </metadata>
+    <components />
+</bom>

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-metadata-tool-1.5.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-metadata-tool-1.5.json.snap
@@ -10,23 +10,44 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.json
   "version": 1,
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
   "metadata": {
-    "tools": [
-      {
-        "vendor": "Awesome Vendor",
-        "name": "Awesome Tool",
-        "version": "9.1.2",
-        "hashes": [
-          {
-            "alg": "SHA-1",
-            "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+    "tools": {
+      "services": [
+        {
+          "provider": {
+            "name": "Acme Org",
+            "url": [
+              "https://example.com"
+            ]
           },
-          {
-            "alg": "SHA-256",
-            "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
-          }
-        ]
-      }
-    ]
+          "group": "com.example",
+          "name": "Acme Signing Server",
+          "description": "Signs artifacts",
+          "endpoints": [
+            "https://example.com/sign",
+            "https://example.com/verify",
+            "https://example.com/tsa"
+          ]
+        }
+      ],
+      "components": [
+        {
+          "type": "application",
+          "group": "Awesome Vendor",
+          "name": "Awesome Tool",
+          "version": "9.1.2",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
+            }
+          ]
+        }
+      ]
+    }
   },
   "components": []
 }

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-metadata-tool-legacy-1.5.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-metadata-tool-legacy-1.5.json.snap
@@ -2,7 +2,7 @@
 source: cyclonedx-bom/tests/specification_tests_v1_5.rs
 assertion_line: 52
 expression: bom_output
-input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.json
+input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-legacy-1.5.json
 ---
 {
   "bomFormat": "CycloneDX",

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_xml_specifications@valid-metadata-tool-1.5.xml.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_xml_specifications@valid-metadata-tool-1.5.xml.snap
@@ -8,15 +8,33 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.xml
 <bom xmlns="http://cyclonedx.org/schema/bom/1.5" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
   <metadata>
     <tools>
-      <tool>
-        <vendor>Awesome Vendor</vendor>
-        <name>Awesome Tool</name>
-        <version>9.1.2</version>
-        <hashes>
-          <hash alg="SHA-1">25ed8e31b995bb927966616df2a42b979a2717f0</hash>
-          <hash alg="SHA-256">a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df</hash>
-        </hashes>
-      </tool>
+      <services>
+        <service>
+          <provider>
+            <name>Acme Org</name>
+            <url>https://example.com</url>
+          </provider>
+          <group>com.example</group>
+          <name>Acme Signing Server</name>
+          <description>Signs artifacts</description>
+          <endpoints>
+            <endpoint>https://example.com/sign</endpoint>
+            <endpoint>https://example.com/verify</endpoint>
+            <endpoint>https://example.com/tsa</endpoint>
+          </endpoints>
+        </service>
+      </services>
+      <components>
+        <component type="application">
+          <group>Awesome Vendor</group>
+          <name>Awesome Tool</name>
+          <version>9.1.2</version>
+          <hashes>
+            <hash alg="SHA-1">25ed8e31b995bb927966616df2a42b979a2717f0</hash>
+            <hash alg="SHA-256">a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df</hash>
+          </hashes>
+        </component>
+      </components>
     </tools>
   </metadata>
   <components />

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_xml_specifications@valid-metadata-tool-legacy-1.5.xml.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_xml_specifications@valid-metadata-tool-legacy-1.5.xml.snap
@@ -2,7 +2,7 @@
 source: cyclonedx-bom/tests/specification_tests_v1_5.rs
 assertion_line: 26
 expression: bom_output
-input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-1.5.xml
+input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-legacy-1.5.xml
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <bom xmlns="http://cyclonedx.org/schema/bom/1.5" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">

--- a/cyclonedx-bom/tests/specification_tests_v1_4.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_4.rs
@@ -1,5 +1,3 @@
-mod specification_tests_v1_5;
-
 mod v1_4 {
     use cyclonedx_bom::models::bom::{Bom, SpecVersion};
     use cyclonedx_bom::schema::validate_json_with_schema;


### PR DESCRIPTION
Refactor `Tools` type for spec version 1.5. The type changed to a [`oneOf`](https://cyclonedx.org/docs/1.5/json/#metadata_tools)  property, that can either be a list of `tool` (as before), or contains `<services>` & `<components>`.

The base type changed from a struct into an `enum`.

```rust
pub enum Tools {
    List(Vec<Tool>),
    Object {
        services: Services,
        components: Components,
    },
}
```

After a few refactorings / adjustments, the serialization code works now. Previous `tools` tests used in `metadata` moved to legacy sample files. New samples that declare the `Object` type with `services` & `components` have been added for XML / JSON serialization.

See #646 