### PR TITLE
Add 'bom-ref' field to OrganizationalEntity

### DIFF
--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -405,6 +405,7 @@ mod test {
             mime_type: Some(MimeType("text/text".to_string())),
             bom_ref: Some("bom ref".to_string()),
             supplier: Some(OrganizationalEntity {
+                bom_ref: Some(BomReference::new("Supplier 1")),
                 name: Some(NormalizedString::new("name")),
                 url: None,
                 contact: None,
@@ -562,6 +563,7 @@ mod test {
             mime_type: Some(MimeType("invalid mime type".to_string())),
             bom_ref: Some("bom ref".to_string()),
             supplier: Some(OrganizationalEntity {
+                bom_ref: Some(BomReference::new("Supplier 1")),
                 name: Some(NormalizedString("invalid\tname".to_string())),
                 url: None,
                 contact: None,

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -103,6 +103,7 @@ mod test {
     use crate::{
         external_models::{normalized_string::NormalizedString, spdx::SpdxExpression},
         models::{
+            bom::BomReference,
             component::Classification,
             license::LicenseChoice,
             lifecycle::{Description, Lifecycle, Phase},
@@ -159,11 +160,13 @@ mod test {
                 model_card: None,
             }),
             manufacture: Some(OrganizationalEntity {
+                bom_ref: Some(BomReference::new("Manufacturer")),
                 name: Some(NormalizedString::new("name")),
                 url: None,
                 contact: None,
             }),
             supplier: Some(OrganizationalEntity {
+                bom_ref: Some(BomReference::new("Supplier")),
                 name: Some(NormalizedString::new("name")),
                 url: None,
                 contact: None,
@@ -226,11 +229,13 @@ mod test {
                 model_card: None,
             }),
             manufacture: Some(OrganizationalEntity {
+                bom_ref: Some(BomReference::new("Manufacturer")),
                 name: Some(NormalizedString("invalid\tname".to_string())),
                 url: None,
                 contact: None,
             }),
             supplier: Some(OrganizationalEntity {
+                bom_ref: Some(BomReference::new("Supplier")),
                 name: Some(NormalizedString("invalid\tname".to_string())),
                 url: None,
                 contact: None,

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -80,9 +80,21 @@ fn validate_bom_ref(_bom_ref: &BomReference, version: SpecVersion) -> Result<(),
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_organizationalEntity)
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OrganizationalEntity {
+    pub bom_ref: Option<BomReference>,
     pub name: Option<NormalizedString>,
     pub url: Option<Vec<Uri>>,
     pub contact: Option<Vec<OrganizationalContact>>,
+}
+
+impl OrganizationalEntity {
+    pub fn new(name: &str) -> Self {
+        Self {
+            bom_ref: None,
+            name: Some(NormalizedString::new_unchecked(name.to_string())),
+            url: None,
+            contact: None,
+        }
+    }
 }
 
 impl Validate for OrganizationalEntity {
@@ -197,11 +209,7 @@ mod test {
 
     #[test]
     fn it_should_validate_an_invalid_entity_as_failed() {
-        let entity = OrganizationalEntity {
-            name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
-            url: None,
-            contact: None,
-        };
+        let entity = OrganizationalEntity::new("invalid\tname");
         let actual = entity.validate();
 
         assert_eq!(
@@ -216,6 +224,7 @@ mod test {
     #[test]
     fn it_should_validate_an_entity_with_multiple_validation_issues_as_failed() {
         let entity = OrganizationalEntity {
+            bom_ref: None,
             name: Some(NormalizedString::new_unchecked("invalid\tname".to_string())),
             url: Some(vec![Uri("invalid uri".to_string())]),
             contact: Some(vec![OrganizationalContact {

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -204,11 +204,7 @@ mod test {
     fn valid_services_should_pass_validation() {
         let validation_result = Services(vec![Service {
             bom_ref: Some("bom ref".to_string()),
-            provider: Some(OrganizationalEntity {
-                name: Some(NormalizedString::new("name")),
-                url: None,
-                contact: None,
-            }),
+            provider: Some(OrganizationalEntity::new("name")),
             group: Some(NormalizedString::new("group")),
             name: NormalizedString::new("name"),
             version: Some(NormalizedString::new("version")),
@@ -247,6 +243,7 @@ mod test {
         let validation_result = Services(vec![Service {
             bom_ref: Some("bom ref".to_string()),
             provider: Some(OrganizationalEntity {
+                bom_ref: None,
                 name: Some(NormalizedString("invalid\tname".to_string())),
                 url: None,
                 contact: None,

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -207,11 +207,7 @@ mod test {
             published: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
             updated: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
             vulnerability_credits: Some(VulnerabilityCredits {
-                organizations: Some(vec![OrganizationalEntity {
-                    name: Some(NormalizedString::new("name")),
-                    url: None,
-                    contact: None,
-                }]),
+                organizations: Some(vec![OrganizationalEntity::new("name")]),
                 individuals: None,
             }),
             tools: None,

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -51,11 +51,7 @@ mod test {
     #[test]
     fn valid_vulnerability_credits_should_pass_validation() {
         let validation_result = VulnerabilityCredits {
-            organizations: Some(vec![OrganizationalEntity {
-                name: Some(NormalizedString::new("name")),
-                url: None,
-                contact: None,
-            }]),
+            organizations: Some(vec![OrganizationalEntity::new("name")]),
             individuals: Some(vec![OrganizationalContact {
                 bom_ref: None,
                 name: Some(NormalizedString::new("name")),
@@ -71,11 +67,7 @@ mod test {
     #[test]
     fn invalid_vulnerability_credits_should_fail_validation() {
         let validation_result = VulnerabilityCredits {
-            organizations: Some(vec![OrganizationalEntity {
-                name: Some(NormalizedString("invalid\tname".to_string())),
-                url: None,
-                contact: None,
-            }]),
+            organizations: Some(vec![OrganizationalEntity::new("invalid\tname")]),
             individuals: Some(vec![OrganizationalContact {
                 bom_ref: None,
                 name: Some(NormalizedString("invalid\tname".to_string())),

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__organization__test__it_should_not_write_xml_empty_contacts.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__organization__test__it_should_not_write_xml_empty_contacts.snap
@@ -1,9 +1,10 @@
 ---
 source: cyclonedx-bom/src/specs/common/organization.rs
+assertion_line: 398
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<supplier>
+<supplier bom-ref="Supplier">
   <name>name</name>
   <url>url</url>
 </supplier>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__organization__test__it_should_write_xml_multiple_urls_contacts.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__organization__test__it_should_write_xml_multiple_urls_contacts.snap
@@ -1,9 +1,10 @@
 ---
 source: cyclonedx-bom/src/specs/common/organization.rs
+assertion_line: 412
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<supplier>
+<supplier bom-ref="Supplier">
   <name>name</name>
   <url>url</url>
   <url>url</url>

--- a/cyclonedx-bom/src/specs/common/tool.rs
+++ b/cyclonedx-bom/src/specs/common/tool.rs
@@ -459,6 +459,7 @@ pub(crate) mod base {
             let service = Service {
                 bom_ref: None,
                 provider: Some(OrganizationalEntity {
+                    bom_ref: None,
                     name: Some("Acme Org".to_string()),
                     url: Some(vec!["https://example.com".to_string()]),
                     contact: None,

--- a/cyclonedx-bom/src/specs/v1_5/annotation.rs
+++ b/cyclonedx-bom/src/specs/v1_5/annotation.rs
@@ -521,6 +521,7 @@ impl FromXml for Annotation {
 
 #[cfg(test)]
 pub(crate) mod test {
+    use pretty_assertions::assert_eq;
     use xml::{EventReader, ParserConfig};
 
     use crate::{
@@ -644,7 +645,7 @@ pub(crate) mod test {
       <subject ref="component-a" />
     </subjects>
     <annotator>
-      <organization>
+      <organization bom-ref="Acme">
         <name>Acme, Inc.</name>
         <url>https://example.com</url>
         <contact bom-ref="contact-1">
@@ -663,6 +664,7 @@ pub(crate) mod test {
             bom_ref: Some("annotation-1".to_string()),
             subjects: vec!["component-a".to_string()],
             annotator: Annotator::Organization(OrganizationalEntity {
+                bom_ref: Some("Acme".to_string()),
                 name: Some(String::from("Acme, Inc.")),
                 url: Some(vec!["https://example.com".to_string()]),
                 contact: Some(vec![OrganizationalContact {

--- a/cyclonedx-bom/src/specs/v1_5/modelcard.rs
+++ b/cyclonedx-bom/src/specs/v1_5/modelcard.rs
@@ -2545,11 +2545,7 @@ pub(crate) mod test {
             )]),
             stewards: None,
             owners: Some(vec![DataGovernanceResponsibleParty::Organization(
-                OrganizationalEntity {
-                    contact: None,
-                    name: Some("Organization 1".to_string()),
-                    url: None,
-                },
+                OrganizationalEntity::new("Organization 1"),
             )]),
         };
         assert_eq!(expected, actual);
@@ -2595,11 +2591,7 @@ pub(crate) mod test {
                 custodians: None,
                 stewards: None,
                 owners: Some(vec![DataGovernanceResponsibleParty::Organization(
-                    OrganizationalEntity {
-                        contact: None,
-                        name: Some("Organization name".to_string()),
-                        url: None,
-                    },
+                    OrganizationalEntity::new("Organization name"),
                 )]),
             }),
         });


### PR DESCRIPTION
This PR adds the `bom-ref` field to the `OrganizationalEntity` to support spec version 1.5.
