### PR TITLE
Remove `ToString` implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spdx",
+ "strum",
  "thiserror",
  "time",
  "uuid",
@@ -1384,6 +1385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1523,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -179,9 +179,9 @@ impl FilenameOverride {
     }
 }
 
-impl ToString for FilenameOverride {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for FilenameOverride {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -894,7 +894,7 @@ fn to_bom_hash(hash: &Checksum) -> cyclonedx_bom::models::hash::Hash {
     match hash {
         Checksum::Sha256(_) => {
             Hash {
-                alg: HashAlgorithm::SHA256,
+                alg: HashAlgorithm::SHA_256,
                 // {:x} means "format as lowercase hex"
                 content: HashValue(format!("{hash:x}")),
             }

--- a/cyclonedx-bom/Cargo.toml
+++ b/cyclonedx-bom/Cargo.toml
@@ -30,6 +30,7 @@ time = { version = "0.3.29", features = ["formatting", "parsing"] }
 uuid = { version = "1.6.1", features = ["v4"] }
 xml-rs = "0.8.16"
 cyclonedx-bom-macros = { path = "../cyclonedx-bom-macros" }
+strum = { version = "0.26.2", features = ["derive"] }
 
 [dev-dependencies]
 insta = { version = "1.33.0", features = ["glob", "json"] }

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -71,9 +71,9 @@ impl TryFrom<String> for DateTime {
     }
 }
 
-impl ToString for DateTime {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for DateTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -74,9 +74,9 @@ impl TryFrom<String> for SpdxIdentifier {
     }
 }
 
-impl ToString for SpdxIdentifier {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for SpdxIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 
@@ -164,9 +164,9 @@ impl TryFrom<String> for SpdxExpression {
     }
 }
 
-impl ToString for SpdxExpression {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for SpdxExpression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 

--- a/cyclonedx-bom/src/external_models/uri.rs
+++ b/cyclonedx-bom/src/external_models/uri.rs
@@ -43,9 +43,9 @@ impl Purl {
     }
 }
 
-impl ToString for Purl {
-    fn to_string(&self) -> String {
-        self.0.to_string()
+impl std::fmt::Display for Purl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 
@@ -79,9 +79,9 @@ impl TryFrom<String> for Uri {
     }
 }
 
-impl ToString for Uri {
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for Uri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -81,20 +81,13 @@ pub(crate) fn validate_encoding(encoding: &Encoding) -> Result<(), ValidationErr
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub(crate) enum Encoding {
     Base64,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownEncoding(String),
-}
-
-impl ToString for Encoding {
-    fn to_string(&self) -> String {
-        match self {
-            Encoding::Base64 => "base64".to_string(),
-            Encoding::UnknownEncoding(ue) => ue.clone(),
-        }
-    }
 }
 
 impl Encoding {

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -42,14 +42,17 @@ use crate::validation::{Validate, ValidationContext, ValidationError, Validation
 use crate::xml::{FromXmlDocument, ToXml};
 
 /// Represents the spec version of a BOM.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, PartialOrd)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy, PartialOrd, strum::Display)]
 #[repr(u16)]
 #[non_exhaustive]
 pub enum SpecVersion {
+    #[strum(to_string = "1.3")]
     #[serde(rename = "1.3")]
     V1_3 = 1,
+    #[strum(to_string = "1.4")]
     #[serde(rename = "1.4")]
     V1_4 = 2,
+    #[strum(to_string = "1.5")]
     #[serde(rename = "1.5")]
     V1_5 = 3,
 }
@@ -70,17 +73,6 @@ impl FromStr for SpecVersion {
             "1.5" => Ok(SpecVersion::V1_5),
             s => Err(BomError::UnsupportedSpecVersion(s.to_string())),
         }
-    }
-}
-
-impl ToString for SpecVersion {
-    fn to_string(&self) -> String {
-        let s = match self {
-            SpecVersion::V1_3 => "1.3",
-            SpecVersion::V1_4 => "1.4",
-            SpecVersion::V1_5 => "1.5",
-        };
-        s.to_string()
     }
 }
 

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -135,25 +135,15 @@ pub fn validate_issue_classification(
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum IssueClassification {
     Defect,
     Enhancement,
     Security,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownIssueClassification(String),
-}
-
-impl ToString for IssueClassification {
-    fn to_string(&self) -> String {
-        match self {
-            IssueClassification::Defect => "defect",
-            IssueClassification::Enhancement => "enhancement",
-            IssueClassification::Security => "security",
-            IssueClassification::UnknownIssueClassification(uic) => uic,
-        }
-        .to_string()
-    }
 }
 
 impl IssueClassification {
@@ -213,27 +203,16 @@ pub fn validate_patch_classification(
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum PatchClassification {
     Unofficial,
     Monkey,
     Backport,
     CherryPick,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownPatchClassification(String),
-}
-
-impl ToString for PatchClassification {
-    fn to_string(&self) -> String {
-        match self {
-            PatchClassification::Unofficial => "unofficial",
-            PatchClassification::Monkey => "monkey",
-            PatchClassification::Backport => "backport",
-            PatchClassification::CherryPick => "cherry-pick",
-            PatchClassification::UnknownPatchClassification(upc) => upc,
-        }
-        .to_string()
-    }
 }
 
 impl PatchClassification {

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -181,7 +181,8 @@ pub fn validate_classification(
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 #[repr(u16)]
 pub enum Classification {
     Application = 1,
@@ -201,28 +202,8 @@ pub enum Classification {
     /// Added in 1.5
     Data = 12,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownClassification(String),
-}
-
-impl ToString for Classification {
-    fn to_string(&self) -> String {
-        match self {
-            Classification::Application => "application",
-            Classification::Framework => "framework",
-            Classification::Library => "library",
-            Classification::Container => "container",
-            Classification::OperatingSystem => "operating-system",
-            Classification::Device => "device",
-            Classification::Firmware => "firmware",
-            Classification::File => "file",
-            Classification::Platform => "platform",
-            Classification::DeviceDriver => "device-driver",
-            Classification::MachineLearningModel => "machine-learning-model",
-            Classification::Data => "data",
-            Classification::UnknownClassification(uc) => uc,
-        }
-        .to_string()
-    }
 }
 
 impl Classification {
@@ -252,25 +233,15 @@ pub fn validate_scope(scope: &Scope) -> Result<(), ValidationError> {
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum Scope {
     Required,
     Optional,
     Excluded,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownScope(String),
-}
-
-impl ToString for Scope {
-    fn to_string(&self) -> String {
-        match self {
-            Scope::Required => "required",
-            Scope::Optional => "optional",
-            Scope::Excluded => "excluded",
-            Scope::UnknownScope(us) => us,
-        }
-        .to_string()
-    }
 }
 
 impl Scope {

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -60,7 +60,8 @@ pub fn validate_aggregate_type(aggregate_type: &AggregateType) -> Result<(), Val
     Ok(())
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum AggregateType {
     Complete,
     Incomplete,
@@ -69,22 +70,8 @@ pub enum AggregateType {
     Unknown,
     NotSpecified,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownAggregateType(String),
-}
-
-impl ToString for AggregateType {
-    fn to_string(&self) -> String {
-        match self {
-            AggregateType::Complete => "complete",
-            AggregateType::Incomplete => "incomplete",
-            AggregateType::IncompleteFirstPartyOnly => "incomplete_first_party_only",
-            AggregateType::IncompleteThirdPartyOnly => "incomplete_third_party_only",
-            AggregateType::Unknown => "unknown",
-            AggregateType::NotSpecified => "not_specified",
-            AggregateType::UnknownAggregateType(uat) => uat,
-        }
-        .to_string()
-    }
 }
 
 impl AggregateType {

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -99,7 +99,8 @@ pub fn validate_external_reference_type(
 }
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_externalReferenceType).
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum ExternalReferenceType {
     Vcs,
     IssueTracker,
@@ -118,6 +119,7 @@ pub enum ExternalReferenceType {
     BuildSystem,
     Other,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownExternalReferenceType(String),
     ReleaseNotes,
     SecurityContact,
@@ -142,54 +144,6 @@ pub enum ExternalReferenceType {
     CondifiedInfrastructure,
     QualityMetrics,
     Poam,
-}
-
-impl ToString for ExternalReferenceType {
-    fn to_string(&self) -> String {
-        match self {
-            ExternalReferenceType::Vcs => "vcs",
-            ExternalReferenceType::IssueTracker => "issue-tracker",
-            ExternalReferenceType::Website => "website",
-            ExternalReferenceType::Advisories => "advisories",
-            ExternalReferenceType::Bom => "bom",
-            ExternalReferenceType::MailingList => "mailing-list",
-            ExternalReferenceType::Social => "social",
-            ExternalReferenceType::Chat => "chat",
-            ExternalReferenceType::Documentation => "documentation",
-            ExternalReferenceType::Support => "support",
-            ExternalReferenceType::Distribution => "distribution",
-            ExternalReferenceType::DistributionIntake => "distribution-intake",
-            ExternalReferenceType::License => "license",
-            ExternalReferenceType::BuildMeta => "build-meta",
-            ExternalReferenceType::BuildSystem => "build-system",
-            ExternalReferenceType::ReleaseNotes => "release-notes",
-            ExternalReferenceType::SecurityContact => "security-contact",
-            ExternalReferenceType::ModelCard => "model-card",
-            ExternalReferenceType::Log => "log",
-            ExternalReferenceType::Configuration => "configuration",
-            ExternalReferenceType::Evidence => "evidence",
-            ExternalReferenceType::Formulation => "formulation",
-            ExternalReferenceType::Attestation => "attestation",
-            ExternalReferenceType::ThreatModel => "threat-model",
-            ExternalReferenceType::AdversaryModel => "adversary-model",
-            ExternalReferenceType::RiskAssessment => "risk-assessment",
-            ExternalReferenceType::VulnerabilityAssertion => "vulnerability-assertion",
-            ExternalReferenceType::ExploitabilityStatement => "exploitability-statement",
-            ExternalReferenceType::PentestReport => "pentest-report",
-            ExternalReferenceType::StaticAnalysisReport => "static-analysis-report",
-            ExternalReferenceType::DynamicAnalysisReport => "dynamic-analysis-report",
-            ExternalReferenceType::RuntimeAnalysisReport => "runtime-analysis-report",
-            ExternalReferenceType::ComponentAnalysisReport => "component-analysis-report",
-            ExternalReferenceType::MaturityReport => "maturity-report",
-            ExternalReferenceType::CertificationReport => "certification-report",
-            ExternalReferenceType::CondifiedInfrastructure => "codified-infrastructure",
-            ExternalReferenceType::QualityMetrics => "quality-metrics",
-            ExternalReferenceType::Poam => "poam",
-            ExternalReferenceType::Other => "other",
-            ExternalReferenceType::UnknownExternalReferenceType(un) => un,
-        }
-        .to_string()
-    }
 }
 
 impl ExternalReferenceType {

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -63,53 +63,37 @@ pub fn validate_hash_algorithm(algorithm: &HashAlgorithm) -> Result<(), Validati
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashAlg)
 #[allow(non_camel_case_types)]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "SCREAMING-KEBAB-CASE")]
 pub enum HashAlgorithm {
     MD5,
+    #[strum(serialize = "SHA-1")]
     SHA1,
-    SHA256,
-    SHA384,
-    SHA512,
+    SHA_256,
+    SHA_384,
+    SHA_512,
     SHA3_256,
     SHA3_384,
     SHA3_512,
+    #[strum(serialize = "BLAKE2b-256")]
     BLAKE2b_256,
+    #[strum(serialize = "BLAKE2b-384")]
     BLAKE2b_384,
+    #[strum(serialize = "BLAKE2b-512")]
     BLAKE2b_512,
     BLAKE3,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownHashAlgorithm(String),
 }
-
-impl ToString for HashAlgorithm {
-    fn to_string(&self) -> String {
-        match self {
-            HashAlgorithm::MD5 => "MD5",
-            HashAlgorithm::SHA1 => "SHA-1",
-            HashAlgorithm::SHA256 => "SHA-256",
-            HashAlgorithm::SHA384 => "SHA-384",
-            HashAlgorithm::SHA512 => "SHA-512",
-            HashAlgorithm::SHA3_256 => "SHA3-256",
-            HashAlgorithm::SHA3_384 => "SHA3-384",
-            HashAlgorithm::SHA3_512 => "SHA3-512",
-            HashAlgorithm::BLAKE2b_256 => "BLAKE2b-256",
-            HashAlgorithm::BLAKE2b_384 => "BLAKE2b-384",
-            HashAlgorithm::BLAKE2b_512 => "BLAKE2b-512",
-            HashAlgorithm::BLAKE3 => "BLAKE3",
-            HashAlgorithm::UnknownHashAlgorithm(un) => un,
-        }
-        .to_string()
-    }
-}
-
 impl HashAlgorithm {
     pub(crate) fn new_unchecked<A: AsRef<str>>(value: A) -> Self {
         match value.as_ref() {
             "MD5" => Self::MD5,
             "SHA-1" => Self::SHA1,
-            "SHA-256" => Self::SHA256,
-            "SHA-384" => Self::SHA384,
-            "SHA-512" => Self::SHA512,
+            "SHA-256" => Self::SHA_256,
+            "SHA-384" => Self::SHA_384,
+            "SHA-512" => Self::SHA_512,
             "SHA3-256" => Self::SHA3_256,
             "SHA3-384" => Self::SHA3_384,
             "SHA3-512" => Self::SHA3_512,

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -160,27 +160,16 @@ impl Validate for DataClassification {
 /// Represents the flow direction of the data
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_dataFlowType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum DataFlowType {
     Inbound,
     Outbound,
     BiDirectional,
     Unknown,
     #[doc(hidden)]
+    #[strum(default)]
     UnknownDataFlow(String),
-}
-
-impl ToString for DataFlowType {
-    fn to_string(&self) -> String {
-        match self {
-            DataFlowType::Inbound => "inbound",
-            DataFlowType::Outbound => "outbound",
-            DataFlowType::BiDirectional => "bi-directional",
-            DataFlowType::Unknown => "unknown",
-            DataFlowType::UnknownDataFlow(df) => df,
-        }
-        .to_string()
-    }
 }
 
 impl DataFlowType {

--- a/cyclonedx-bom/src/models/signature.rs
+++ b/cyclonedx-bom/src/models/signature.rs
@@ -78,7 +78,7 @@ impl Signature {
 }
 
 /// Supported signature algorithms.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
 pub enum Algorithm {
     RS256,
     RS384,
@@ -117,27 +117,5 @@ impl FromStr for Algorithm {
             "HS512" => Ok(Algorithm::HS512),
             _ => Err(format!("Invalid signature algorithm '{}' found", s)),
         }
-    }
-}
-
-impl ToString for Algorithm {
-    fn to_string(&self) -> String {
-        let s = match self {
-            Algorithm::RS256 => "RS256",
-            Algorithm::RS384 => "RS384",
-            Algorithm::RS512 => "RS512",
-            Algorithm::PS256 => "PS256",
-            Algorithm::PS384 => "PS384",
-            Algorithm::PS512 => "PS512",
-            Algorithm::ES256 => "ES256",
-            Algorithm::ES384 => "ES384",
-            Algorithm::ES512 => "ES512",
-            Algorithm::Ed25519 => "Ed25519",
-            Algorithm::Ed448 => "Ed448",
-            Algorithm::HS256 => "HS256",
-            Algorithm::HS384 => "HS384",
-            Algorithm::HS512 => "HS512",
-        };
-        s.to_string()
     }
 }

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -82,7 +82,8 @@ pub fn validate_impact_analysis_state(state: &ImpactAnalysisState) -> Result<(),
 /// Specifies a vulnerability's state according to impact analysis.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisStateType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum ImpactAnalysisState {
     Resolved,
     ResolvedWithPedigree,
@@ -91,6 +92,7 @@ pub enum ImpactAnalysisState {
     FalsePositive,
     NotAffected,
     #[doc(hidden)]
+    #[strum(default)]
     UndefinedImpactAnalysisState(String),
 }
 
@@ -105,21 +107,6 @@ impl ImpactAnalysisState {
             "not_affected" => Self::NotAffected,
             undefined => Self::UndefinedImpactAnalysisState(undefined.to_string()),
         }
-    }
-}
-
-impl ToString for ImpactAnalysisState {
-    fn to_string(&self) -> String {
-        match self {
-            ImpactAnalysisState::Resolved => "resolved",
-            ImpactAnalysisState::ResolvedWithPedigree => "resolved_with_pedigree",
-            ImpactAnalysisState::Exploitable => "exploitable",
-            ImpactAnalysisState::InTriage => "in_triage",
-            ImpactAnalysisState::FalsePositive => "false_positive",
-            ImpactAnalysisState::NotAffected => "not_affected",
-            ImpactAnalysisState::UndefinedImpactAnalysisState(undefined) => undefined,
-        }
-        .to_string()
     }
 }
 
@@ -138,7 +125,8 @@ pub fn validate_impact_analysis_justification(
 /// Justifies the vulnerability's state according to impact analysis.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisJustificationType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum ImpactAnalysisJustification {
     CodeNotPresent,
     CodeNotReachable,
@@ -150,6 +138,7 @@ pub enum ImpactAnalysisJustification {
     ProtectedAtPerimeter,
     ProtectedByMitigatingControl,
     #[doc(hidden)]
+    #[strum(default)]
     UndefinedImpactAnalysisJustification(String),
 }
 
@@ -170,28 +159,6 @@ impl ImpactAnalysisJustification {
     }
 }
 
-impl ToString for ImpactAnalysisJustification {
-    fn to_string(&self) -> String {
-        match self {
-            ImpactAnalysisJustification::CodeNotPresent => "code_not_present",
-            ImpactAnalysisJustification::CodeNotReachable => "code_not_reachable",
-            ImpactAnalysisJustification::RequiresConfiguration => "requires_configuration",
-            ImpactAnalysisJustification::RequiresDependency => "requires_dependency",
-            ImpactAnalysisJustification::RequiresEnvironment => "requires_environment",
-            ImpactAnalysisJustification::ProtectedByCompiler => "protected_by_compiler",
-            ImpactAnalysisJustification::ProtectedAtRuntime => "protected_at_runtime",
-            ImpactAnalysisJustification::ProtectedAtPerimeter => "protected_at_perimeter",
-            ImpactAnalysisJustification::ProtectedByMitigatingControl => {
-                "protected_by_mitigating_control"
-            }
-            ImpactAnalysisJustification::UndefinedImpactAnalysisJustification(undefined) => {
-                undefined
-            }
-        }
-        .to_string()
-    }
-}
-
 pub fn validate_impact_analysis_response(
     response: &ImpactAnalysisResponse,
 ) -> Result<(), ValidationError> {
@@ -204,7 +171,8 @@ pub fn validate_impact_analysis_response(
 /// Provides a response to the vulnerability according to impact analysis.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisResponsesType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum ImpactAnalysisResponse {
     CanNotFix,
     WillNotFix,
@@ -212,6 +180,7 @@ pub enum ImpactAnalysisResponse {
     Rollback,
     WorkaroundAvailable,
     #[doc(hidden)]
+    #[strum(default)]
     UndefinedResponse(String),
 }
 
@@ -225,20 +194,6 @@ impl ImpactAnalysisResponse {
             "workaround_available" => Self::WorkaroundAvailable,
             undefined => Self::UndefinedResponse(undefined.to_string()),
         }
-    }
-}
-
-impl ToString for ImpactAnalysisResponse {
-    fn to_string(&self) -> String {
-        match self {
-            ImpactAnalysisResponse::CanNotFix => "can_not_fix",
-            ImpactAnalysisResponse::WillNotFix => "will_not_fix",
-            ImpactAnalysisResponse::Update => "update",
-            ImpactAnalysisResponse::Rollback => "rollback",
-            ImpactAnalysisResponse::WorkaroundAvailable => "workaround_available",
-            ImpactAnalysisResponse::UndefinedResponse(undefined) => undefined,
-        }
-        .to_string()
     }
 }
 

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -132,7 +132,8 @@ pub fn validate_severity(severity: &Severity) -> Result<(), ValidationError> {
 /// Specifies a vulnerability's severity adopted by the analysis method.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_severityType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum Severity {
     Critical,
     High,
@@ -142,6 +143,7 @@ pub enum Severity {
     None,
     Unknown,
     #[doc(hidden)]
+    #[strum(default)]
     UndefinedSeverity(String),
 }
 
@@ -160,31 +162,16 @@ impl Severity {
     }
 }
 
-impl ToString for Severity {
-    fn to_string(&self) -> String {
-        match self {
-            Severity::Critical => "critical",
-            Severity::High => "high",
-            Severity::Medium => "medium",
-            Severity::Low => "low",
-            Severity::Info => "info",
-            Severity::None => "none",
-            Severity::Unknown => "unknown",
-            Severity::UndefinedSeverity(undefined) => undefined,
-        }
-        .to_string()
-    }
-}
-
 /// Specifies the risk scoring method or standard used.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_scoreSourceType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
 pub enum ScoreMethod {
     CVSSv2,
     CVSSv3,
     CVSSv31,
     OWASP,
+    #[strum(default)]
     Other(String),
 }
 
@@ -197,19 +184,6 @@ impl ScoreMethod {
             "OWASP" => Self::OWASP,
             score_method => Self::Other(score_method.to_string()),
         }
-    }
-}
-
-impl ToString for ScoreMethod {
-    fn to_string(&self) -> String {
-        match self {
-            ScoreMethod::CVSSv2 => "CVSSv2",
-            ScoreMethod::CVSSv3 => "CVSSv3",
-            ScoreMethod::CVSSv31 => "CVSSv31",
-            ScoreMethod::OWASP => "OWASP",
-            ScoreMethod::Other(score_method) => score_method,
-        }
-        .to_string()
     }
 }
 

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -119,11 +119,14 @@ pub fn validate_version_range(range: &VersionRange) -> Result<(), ValidationErro
 ///
 /// Defined via the [PURL specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst)
 /// Spec for version ranges still work in progress [PURL version-range-spec](https://github.com/package-url/purl-spec/blob/version-range-spec/VERSION-RANGE-SPEC.rst)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
 pub enum VersionRange {
+    #[strum(default)]
     Version(NormalizedString),
+    #[strum(default)]
     Range(NormalizedString),
     #[doc(hidden)]
+    #[strum(default)]
     UndefinedVersionRange(String),
 }
 
@@ -132,16 +135,6 @@ impl VersionRange {
         match matches_purl_version_range_regex(value) {
             true => VersionRange::Range(NormalizedString::new(value)),
             false => VersionRange::Version(NormalizedString::new(value)),
-        }
-    }
-}
-
-impl ToString for VersionRange {
-    fn to_string(&self) -> String {
-        match self {
-            VersionRange::Version(version) => version.to_string(),
-            VersionRange::Range(range) => range.to_string(),
-            VersionRange::UndefinedVersionRange(undefined) => undefined.to_string(),
         }
     }
 }
@@ -163,12 +156,14 @@ pub fn validate_status(status: &Status) -> Result<(), ValidationError> {
 /// Specifies if a vulnerability affects a component or service.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisAffectedStatusType)
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum Status {
     Affected,
     Unaffected,
     Unknown,
     #[doc(hidden)]
+    #[strum(default)]
     UndefinedStatus(String),
 }
 
@@ -180,18 +175,6 @@ impl Status {
             "unknown" => Self::Unknown,
             undefined => Self::UndefinedStatus(undefined.to_string()),
         }
-    }
-}
-
-impl ToString for Status {
-    fn to_string(&self) -> String {
-        match self {
-            Status::Affected => "affected",
-            Status::Unaffected => "unaffected",
-            Status::Unknown => "unknown",
-            Status::UndefinedStatus(undefined) => undefined,
-        }
-        .to_string()
     }
 }
 

--- a/cyclonedx-bom/src/specs/common/signature.rs
+++ b/cyclonedx-bom/src/specs/common/signature.rs
@@ -201,7 +201,7 @@ impl From<Signature> for models::signature::Signature {
 }
 
 /// Supported signature algorithms.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, strum::Display)]
 pub enum Algorithm {
     RS256,
     RS384,
@@ -240,28 +240,6 @@ impl FromStr for Algorithm {
             "HS512" => Ok(Algorithm::HS512),
             _ => Err(format!("Invalid signature algorithm '{}' found", s)),
         }
-    }
-}
-
-impl ToString for Algorithm {
-    fn to_string(&self) -> String {
-        let s = match self {
-            Algorithm::RS256 => "RS256",
-            Algorithm::RS384 => "RS384",
-            Algorithm::RS512 => "RS512",
-            Algorithm::PS256 => "PS256",
-            Algorithm::PS384 => "PS384",
-            Algorithm::PS512 => "PS512",
-            Algorithm::ES256 => "ES256",
-            Algorithm::ES384 => "ES384",
-            Algorithm::ES512 => "ES512",
-            Algorithm::Ed25519 => "Ed25519",
-            Algorithm::Ed448 => "Ed448",
-            Algorithm::HS256 => "HS256",
-            Algorithm::HS384 => "HS384",
-            Algorithm::HS512 => "HS512",
-        };
-        s.to_string()
     }
 }
 


### PR DESCRIPTION
`ToString` is not supposed to be implemented manually as any type implementing `Display` will automatically implement `ToString`.

I replaced all the `ToString` implementations and used the `strum` crate when possible.
