### PR TITLE
Set top-level "properties" only for spec 1.5

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -548,10 +548,10 @@ mod test {
             external_references: None,
             dependencies: None,
             compositions: None,
-            properties: None,
             vulnerabilities: None,
             signature: None,
             annotations: None,
+            properties: None,
         };
 
         let actual = bom.validate();

--- a/cyclonedx-bom/src/specs/common/service.rs
+++ b/cyclonedx-bom/src/specs/common/service.rs
@@ -892,6 +892,7 @@ pub(crate) mod base {
                     stewards: None,
                     owners: Some(vec![DataGovernanceResponsibleParty::Organization(
                         OrganizationalEntity {
+                            bom_ref: None,
                             name: Some("Organization 1".to_string()),
                             url: None,
                             contact: None,
@@ -930,6 +931,7 @@ pub(crate) mod base {
                     owners: Some(vec![
                         models::modelcard::DataGovernanceResponsibleParty::Organization(
                             models::organization::OrganizationalEntity {
+                                bom_ref: None,
                                 name: Some(NormalizedString::new_unchecked(
                                     "Organization 1".to_string(),
                                 )),

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
+assertion_line: 606
 expression: actual
 ---
 {
@@ -429,12 +430,6 @@ expression: actual
       "dependencies": [
         "dependency"
       ]
-    }
-  ],
-  "properties": [
-    {
-      "name": "name",
-      "value": "value"
     }
   ]
 }

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
+assertion_line: 612
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -312,7 +313,4 @@ expression: xml_output
       </dependencies>
     </composition>
   </compositions>
-  <properties>
-    <property name="name">value</property>
-  </properties>
 </bom>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
+assertion_line: 606
 expression: actual
 ---
 {
@@ -445,12 +446,6 @@ expression: actual
         "algorithm": "HS512",
         "value": "1234567890"
       }
-    }
-  ],
-  "properties": [
-    {
-      "name": "name",
-      "value": "value"
     }
   ],
   "vulnerabilities": [

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
+assertion_line: 612
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -328,9 +329,6 @@ expression: xml_output
       </signature>
     </composition>
   </compositions>
-  <properties>
-    <property name="name">value</property>
-  </properties>
   <vulnerabilities>
     <vulnerability bom-ref="bom-ref">
       <id>id</id>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 592
+assertion_line: 606
 expression: actual
 ---
 {
@@ -607,12 +607,6 @@ expression: actual
       }
     }
   ],
-  "properties": [
-    {
-      "name": "name",
-      "value": "value"
-    }
-  ],
   "vulnerabilities": [
     {
       "bom-ref": "bom-ref",
@@ -759,6 +753,12 @@ expression: actual
         "algorithm": "HS512",
         "value": "1234567890"
       }
+    }
+  ],
+  "properties": [
+    {
+      "name": "name",
+      "value": "value"
     }
   ]
 }

--- a/cyclonedx-bom/src/specs/v1_5/service_data.rs
+++ b/cyclonedx-bom/src/specs/v1_5/service_data.rs
@@ -291,6 +291,7 @@ pub(crate) mod test {
             governance: Some(DataGovernance {
                 owners: Some(vec![DataGovernanceResponsibleParty::Organization(
                     OrganizationalEntity {
+                        bom_ref: None,
                         name: Some("Customer Name".to_string()),
                         url: None,
                         contact: None,


### PR DESCRIPTION
The top-level field [`properties`](https://cyclonedx.org/docs/1.5/json/#properties) was added in spec version 1.5.

Before this change the `properties` was also available for other spec versions.