### PR TITLE
Add 'bom-ref' to organizational contact

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -97,12 +97,6 @@ impl BomReference {
     }
 }
 
-impl AsRef<String> for BomReference {
-    fn as_ref(&self) -> &String {
-        &self.0
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Bom {
     pub version: u32,

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -126,6 +126,7 @@ mod test {
                 hashes: None,
             }])),
             authors: Some(vec![OrganizationalContact {
+                bom_ref: None,
                 name: Some(NormalizedString::new("name")),
                 email: None,
                 phone: None,
@@ -191,6 +192,7 @@ mod test {
                 hashes: None,
             }])),
             authors: Some(vec![OrganizationalContact {
+                bom_ref: None,
                 name: Some(NormalizedString("invalid\tname".to_string())),
                 email: None,
                 phone: None,

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -24,13 +24,14 @@ use crate::{
     validation::{Validate, ValidationContext, ValidationResult},
 };
 
-use super::bom::SpecVersion;
+use super::bom::{BomReference, SpecVersion};
 
 /// Represents the contact information for an organization
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_organizationalContact)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct OrganizationalContact {
+    pub bom_ref: Option<BomReference>,
     pub name: Option<NormalizedString>,
     pub email: Option<NormalizedString>,
     pub phone: Option<NormalizedString>,
@@ -45,6 +46,7 @@ impl OrganizationalContact {
     /// ```
     pub fn new(name: &str, email: Option<&str>) -> Self {
         Self {
+            bom_ref: None,
             name: Some(NormalizedString::new(name)),
             email: email.map(NormalizedString::new),
             phone: None,
@@ -97,6 +99,7 @@ mod test {
     #[test]
     fn it_should_validate_an_empty_contact_as_passed() {
         let contact = OrganizationalContact {
+            bom_ref: None,
             name: None,
             email: None,
             phone: None,
@@ -108,6 +111,7 @@ mod test {
     #[test]
     fn it_should_validate_an_invalid_contact_as_failed() {
         let contact = OrganizationalContact {
+            bom_ref: None,
             name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
             email: None,
             phone: None,
@@ -126,6 +130,7 @@ mod test {
     #[test]
     fn it_should_validate_a_contact_with_multiple_validation_issues_as_failed() {
         let contact = OrganizationalContact {
+            bom_ref: None,
             name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
             email: Some(NormalizedString::new_unchecked(
                 "invalid\temail".to_string(),
@@ -180,6 +185,7 @@ mod test {
             name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
             url: Some(vec![Uri("invalid uri".to_string())]),
             contact: Some(vec![OrganizationalContact {
+                bom_ref: None,
                 name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
                 email: None,
                 phone: None,

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -44,12 +44,10 @@ impl Validate for Tools {
     fn validate_version(&self, version: SpecVersion) -> ValidationResult {
         let mut context = ValidationContext::new();
 
-        if version <= SpecVersion::V1_4 {
-            if !matches!(self, Tools::List(_)) {
-                return ValidationContext::new()
-                    .add_custom("inner", "Unsupported tools type found.")
-                    .into();
-            }
+        if version <= SpecVersion::V1_4 && !matches!(self, Tools::List(_)) {
+            return ValidationContext::new()
+                .add_custom("inner", "Unsupported tools type found.")
+                .into();
         }
 
         match self {

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -57,6 +57,7 @@ mod test {
                 contact: None,
             }]),
             individuals: Some(vec![OrganizationalContact {
+                bom_ref: None,
                 name: Some(NormalizedString::new("name")),
                 email: None,
                 phone: None,
@@ -76,6 +77,7 @@ mod test {
                 contact: None,
             }]),
             individuals: Some(vec![OrganizationalContact {
+                bom_ref: None,
                 name: Some(NormalizedString("invalid\tname".to_string())),
                 email: None,
                 phone: None,

--- a/cyclonedx-bom/src/specs/v1_5/annotation.rs
+++ b/cyclonedx-bom/src/specs/v1_5/annotation.rs
@@ -609,7 +609,7 @@ pub(crate) mod test {
     fn it_should_read_xml_annotator() {
         let input = r#"
 <annotator>
-  <individual>
+  <individual bom-ref="contact">
     <name>Samantha Wright</name>
     <email>samantha.wright@example.com</email>
     <phone>800-555-1212</phone>
@@ -618,6 +618,7 @@ pub(crate) mod test {
 "#;
         let actual: Annotator = read_element_from_string(input);
         let expected = Annotator::Individual(OrganizationalContact {
+            bom_ref: Some("contact".to_string()),
             name: Some("Samantha Wright".to_string()),
             email: Some("samantha.wright@example.com".to_string()),
             phone: Some("800-555-1212".to_string()),
@@ -638,7 +639,7 @@ pub(crate) mod test {
       <organization>
         <name>Acme, Inc.</name>
         <url>https://example.com</url>
-        <contact>
+        <contact bom-ref="contact-1">
           <name>Acme Professional Services</name>
           <email>professional.services@example.com</email>
         </contact>
@@ -657,6 +658,7 @@ pub(crate) mod test {
                 name: Some(String::from("Acme, Inc.")),
                 url: Some(vec!["https://example.com".to_string()]),
                 contact: Some(vec![OrganizationalContact {
+                    bom_ref: Some("contact-1".to_string()),
                     name: Some("Acme Professional Services".to_string()),
                     email: Some("professional.services@example.com".to_string()),
                     phone: None,


### PR DESCRIPTION
This adds support for the `bom-ref` attribute in the `OrganizatioalContact` type. The attribute has been added in spec version 1.5.