### PR TITLE
Extract BomReference type

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -41,8 +41,6 @@ use crate::models::vulnerability::Vulnerabilities;
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
 use crate::xml::{FromXmlDocument, ToXml};
 
-use super::composition::BomReference;
-
 /// Represents the spec version of a BOM.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, PartialOrd)]
 #[repr(u16)]
@@ -83,6 +81,25 @@ impl ToString for SpecVersion {
             SpecVersion::V1_5 => "1.5",
         };
         s.to_string()
+    }
+}
+
+/// A reference to a Bom element
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BomReference(pub(crate) String);
+
+impl BomReference {
+    pub fn new<T>(input: T) -> Self
+    where
+        T: ToString,
+    {
+        Self(input.to_string())
+    }
+}
+
+impl AsRef<String> for BomReference {
+    fn as_ref(&self) -> &String {
+        &self.0
     }
 }
 
@@ -506,7 +523,7 @@ mod test {
         external_models::{date_time::DateTime, normalized_string::NormalizedString, uri::Uri},
         models::{
             component::{Classification, Component},
-            composition::{AggregateType, BomReference, Composition},
+            composition::{AggregateType, Composition},
             dependency::Dependency,
             external_reference::{ExternalReference, ExternalReferenceType},
             property::Property,

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -18,7 +18,10 @@
 
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
 
-use super::{bom::SpecVersion, signature::Signature};
+use super::{
+    bom::{BomReference, SpecVersion},
+    signature::Signature,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Composition {
@@ -98,9 +101,6 @@ impl AggregateType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BomReference(pub(crate) String);
-
 #[cfg(test)]
 mod test {
     use crate::{models::signature::Algorithm, validation};
@@ -112,8 +112,8 @@ mod test {
     fn it_should_pass_validation() {
         let validation_result = Compositions(vec![Composition {
             aggregate: AggregateType::Complete,
-            assemblies: Some(vec![BomReference("reference".to_string())]),
-            dependencies: Some(vec![BomReference("reference".to_string())]),
+            assemblies: Some(vec![BomReference::new("reference")]),
+            dependencies: Some(vec![BomReference::new("reference")]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate();
@@ -125,8 +125,8 @@ mod test {
     fn it_should_fail_validation() {
         let validation_result = Compositions(vec![Composition {
             aggregate: AggregateType::UnknownAggregateType("unknown aggregate type".to_string()),
-            assemblies: Some(vec![BomReference("reference".to_string())]),
-            dependencies: Some(vec![BomReference("reference".to_string())]),
+            assemblies: Some(vec![BomReference::new("reference")]),
+            dependencies: Some(vec![BomReference::new("reference")]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate();

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -1,0 +1,93 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use serde::{Deserialize, Serialize};
+use xml::writer::XmlEvent;
+
+use crate::{
+    errors::XmlReadError,
+    models,
+    xml::{
+        attribute_or_error, closing_tag_or_error, to_xml_read_error, to_xml_write_error, FromXml,
+        ToInnerXml,
+    },
+};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub(crate) struct BomReference(String);
+
+impl BomReference {
+    #[allow(unused)]
+    pub fn new<T>(input: T) -> Self
+    where
+        T: ToString,
+    {
+        Self(input.to_string())
+    }
+}
+
+impl From<models::bom::BomReference> for BomReference {
+    fn from(other: models::bom::BomReference) -> Self {
+        Self(other.0)
+    }
+}
+
+impl From<BomReference> for models::bom::BomReference {
+    fn from(other: BomReference) -> Self {
+        Self(other.0)
+    }
+}
+
+const REF_ATTR: &str = "ref";
+
+impl ToInnerXml for BomReference {
+    fn write_xml_named_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+        tag: &str,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        writer
+            .write(XmlEvent::start_element(tag).attr(REF_ATTR, &self.0))
+            .map_err(to_xml_write_error(tag))?;
+
+        writer
+            .write(XmlEvent::end_element())
+            .map_err(to_xml_write_error(tag))?;
+
+        Ok(())
+    }
+}
+
+impl FromXml for BomReference {
+    fn read_xml_element<R: std::io::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, XmlReadError>
+    where
+        Self: Sized,
+    {
+        let reference = attribute_or_error(element_name, attributes, REF_ATTR)?;
+        event_reader
+            .next()
+            .map_err(to_xml_read_error(&element_name.local_name))
+            .and_then(closing_tag_or_error(element_name))?;
+
+        Ok(Self(reference))
+    }
+}

--- a/cyclonedx-bom/src/specs/common/mod.rs
+++ b/cyclonedx-bom/src/specs/common/mod.rs
@@ -18,6 +18,7 @@
 
 pub(crate) mod advisory;
 pub(crate) mod attached_text;
+pub(crate) mod bom;
 pub(crate) mod code;
 pub(crate) mod dependency;
 pub(crate) mod external_reference;

--- a/cyclonedx-bom/src/specs/v1_4/composition.rs
+++ b/cyclonedx-bom/src/specs/v1_4/composition.rs
@@ -19,12 +19,11 @@
 use crate::{
     errors::XmlReadError,
     models,
-    specs::common::signature::Signature,
+    specs::common::{bom::BomReference, signature::Signature},
     utilities::{convert_optional, convert_optional_vec, convert_vec},
     xml::{
-        attribute_or_error, closing_tag_or_error, read_lax_validation_list_tag, read_simple_tag,
-        to_xml_read_error, to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml,
-        ToInnerXml, ToXml,
+        read_lax_validation_list_tag, read_simple_tag, to_xml_read_error, to_xml_write_error,
+        unexpected_element_error, write_simple_tag, FromXml, ToInnerXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -245,60 +244,6 @@ impl FromXml for Composition {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-struct BomReference(String);
-
-impl From<models::composition::BomReference> for BomReference {
-    fn from(other: models::composition::BomReference) -> Self {
-        Self(other.0)
-    }
-}
-
-impl From<BomReference> for models::composition::BomReference {
-    fn from(other: BomReference) -> Self {
-        Self(other.0)
-    }
-}
-
-const REF_ATTR: &str = "ref";
-
-impl ToInnerXml for BomReference {
-    fn write_xml_named_element<W: std::io::Write>(
-        &self,
-        writer: &mut xml::EventWriter<W>,
-        tag: &str,
-    ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(tag).attr(REF_ATTR, &self.0))
-            .map_err(to_xml_write_error(tag))?;
-
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(tag))?;
-
-        Ok(())
-    }
-}
-
-impl FromXml for BomReference {
-    fn read_xml_element<R: std::io::Read>(
-        event_reader: &mut xml::EventReader<R>,
-        element_name: &xml::name::OwnedName,
-        attributes: &[xml::attribute::OwnedAttribute],
-    ) -> Result<Self, XmlReadError>
-    where
-        Self: Sized,
-    {
-        let reference = attribute_or_error(element_name, attributes, REF_ATTR)?;
-        event_reader
-            .next()
-            .map_err(to_xml_read_error(&element_name.local_name))
-            .and_then(closing_tag_or_error(element_name))?;
-
-        Ok(Self(reference))
-    }
-}
-
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
@@ -316,8 +261,8 @@ pub(crate) mod test {
     pub(crate) fn example_composition() -> Composition {
         Composition {
             aggregate: "aggregate".to_string(),
-            assemblies: Some(vec![BomReference("assembly".to_string())]),
-            dependencies: Some(vec![BomReference("dependency".to_string())]),
+            assemblies: Some(vec![BomReference::new("assembly")]),
+            dependencies: Some(vec![BomReference::new("dependency")]),
             signature: Some(example_signature()),
         }
     }
@@ -327,12 +272,8 @@ pub(crate) mod test {
             aggregate: models::composition::AggregateType::UnknownAggregateType(
                 "aggregate".to_string(),
             ),
-            assemblies: Some(vec![models::composition::BomReference(
-                "assembly".to_string(),
-            )]),
-            dependencies: Some(vec![models::composition::BomReference(
-                "dependency".to_string(),
-            )]),
+            assemblies: Some(vec![models::bom::BomReference::new("assembly")]),
+            dependencies: Some(vec![models::bom::BomReference::new("dependency")]),
             signature: Some(corresponding_signature()),
         }
     }

--- a/cyclonedx-bom/src/specs/v1_5/composition.rs
+++ b/cyclonedx-bom/src/specs/v1_5/composition.rs
@@ -19,12 +19,11 @@
 use crate::{
     errors::XmlReadError,
     models,
-    specs::common::signature::Signature,
+    specs::common::{bom::BomReference, signature::Signature},
     utilities::{convert_optional, convert_optional_vec, convert_vec},
     xml::{
-        attribute_or_error, closing_tag_or_error, read_lax_validation_list_tag, read_simple_tag,
-        to_xml_read_error, to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml,
-        ToInnerXml, ToXml,
+        read_lax_validation_list_tag, read_simple_tag, to_xml_read_error, to_xml_write_error,
+        unexpected_element_error, write_simple_tag, FromXml, ToInnerXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -245,60 +244,6 @@ impl FromXml for Composition {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-struct BomReference(String);
-
-impl From<models::composition::BomReference> for BomReference {
-    fn from(other: models::composition::BomReference) -> Self {
-        Self(other.0)
-    }
-}
-
-impl From<BomReference> for models::composition::BomReference {
-    fn from(other: BomReference) -> Self {
-        Self(other.0)
-    }
-}
-
-const REF_ATTR: &str = "ref";
-
-impl ToInnerXml for BomReference {
-    fn write_xml_named_element<W: std::io::Write>(
-        &self,
-        writer: &mut xml::EventWriter<W>,
-        tag: &str,
-    ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(tag).attr(REF_ATTR, &self.0))
-            .map_err(to_xml_write_error(tag))?;
-
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(tag))?;
-
-        Ok(())
-    }
-}
-
-impl FromXml for BomReference {
-    fn read_xml_element<R: std::io::Read>(
-        event_reader: &mut xml::EventReader<R>,
-        element_name: &xml::name::OwnedName,
-        attributes: &[xml::attribute::OwnedAttribute],
-    ) -> Result<Self, XmlReadError>
-    where
-        Self: Sized,
-    {
-        let reference = attribute_or_error(element_name, attributes, REF_ATTR)?;
-        event_reader
-            .next()
-            .map_err(to_xml_read_error(&element_name.local_name))
-            .and_then(closing_tag_or_error(element_name))?;
-
-        Ok(Self(reference))
-    }
-}
-
 #[cfg(test)]
 pub(crate) mod test {
     use crate::{
@@ -320,8 +265,8 @@ pub(crate) mod test {
     pub(crate) fn example_composition() -> Composition {
         Composition {
             aggregate: "aggregate".to_string(),
-            assemblies: Some(vec![BomReference("assembly".to_string())]),
-            dependencies: Some(vec![BomReference("dependency".to_string())]),
+            assemblies: Some(vec![BomReference::new("assembly")]),
+            dependencies: Some(vec![BomReference::new("dependency")]),
             signature: Some(example_signature()),
         }
     }
@@ -331,12 +276,8 @@ pub(crate) mod test {
             aggregate: models::composition::AggregateType::UnknownAggregateType(
                 "aggregate".to_string(),
             ),
-            assemblies: Some(vec![models::composition::BomReference(
-                "assembly".to_string(),
-            )]),
-            dependencies: Some(vec![models::composition::BomReference(
-                "dependency".to_string(),
-            )]),
+            assemblies: Some(vec![models::bom::BomReference::new("assembly")]),
+            dependencies: Some(vec![models::bom::BomReference::new("dependency")]),
             signature: Some(corresponding_signature()),
         }
     }


### PR DESCRIPTION
This reduces duplication of the `BomReference` spec types.