### PR TITLE
`#[versioned]` refactors

### DIFF
--- a/cyclonedx-bom-macros/src/lib.rs
+++ b/cyclonedx-bom-macros/src/lib.rs
@@ -9,7 +9,7 @@ use syn::{
     parse_quote,
     punctuated::Punctuated,
     token::Comma,
-    Error, Expr, Item,
+    Error, Expr, Item, Stmt,
 };
 
 #[derive(PartialEq, Eq)]
@@ -117,12 +117,12 @@ impl Fold for VersionFilter {
         fields
     }
 
-    fn fold_stmt(&mut self, mut stmt: syn::Stmt) -> syn::Stmt {
+    fn fold_stmt(&mut self, mut stmt: Stmt) -> Stmt {
         match stmt {
-            syn::Stmt::Local(syn::Local { ref mut attrs, .. })
-            | syn::Stmt::Macro(syn::StmtMacro { ref mut attrs, .. }) => {
+            Stmt::Local(syn::Local { ref mut attrs, .. })
+            | Stmt::Macro(syn::StmtMacro { ref mut attrs, .. }) => {
                 if !self.is_active(attrs) {
-                    stmt = parse_quote!({};);
+                    stmt = Stmt::Item(Item::Verbatim(TokenStream2::new()));
                 }
             }
             _ => {}
@@ -215,9 +215,7 @@ impl Fold for VersionFilter {
             | Item::Union(syn::ItemUnion { ref mut attrs, .. })
             | Item::Use(syn::ItemUse { ref mut attrs, .. }) => {
                 if !self.is_active(attrs) {
-                    item = parse_quote!(
-                        use {};
-                    );
+                    item = Item::Verbatim(TokenStream2::new());
                 }
             }
             _ => {}

--- a/cyclonedx-bom-macros/src/lib.rs
+++ b/cyclonedx-bom-macros/src/lib.rs
@@ -118,64 +118,60 @@ impl Fold for VersionFilter {
     }
 
     fn fold_stmt(&mut self, mut stmt: Stmt) -> Stmt {
-        match stmt {
-            Stmt::Local(syn::Local { ref mut attrs, .. })
-            | Stmt::Macro(syn::StmtMacro { ref mut attrs, .. }) => {
-                if !self.is_active(attrs) {
-                    stmt = Stmt::Item(Item::Verbatim(TokenStream2::new()));
-                }
+        if let Stmt::Local(syn::Local { ref mut attrs, .. })
+        | Stmt::Macro(syn::StmtMacro { ref mut attrs, .. }) = &mut stmt
+        {
+            if !self.is_active(attrs) {
+                stmt = Stmt::Item(Item::Verbatim(TokenStream2::new()));
             }
-            _ => {}
         }
 
         fold::fold_stmt(self, stmt)
     }
 
     fn fold_expr(&mut self, mut expr: Expr) -> Expr {
-        match &mut expr {
-            Expr::Array(syn::ExprArray { ref mut attrs, .. })
-            | Expr::Assign(syn::ExprAssign { ref mut attrs, .. })
-            | Expr::Async(syn::ExprAsync { ref mut attrs, .. })
-            | Expr::Await(syn::ExprAwait { ref mut attrs, .. })
-            | Expr::Binary(syn::ExprBinary { ref mut attrs, .. })
-            | Expr::Block(syn::ExprBlock { ref mut attrs, .. })
-            | Expr::Break(syn::ExprBreak { ref mut attrs, .. })
-            | Expr::Call(syn::ExprCall { ref mut attrs, .. })
-            | Expr::Cast(syn::ExprCast { ref mut attrs, .. })
-            | Expr::Closure(syn::ExprClosure { ref mut attrs, .. })
-            | Expr::Const(syn::ExprConst { ref mut attrs, .. })
-            | Expr::Continue(syn::ExprContinue { ref mut attrs, .. })
-            | Expr::Field(syn::ExprField { ref mut attrs, .. })
-            | Expr::ForLoop(syn::ExprForLoop { ref mut attrs, .. })
-            | Expr::Group(syn::ExprGroup { ref mut attrs, .. })
-            | Expr::If(syn::ExprIf { ref mut attrs, .. })
-            | Expr::Index(syn::ExprIndex { ref mut attrs, .. })
-            | Expr::Infer(syn::ExprInfer { ref mut attrs, .. })
-            | Expr::Let(syn::ExprLet { ref mut attrs, .. })
-            | Expr::Lit(syn::ExprLit { ref mut attrs, .. })
-            | Expr::Loop(syn::ExprLoop { ref mut attrs, .. })
-            | Expr::Macro(syn::ExprMacro { ref mut attrs, .. })
-            | Expr::Match(syn::ExprMatch { ref mut attrs, .. })
-            | Expr::MethodCall(syn::ExprMethodCall { ref mut attrs, .. })
-            | Expr::Paren(syn::ExprParen { ref mut attrs, .. })
-            | Expr::Path(syn::ExprPath { ref mut attrs, .. })
-            | Expr::Range(syn::ExprRange { ref mut attrs, .. })
-            | Expr::Reference(syn::ExprReference { ref mut attrs, .. })
-            | Expr::Repeat(syn::ExprRepeat { ref mut attrs, .. })
-            | Expr::Return(syn::ExprReturn { ref mut attrs, .. })
-            | Expr::Struct(syn::ExprStruct { ref mut attrs, .. })
-            | Expr::Try(syn::ExprTry { ref mut attrs, .. })
-            | Expr::TryBlock(syn::ExprTryBlock { ref mut attrs, .. })
-            | Expr::Tuple(syn::ExprTuple { ref mut attrs, .. })
-            | Expr::Unary(syn::ExprUnary { ref mut attrs, .. })
-            | Expr::Unsafe(syn::ExprUnsafe { ref mut attrs, .. })
-            | Expr::While(syn::ExprWhile { ref mut attrs, .. })
-            | Expr::Yield(syn::ExprYield { ref mut attrs, .. }) => {
-                if !self.is_active(attrs) {
-                    expr = parse_quote!({});
-                }
+        if let Expr::Array(syn::ExprArray { ref mut attrs, .. })
+        | Expr::Assign(syn::ExprAssign { ref mut attrs, .. })
+        | Expr::Async(syn::ExprAsync { ref mut attrs, .. })
+        | Expr::Await(syn::ExprAwait { ref mut attrs, .. })
+        | Expr::Binary(syn::ExprBinary { ref mut attrs, .. })
+        | Expr::Block(syn::ExprBlock { ref mut attrs, .. })
+        | Expr::Break(syn::ExprBreak { ref mut attrs, .. })
+        | Expr::Call(syn::ExprCall { ref mut attrs, .. })
+        | Expr::Cast(syn::ExprCast { ref mut attrs, .. })
+        | Expr::Closure(syn::ExprClosure { ref mut attrs, .. })
+        | Expr::Const(syn::ExprConst { ref mut attrs, .. })
+        | Expr::Continue(syn::ExprContinue { ref mut attrs, .. })
+        | Expr::Field(syn::ExprField { ref mut attrs, .. })
+        | Expr::ForLoop(syn::ExprForLoop { ref mut attrs, .. })
+        | Expr::Group(syn::ExprGroup { ref mut attrs, .. })
+        | Expr::If(syn::ExprIf { ref mut attrs, .. })
+        | Expr::Index(syn::ExprIndex { ref mut attrs, .. })
+        | Expr::Infer(syn::ExprInfer { ref mut attrs, .. })
+        | Expr::Let(syn::ExprLet { ref mut attrs, .. })
+        | Expr::Lit(syn::ExprLit { ref mut attrs, .. })
+        | Expr::Loop(syn::ExprLoop { ref mut attrs, .. })
+        | Expr::Macro(syn::ExprMacro { ref mut attrs, .. })
+        | Expr::Match(syn::ExprMatch { ref mut attrs, .. })
+        | Expr::MethodCall(syn::ExprMethodCall { ref mut attrs, .. })
+        | Expr::Paren(syn::ExprParen { ref mut attrs, .. })
+        | Expr::Path(syn::ExprPath { ref mut attrs, .. })
+        | Expr::Range(syn::ExprRange { ref mut attrs, .. })
+        | Expr::Reference(syn::ExprReference { ref mut attrs, .. })
+        | Expr::Repeat(syn::ExprRepeat { ref mut attrs, .. })
+        | Expr::Return(syn::ExprReturn { ref mut attrs, .. })
+        | Expr::Struct(syn::ExprStruct { ref mut attrs, .. })
+        | Expr::Try(syn::ExprTry { ref mut attrs, .. })
+        | Expr::TryBlock(syn::ExprTryBlock { ref mut attrs, .. })
+        | Expr::Tuple(syn::ExprTuple { ref mut attrs, .. })
+        | Expr::Unary(syn::ExprUnary { ref mut attrs, .. })
+        | Expr::Unsafe(syn::ExprUnsafe { ref mut attrs, .. })
+        | Expr::While(syn::ExprWhile { ref mut attrs, .. })
+        | Expr::Yield(syn::ExprYield { ref mut attrs, .. }) = &mut expr
+        {
+            if !self.is_active(attrs) {
+                expr = parse_quote!({});
             }
-            _ => {}
         }
 
         fold::fold_expr(self, expr)
@@ -198,27 +194,25 @@ impl Fold for VersionFilter {
     }
 
     fn fold_item(&mut self, mut item: Item) -> Item {
-        match item {
-            Item::Const(syn::ItemConst { ref mut attrs, .. })
-            | Item::Enum(syn::ItemEnum { ref mut attrs, .. })
-            | Item::ExternCrate(syn::ItemExternCrate { ref mut attrs, .. })
-            | Item::Fn(syn::ItemFn { ref mut attrs, .. })
-            | Item::ForeignMod(syn::ItemForeignMod { ref mut attrs, .. })
-            | Item::Impl(syn::ItemImpl { ref mut attrs, .. })
-            | Item::Macro(syn::ItemMacro { ref mut attrs, .. })
-            | Item::Mod(syn::ItemMod { ref mut attrs, .. })
-            | Item::Static(syn::ItemStatic { ref mut attrs, .. })
-            | Item::Struct(syn::ItemStruct { ref mut attrs, .. })
-            | Item::Trait(syn::ItemTrait { ref mut attrs, .. })
-            | Item::TraitAlias(syn::ItemTraitAlias { ref mut attrs, .. })
-            | Item::Type(syn::ItemType { ref mut attrs, .. })
-            | Item::Union(syn::ItemUnion { ref mut attrs, .. })
-            | Item::Use(syn::ItemUse { ref mut attrs, .. }) => {
-                if !self.is_active(attrs) {
-                    item = Item::Verbatim(TokenStream2::new());
-                }
+        if let Item::Const(syn::ItemConst { ref mut attrs, .. })
+        | Item::Enum(syn::ItemEnum { ref mut attrs, .. })
+        | Item::ExternCrate(syn::ItemExternCrate { ref mut attrs, .. })
+        | Item::Fn(syn::ItemFn { ref mut attrs, .. })
+        | Item::ForeignMod(syn::ItemForeignMod { ref mut attrs, .. })
+        | Item::Impl(syn::ItemImpl { ref mut attrs, .. })
+        | Item::Macro(syn::ItemMacro { ref mut attrs, .. })
+        | Item::Mod(syn::ItemMod { ref mut attrs, .. })
+        | Item::Static(syn::ItemStatic { ref mut attrs, .. })
+        | Item::Struct(syn::ItemStruct { ref mut attrs, .. })
+        | Item::Trait(syn::ItemTrait { ref mut attrs, .. })
+        | Item::TraitAlias(syn::ItemTraitAlias { ref mut attrs, .. })
+        | Item::Type(syn::ItemType { ref mut attrs, .. })
+        | Item::Union(syn::ItemUnion { ref mut attrs, .. })
+        | Item::Use(syn::ItemUse { ref mut attrs, .. }) = &mut item
+        {
+            if !self.is_active(attrs) {
+                item = Item::Verbatim(TokenStream2::new());
             }
-            _ => {}
         }
 
         fold::fold_item(self, item)

--- a/cyclonedx-bom-macros/src/lib.rs
+++ b/cyclonedx-bom-macros/src/lib.rs
@@ -80,7 +80,10 @@ impl VersionFilter {
             if path.is_ident("versioned") {
                 match attr.parse_args::<VersionReq>() {
                     Ok(req) => matches = req.matches(&self.version),
-                    Err(err) => self.error = Some(err),
+                    Err(err) => match self.error.as_mut() {
+                        Some(error) => error.combine(err),
+                        None => self.error = Some(err),
+                    },
                 }
 
                 false

--- a/cyclonedx-bom-macros/src/lib.rs
+++ b/cyclonedx-bom-macros/src/lib.rs
@@ -2,7 +2,7 @@ use std::error::Error as StdError;
 use std::str::FromStr;
 
 use proc_macro::TokenStream;
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{
     fold::{self, Fold},
@@ -263,10 +263,7 @@ impl Fold for VersionFilter {
     }
 }
 
-fn helper(
-    input: TokenStream,
-    annotated_item: TokenStream,
-) -> syn::Result<proc_macro2::TokenStream> {
+fn helper(input: TokenStream, annotated_item: TokenStream) -> syn::Result<TokenStream2> {
     // This parses the module being annotated by the `#[versioned(..)]` attribute.
     let module = syn::parse::<syn::ItemMod>(annotated_item)
         .map_err(|err| Error::new(err.span(), format!("cannot parse module: {err}")))?;
@@ -284,7 +281,7 @@ fn helper(
         .as_ref()
         .ok_or_else(|| Error::new(module.ident.span(), "found module without content"))?;
 
-    let mut tokens = proc_macro2::TokenStream::new();
+    let mut tokens = TokenStream2::new();
 
     for version in versions {
         let mod_vis = &module.vis;


### PR DESCRIPTION
These are some small improvements to the `#[versioned]` macro codebase. Most of them are non-functional and just make the code cleaner.
