### PR TITLE
Refactor writing start / close tags

### DIFF
--- a/cyclonedx-bom/src/specs/common/advisory.rs
+++ b/cyclonedx-bom/src/specs/common/advisory.rs
@@ -23,7 +23,8 @@ use crate::{
     utilities::convert_vec,
     xml::{
         read_lax_validation_list_tag, read_lax_validation_tag, read_simple_tag, to_xml_read_error,
-        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+        to_xml_write_error, unexpected_element_error, write_close_tag, write_simple_tag,
+        write_start_tag, FromXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -52,17 +53,13 @@ impl ToXml for Advisories {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(ADVISORIES_TAG))
-            .map_err(to_xml_write_error(ADVISORIES_TAG))?;
+        write_start_tag(writer, ADVISORIES_TAG)?;
 
         for advisory in &self.0 {
             advisory.write_xml_element(writer)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(ADVISORIES_TAG))?;
+        write_close_tag(writer, ADVISORIES_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/bom_reference.rs
+++ b/cyclonedx-bom/src/specs/common/bom_reference.rs
@@ -23,8 +23,8 @@ use crate::{
     errors::XmlReadError,
     models,
     xml::{
-        attribute_or_error, closing_tag_or_error, to_xml_read_error, to_xml_write_error, FromXml,
-        ToInnerXml,
+        attribute_or_error, closing_tag_or_error, to_xml_read_error, to_xml_write_error,
+        write_close_tag, FromXml, ToInnerXml,
     },
 };
 
@@ -72,9 +72,7 @@ impl ToInnerXml for BomReference {
             .write(XmlEvent::start_element(tag).attr(REF_ATTR, &self.0))
             .map_err(to_xml_write_error(tag))?;
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(tag))?;
+        write_close_tag(writer, tag)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/component.rs
+++ b/cyclonedx-bom/src/specs/common/component.rs
@@ -53,8 +53,8 @@ pub(crate) mod base {
         xml::{
             attribute_or_error, optional_attribute, read_boolean_tag, read_lax_validation_list_tag,
             read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
-            to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, FromXmlType,
-            ToInnerXml, ToXml,
+            to_xml_write_error, unexpected_element_error, write_close_tag, write_simple_tag,
+            write_start_tag, FromXml, FromXmlType, ToInnerXml, ToXml,
         },
     };
     use serde::{Deserialize, Serialize};
@@ -84,17 +84,14 @@ pub(crate) mod base {
             writer: &mut xml::EventWriter<W>,
             tag: &str,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(tag))
-                .map_err(to_xml_write_error(tag))?;
+            write_start_tag(writer, tag)?;
 
             for component in &self.0 {
                 component.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(tag))?;
+            write_close_tag(writer, tag)?;
+
             Ok(())
         }
     }
@@ -923,9 +920,7 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(EVIDENCE_TAG))
-                .map_err(to_xml_write_error(EVIDENCE_TAG))?;
+            write_start_tag(writer, EVIDENCE_TAG)?;
 
             if let Some(licenses) = &self.licenses {
                 licenses.write_xml_element(writer)?;
@@ -935,9 +930,7 @@ pub(crate) mod base {
                 copyright.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(EVIDENCE_TAG))?;
+            write_close_tag(writer, EVIDENCE_TAG)?;
 
             Ok(())
         }
@@ -1106,9 +1099,7 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(PEDIGREE_TAG))
-                .map_err(to_xml_write_error(PEDIGREE_TAG))?;
+            write_start_tag(writer, PEDIGREE_TAG)?;
 
             if let Some(ancestors) = &self.ancestors {
                 ancestors.write_xml_named_element(writer, ANCESTORS_TAG)?;
@@ -1134,9 +1125,7 @@ pub(crate) mod base {
                 write_simple_tag(writer, NOTES_TAG, notes)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(PEDIGREE_TAG))?;
+            write_close_tag(writer, PEDIGREE_TAG)?;
 
             Ok(())
         }
@@ -1260,17 +1249,13 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(TEXT_TAG))
-                .map_err(to_xml_write_error(TEXT_TAG))?;
+            write_start_tag(writer, TEXT_TAG)?;
 
             writer
                 .write(XmlEvent::cdata(&self.text))
                 .map_err(to_xml_write_error(TEXT_TAG))?;
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(TEXT_TAG))?;
+            write_close_tag(writer, TEXT_TAG)?;
 
             Ok(())
         }
@@ -1310,17 +1295,14 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(COPYRIGHT_TAG))
-                .map_err(to_xml_write_error(COPYRIGHT_TAG))?;
+            write_start_tag(writer, COPYRIGHT_TAG)?;
 
             for copyright in &self.0 {
                 copyright.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(COPYRIGHT_TAG))?;
+            write_close_tag(writer, COPYRIGHT_TAG)?;
+
             Ok(())
         }
     }

--- a/cyclonedx-bom/src/specs/common/composition.rs
+++ b/cyclonedx-bom/src/specs/common/composition.rs
@@ -34,7 +34,7 @@ pub(crate) mod base {
     #[versioned("1.4", "1.5")]
     use crate::{specs::common::signature::Signature, utilities::convert_optional};
     use serde::{Deserialize, Serialize};
-    use xml::{reader, writer::XmlEvent};
+    use xml::reader;
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(transparent)]
@@ -164,13 +164,13 @@ pub(crate) mod base {
         ) -> Result<(), crate::errors::XmlWriteError> {
             #[versioned("1.3", "1.4")]
             let start_tag = xml::writer::XmlEvent::start_element(COMPOSITION_TAG);
-
             #[versioned("1.5")]
             let mut start_tag = xml::writer::XmlEvent::start_element(COMPOSITION_TAG);
             #[versioned("1.5")]
             if let Some(bom_ref) = &self.bom_ref {
                 start_tag = start_tag.attr(BOM_REF_ATTR, bom_ref);
             }
+
             writer
                 .write(start_tag)
                 .map_err(to_xml_write_error(COMPOSITION_TAG))?;
@@ -213,9 +213,7 @@ pub(crate) mod base {
                 signature.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(COMPOSITION_TAG))?;
+            write_close_tag(writer, COMPOSITION_TAG)?;
 
             Ok(())
         }

--- a/cyclonedx-bom/src/specs/common/dependency.rs
+++ b/cyclonedx-bom/src/specs/common/dependency.rs
@@ -21,7 +21,8 @@ use crate::{
     models,
     xml::{
         attribute_or_error, closing_tag_or_error, read_list_tag, to_xml_read_error,
-        to_xml_write_error, unexpected_element_error, FromXml, ToXml,
+        to_xml_write_error, unexpected_element_error, write_close_tag, write_start_tag, FromXml,
+        ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -49,17 +50,13 @@ impl ToXml for Dependencies {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(DEPENDENCIES_TAG))
-            .map_err(to_xml_write_error(DEPENDENCIES_TAG))?;
+        write_start_tag(writer, DEPENDENCIES_TAG)?;
 
         for dependency in &self.0 {
             dependency.write_xml_element(writer)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(DEPENDENCIES_TAG))?;
+        write_close_tag(writer, DEPENDENCIES_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/external_reference.rs
+++ b/cyclonedx-bom/src/specs/common/external_reference.rs
@@ -27,10 +27,10 @@ pub(crate) mod base {
         external_models, models,
         specs::common::hash::Hashes,
         utilities::{convert_optional, convert_vec},
-        xml::to_xml_write_error,
         xml::{
             attribute_or_error, read_list_tag, read_simple_tag, to_xml_read_error,
-            unexpected_element_error, write_simple_tag, FromXml, ToXml,
+            to_xml_write_error, unexpected_element_error, write_close_tag, write_simple_tag,
+            write_start_tag, FromXml, ToXml,
         },
     };
     use serde::{Deserialize, Serialize};
@@ -71,17 +71,14 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(EXTERNAL_REFERENCES_TAG))
-                .map_err(to_xml_write_error(EXTERNAL_REFERENCES_TAG))?;
+            write_start_tag(writer, EXTERNAL_REFERENCES_TAG)?;
 
             for external_reference in &self.0 {
                 external_reference.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(EXTERNAL_REFERENCES_TAG))?;
+            write_close_tag(writer, EXTERNAL_REFERENCES_TAG)?;
+
             Ok(())
         }
     }

--- a/cyclonedx-bom/src/specs/common/metadata.rs
+++ b/cyclonedx-bom/src/specs/common/metadata.rs
@@ -28,6 +28,7 @@ pub(crate) mod base {
     use crate::specs::v1_5::{component::Component, lifecycles::Lifecycles, tool::Tools};
 
     use crate::errors::BomError;
+    use crate::xml::{write_close_tag, write_start_tag};
     use crate::{
         external_models::date_time::DateTime,
         models,
@@ -38,13 +39,12 @@ pub(crate) mod base {
         utilities::{convert_optional, convert_optional_vec, try_convert_optional},
         xml::{
             read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
-            to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToInnerXml,
-            ToXml,
+            unexpected_element_error, write_simple_tag, FromXml, ToInnerXml, ToXml,
         },
     };
     use serde::{Deserialize, Serialize};
     use std::convert::TryFrom;
-    use xml::{reader, writer::XmlEvent};
+    use xml::reader;
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(rename_all = "camelCase")]
@@ -120,9 +120,7 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(METADATA_TAG))
-                .map_err(to_xml_write_error(METADATA_TAG))?;
+            write_start_tag(writer, METADATA_TAG)?;
 
             if let Some(timestamp) = &self.timestamp {
                 write_simple_tag(writer, TIMESTAMP_TAG, timestamp)?;
@@ -133,9 +131,7 @@ pub(crate) mod base {
             }
 
             if let Some(authors) = &self.authors {
-                writer
-                    .write(XmlEvent::start_element(AUTHORS_TAG))
-                    .map_err(to_xml_write_error(AUTHORS_TAG))?;
+                write_start_tag(writer, AUTHORS_TAG)?;
 
                 for author in authors {
                     if author.will_write() {
@@ -143,9 +139,7 @@ pub(crate) mod base {
                     }
                 }
 
-                writer
-                    .write(XmlEvent::end_element())
-                    .map_err(to_xml_write_error(AUTHORS_TAG))?;
+                write_close_tag(writer, AUTHORS_TAG)?;
             }
 
             if let Some(component) = &self.component {
@@ -173,9 +167,7 @@ pub(crate) mod base {
                 lifecycles.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(METADATA_TAG))?;
+            write_close_tag(writer, METADATA_TAG)?;
 
             Ok(())
         }

--- a/cyclonedx-bom/src/specs/common/property.rs
+++ b/cyclonedx-bom/src/specs/common/property.rs
@@ -22,7 +22,7 @@ use crate::{
     models,
     xml::{
         attribute_or_error, read_lax_validation_list_tag, read_simple_tag, to_xml_write_error,
-        FromXml, ToXml,
+        write_close_tag, write_start_tag, FromXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -51,16 +51,13 @@ impl ToXml for Properties {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(PROPERTIES_TAG))
-            .map_err(to_xml_write_error(PROPERTIES_TAG))?;
+        write_start_tag(writer, PROPERTIES_TAG)?;
 
         for property in &self.0 {
             property.write_xml_element(writer)?;
         }
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(PROPERTIES_TAG))?;
+
+        write_close_tag(writer, PROPERTIES_TAG)?;
 
         Ok(())
     }
@@ -120,9 +117,7 @@ impl ToXml for Property {
             .write(XmlEvent::characters(&self.value))
             .map_err(to_xml_write_error(PROPERTY_TAG))?;
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(PROPERTY_TAG))?;
+        write_close_tag(writer, PROPERTY_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/service.rs
+++ b/cyclonedx-bom/src/specs/common/service.rs
@@ -84,17 +84,13 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(SERVICES_TAG))
-                .map_err(to_xml_write_error(SERVICES_TAG))?;
+            write_start_tag(writer, SERVICES_TAG)?;
 
             for service in &self.0 {
                 service.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(SERVICES_TAG))?;
+            write_close_tag(writer, SERVICES_TAG)?;
 
             Ok(())
         }
@@ -291,15 +287,13 @@ pub(crate) mod base {
             }
 
             if let Some(endpoints) = &self.endpoints {
-                writer
-                    .write(XmlEvent::start_element(ENDPOINTS_TAG))
-                    .map_err(to_xml_write_error(ENDPOINTS_TAG))?;
+                write_start_tag(writer, ENDPOINTS_TAG)?;
+
                 for endpoint in endpoints {
                     write_simple_tag(writer, ENDPOINT_TAG, endpoint)?;
                 }
-                writer
-                    .write(XmlEvent::end_element())
-                    .map_err(to_xml_write_error(ENDPOINTS_TAG))?;
+
+                write_close_tag(writer, ENDPOINTS_TAG)?;
             }
 
             if let Some(authenticated) = &self.authenticated {
@@ -754,9 +748,7 @@ pub(crate) mod base {
                 .write(XmlEvent::characters(&self.classification))
                 .map_err(to_xml_write_error(CLASSIFICATION_TAG))?;
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(CLASSIFICATION_TAG))?;
+            write_close_tag(writer, CLASSIFICATION_TAG)?;
 
             Ok(())
         }

--- a/cyclonedx-bom/src/specs/common/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability.rs
@@ -32,7 +32,8 @@ pub(crate) mod base {
         xml::{
             optional_attribute, read_lax_validation_list_tag, read_lax_validation_tag,
             read_list_tag, read_optional_tag, read_simple_tag, to_xml_read_error,
-            to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+            to_xml_write_error, unexpected_element_error, write_close_tag, write_simple_tag,
+            write_start_tag, FromXml, ToXml,
         },
     };
     use serde::{Deserialize, Serialize};
@@ -74,17 +75,14 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(VULNERABILITIES_TAG))
-                .map_err(to_xml_write_error(VULNERABILITIES_TAG))?;
+            write_start_tag(writer, VULNERABILITIES_TAG)?;
 
             for vulnerability in &self.0 {
                 vulnerability.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(VULNERABILITIES_TAG))?;
+            write_close_tag(writer, VULNERABILITIES_TAG)?;
+
             Ok(())
         }
     }
@@ -249,15 +247,13 @@ pub(crate) mod base {
             }
 
             if let Some(cwes) = &self.cwes {
-                writer
-                    .write(XmlEvent::start_element(CWES_TAG))
-                    .map_err(to_xml_write_error(CWES_TAG))?;
+                write_start_tag(writer, CWES_TAG)?;
+
                 for &cwe in cwes {
                     write_simple_tag(writer, CWE_TAG, format!("{}", cwe).as_ref())?;
                 }
-                writer
-                    .write(XmlEvent::end_element())
-                    .map_err(to_xml_write_error(CWES_TAG))?;
+
+                write_close_tag(writer, CWES_TAG)?;
             }
 
             if let Some(description) = &self.description {

--- a/cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
@@ -17,17 +17,18 @@
  */
 
 use crate::utilities::convert_optional_vec;
+use crate::xml::{write_close_tag, write_start_tag};
 use crate::{
     errors::XmlReadError,
     models,
     utilities::convert_optional,
     xml::{
         read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
-        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+        unexpected_element_error, write_simple_tag, FromXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
-use xml::{reader, writer::XmlEvent};
+use xml::reader;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -76,11 +77,7 @@ impl ToXml for VulnerabilityAnalysis {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        let vulnerability_analysis_start_tag = XmlEvent::start_element(VULNERABILITY_ANALYSIS_TAG);
-
-        writer
-            .write(vulnerability_analysis_start_tag)
-            .map_err(to_xml_write_error(VULNERABILITY_ANALYSIS_TAG))?;
+        write_start_tag(writer, VULNERABILITY_ANALYSIS_TAG)?;
 
         if let Some(state) = &self.state {
             write_simple_tag(writer, STATE_TAG, &state.0)?;
@@ -91,24 +88,20 @@ impl ToXml for VulnerabilityAnalysis {
         }
 
         if let Some(responses) = &self.responses {
-            writer
-                .write(XmlEvent::start_element(RESPONSES_TAG))
-                .map_err(to_xml_write_error(RESPONSES_TAG))?;
+            write_start_tag(writer, RESPONSES_TAG)?;
+
             for response in responses {
                 write_simple_tag(writer, RESPONSE_TAG, &response.0)?;
             }
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(RESPONSES_TAG))?;
+
+            write_close_tag(writer, RESPONSES_TAG)?;
         }
 
         if let Some(detail) = &self.detail {
             write_simple_tag(writer, DETAIL_TAG, detail)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VULNERABILITY_ANALYSIS_TAG))?;
+        write_close_tag(writer, VULNERABILITY_ANALYSIS_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_credits.rs
@@ -21,12 +21,12 @@ use crate::{
     models,
     utilities::convert_optional_vec,
     xml::{
-        read_lax_validation_tag, read_list_tag, to_xml_read_error, to_xml_write_error,
-        unexpected_element_error, FromXml, ToInnerXml, ToXml,
+        read_lax_validation_tag, read_list_tag, to_xml_read_error, unexpected_element_error,
+        write_close_tag, write_start_tag, FromXml, ToInnerXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
-use xml::{reader, writer::XmlEvent};
+use xml::reader;
 
 use crate::specs::common::organization::{OrganizationalContact, OrganizationalEntity};
 
@@ -68,30 +68,22 @@ impl ToXml for VulnerabilityCredits {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        let vulnerability_credits_start_tag = XmlEvent::start_element(VULNERABILITY_CREDITS_TAG);
-
-        writer
-            .write(vulnerability_credits_start_tag)
-            .map_err(to_xml_write_error(VULNERABILITY_CREDITS_TAG))?;
+        write_start_tag(writer, VULNERABILITY_CREDITS_TAG)?;
 
         if let Some(organizations) = &self.organizations {
-            writer
-                .write(XmlEvent::start_element(ORGANIZATIONS_TAG))
-                .map_err(to_xml_write_error(ORGANIZATIONS_TAG))?;
+            write_start_tag(writer, ORGANIZATIONS_TAG)?;
+
             for organization in organizations {
                 if organization.will_write() {
                     organization.write_xml_named_element(writer, ORGANIZATION_TAG)?;
                 }
             }
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(ORGANIZATIONS_TAG))?;
+
+            write_close_tag(writer, ORGANIZATIONS_TAG)?;
         }
 
         if let Some(individuals) = &self.individuals {
-            writer
-                .write(XmlEvent::start_element(INDIVIDUALS_TAG))
-                .map_err(to_xml_write_error(INDIVIDUALS_TAG))?;
+            write_start_tag(writer, INDIVIDUALS_TAG)?;
 
             for individual in individuals {
                 if individual.will_write() {
@@ -99,14 +91,10 @@ impl ToXml for VulnerabilityCredits {
                 }
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(INDIVIDUALS_TAG))?;
+            write_close_tag(writer, INDIVIDUALS_TAG)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VULNERABILITY_CREDITS_TAG))?;
+        write_close_tag(writer, VULNERABILITY_CREDITS_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_rating.rs
@@ -24,8 +24,8 @@ use crate::{
     utilities::{convert_optional, convert_vec},
     xml::{
         read_lax_validation_list_tag, read_lax_validation_tag, read_simple_tag, to_xml_read_error,
-        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, FromXmlType,
-        ToXml,
+        to_xml_write_error, unexpected_element_error, write_close_tag, write_simple_tag,
+        write_start_tag, FromXml, FromXmlType, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -54,17 +54,13 @@ impl ToXml for VulnerabilityRatings {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(VULNERABILITY_RATINGS_TAG))
-            .map_err(to_xml_write_error(VULNERABILITY_RATINGS_TAG))?;
+        write_start_tag(writer, VULNERABILITY_RATINGS_TAG)?;
 
         for vulnerability_rating in &self.0 {
             vulnerability_rating.write_xml_element(writer)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VULNERABILITY_RATINGS_TAG))?;
+        write_close_tag(writer, VULNERABILITY_RATINGS_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_reference.rs
@@ -24,7 +24,8 @@ use crate::{
     utilities::convert_vec,
     xml::{
         read_lax_validation_list_tag, read_lax_validation_tag, read_simple_tag, to_xml_read_error,
-        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+        to_xml_write_error, unexpected_element_error, write_close_tag, write_simple_tag,
+        write_start_tag, FromXml, ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -53,17 +54,13 @@ impl ToXml for VulnerabilityReferences {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(VULNERABILITY_REFERENCES_TAG))
-            .map_err(to_xml_write_error(VULNERABILITY_REFERENCES_TAG))?;
+        write_start_tag(writer, VULNERABILITY_REFERENCES_TAG)?;
 
         for vulnerability_reference in &self.0 {
             vulnerability_reference.write_xml_element(writer)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VULNERABILITY_REFERENCES_TAG))?;
+        write_close_tag(writer, VULNERABILITY_REFERENCES_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/common/vulnerability_target.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_target.rs
@@ -23,11 +23,12 @@ use crate::{
     utilities::{convert_optional, convert_vec},
     xml::{
         read_lax_validation_list_tag, read_lax_validation_tag, read_simple_tag, to_xml_read_error,
-        to_xml_write_error, unexpected_element_error, write_simple_tag, FromXml, ToXml,
+        unexpected_element_error, write_close_tag, write_simple_tag, write_start_tag, FromXml,
+        ToXml,
     },
 };
 use serde::{Deserialize, Serialize};
-use xml::{reader, writer::XmlEvent};
+use xml::reader;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(transparent)]
@@ -52,17 +53,14 @@ impl ToXml for VulnerabilityTargets {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(VULNERABILITY_TARGETS_TAG))
-            .map_err(to_xml_write_error(VULNERABILITY_TARGETS_TAG))?;
+        write_start_tag(writer, VULNERABILITY_TARGETS_TAG)?;
 
         for vulnerability_target in &self.0 {
             vulnerability_target.write_xml_element(writer)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VULNERABILITY_TARGETS_TAG))?;
+        write_close_tag(writer, VULNERABILITY_TARGETS_TAG)?;
+
         Ok(())
     }
 }
@@ -117,29 +115,22 @@ impl ToXml for VulnerabilityTarget {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        let vulnerability_target_start_tag = XmlEvent::start_element(VULNERABILITY_TARGET_TAG);
+        write_start_tag(writer, VULNERABILITY_TARGET_TAG)?;
 
-        writer
-            .write(vulnerability_target_start_tag)
-            .map_err(to_xml_write_error(VULNERABILITY_TARGET_TAG))?;
-
+        // TODO: should not be a tag, but an attribute
         write_simple_tag(writer, REF_TAG, &self.bom_ref)?;
 
         if let Some(versions) = &self.versions {
-            writer
-                .write(XmlEvent::start_element(VERSIONS_TAG))
-                .map_err(to_xml_write_error(VERSIONS_TAG))?;
+            write_start_tag(writer, VERSIONS_TAG)?;
+
             for version in versions.0.iter() {
                 version.write_xml_element(writer)?;
             }
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(VERSIONS_TAG))?;
+
+            write_close_tag(writer, VERSIONS_TAG)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VULNERABILITY_TARGET_TAG))?;
+        write_close_tag(writer, VULNERABILITY_TARGET_TAG)?;
 
         Ok(())
     }
@@ -218,17 +209,13 @@ impl ToXml for Versions {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(VERSIONS_TAG))
-            .map_err(to_xml_write_error(VERSIONS_TAG))?;
+        write_start_tag(writer, VERSIONS_TAG)?;
 
         for version in &self.0 {
             version.write_xml_element(writer)?;
         }
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VERSIONS_TAG))?;
+        write_close_tag(writer, VERSIONS_TAG)?;
 
         Ok(())
     }
@@ -280,16 +267,12 @@ impl ToXml for Version {
         &self,
         writer: &mut xml::EventWriter<W>,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        writer
-            .write(XmlEvent::start_element(VERSION_TAG))
-            .map_err(to_xml_write_error(VERSION_TAG))?;
+        write_start_tag(writer, VERSION_TAG)?;
 
         self.version_range.write_xml_element(writer)?;
         self.status.write_xml_element(writer)?;
 
-        writer
-            .write(XmlEvent::end_element())
-            .map_err(to_xml_write_error(VERSION_TAG))?;
+        write_close_tag(writer, VERSION_TAG)?;
 
         Ok(())
     }

--- a/cyclonedx-bom/src/specs/v1_5/annotation.rs
+++ b/cyclonedx-bom/src/specs/v1_5/annotation.rs
@@ -18,7 +18,6 @@
 
 use serde::{Deserialize, Serialize};
 use xml::name::OwnedName;
-use xml::writer::XmlEvent;
 use xml::{reader, writer};
 
 use crate::errors::{BomError, XmlReadError};
@@ -315,17 +314,13 @@ impl ToXml for Annotation {
             .map_err(to_xml_write_error(ANNOTATION_TAG))?;
 
         if !self.subjects.is_empty() {
-            writer
-                .write(XmlEvent::start_element(SUBJECTS_TAG))
-                .map_err(to_xml_write_error(SUBJECTS_TAG))?;
+            write_start_tag(writer, SUBJECTS_TAG)?;
 
             for subject in &self.subjects {
                 write_simple_tag(writer, SUBJECT_TAG, subject)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(SUBJECTS_TAG))?;
+            write_close_tag(writer, SUBJECTS_TAG)?;
         }
 
         self.annotator.write_xml_element(writer)?;


### PR DESCRIPTION
For most occurrences writing the start & close tags are done now using the helper functions `write_start_tag` & `write_close_tag`. They also handle error reporting. Using the `write_start_tag` helper function eliminates the chance to pass in two entirely different tag constants.