### PR TITLE
Expand Composition for spec version 1.5

### DIFF
--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -25,9 +25,11 @@ use super::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Composition {
+    pub bom_ref: Option<BomReference>,
     pub aggregate: AggregateType,
     pub assemblies: Option<Vec<BomReference>>,
     pub dependencies: Option<Vec<BomReference>>,
+    pub vulnerabilities: Option<Vec<BomReference>>,
     pub signature: Option<Signature>,
 }
 
@@ -98,9 +100,11 @@ mod test {
     #[test]
     fn it_should_pass_validation() {
         let validation_result = Compositions(vec![Composition {
+            bom_ref: Some(BomReference::new("composition-1")),
             aggregate: AggregateType::Complete,
-            assemblies: Some(vec![BomReference::new("reference")]),
-            dependencies: Some(vec![BomReference::new("reference")]),
+            assemblies: Some(vec![BomReference::new("assembly-ref")]),
+            dependencies: Some(vec![BomReference::new("dependency-ref")]),
+            vulnerabilities: Some(vec![BomReference::new("vulnerability-ref")]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate();
@@ -111,9 +115,11 @@ mod test {
     #[test]
     fn it_should_fail_validation() {
         let validation_result = Compositions(vec![Composition {
+            bom_ref: Some(BomReference::new("composition-1")),
             aggregate: AggregateType::UnknownAggregateType("unknown aggregate type".to_string()),
-            assemblies: Some(vec![BomReference::new("reference")]),
-            dependencies: Some(vec![BomReference::new("reference")]),
+            assemblies: Some(vec![BomReference::new("assembly-ref")]),
+            dependencies: Some(vec![BomReference::new("dependency-ref")]),
+            vulnerabilities: Some(vec![BomReference::new("vulnerability-ref")]),
             signature: Some(Signature::single(Algorithm::HS512, "abcdefgh")),
         }])
         .validate();

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -943,10 +943,10 @@ pub(crate) mod base {
     <composition>
       <aggregate>aggregate</aggregate>
       <assemblies>
-        <assembly ref="assembly" />
+        <assembly ref="assembly-ref" />
       </assemblies>
       <dependencies>
-        <dependency ref="dependency" />
+        <dependency ref="dependency-ref" />
       </dependencies>
     </composition>
   </compositions>
@@ -1275,10 +1275,10 @@ pub(crate) mod base {
     <composition>
       <aggregate>aggregate</aggregate>
       <assemblies>
-        <assembly ref="assembly" />
+        <assembly ref="assembly-ref" />
       </assemblies>
       <dependencies>
-        <dependency ref="dependency" />
+        <dependency ref="dependency-ref" />
       </dependencies>
       <signature>
         <algorithm>HS512</algorithm>
@@ -1923,14 +1923,17 @@ pub(crate) mod base {
     </dependency>
   </dependencies>
   <compositions>
-    <composition>
+    <composition bom-ref="composition-ref">
       <aggregate>aggregate</aggregate>
       <assemblies>
-        <assembly ref="assembly" />
+        <assembly ref="assembly-ref" />
       </assemblies>
       <dependencies>
-        <dependency ref="dependency" />
+        <dependency ref="dependency-ref" />
       </dependencies>
+      <vulnerabilities>
+        <vulnerability ref="vulnerability-ref" />
+      </vulnerabilities>
       <signature>
         <algorithm>HS512</algorithm>
         <value>1234567890</value>

--- a/cyclonedx-bom/src/specs/common/composition.rs
+++ b/cyclonedx-bom/src/specs/common/composition.rs
@@ -27,7 +27,8 @@ pub(crate) mod base {
         utilities::{convert_optional_vec, convert_vec},
         xml::{
             read_lax_validation_list_tag, read_simple_tag, to_xml_read_error, to_xml_write_error,
-            unexpected_element_error, write_simple_tag, FromXml, ToInnerXml, ToXml,
+            unexpected_element_error, write_close_tag, write_simple_tag, write_start_tag, FromXml,
+            ToInnerXml, ToXml,
         },
     };
     #[versioned("1.4", "1.5")]
@@ -58,17 +59,14 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
-            writer
-                .write(XmlEvent::start_element(COMPOSITIONS_TAG))
-                .map_err(to_xml_write_error(COMPOSITIONS_TAG))?;
+            write_start_tag(writer, COMPOSITIONS_TAG)?;
 
             for composition in &self.0 {
                 composition.write_xml_element(writer)?;
             }
 
-            writer
-                .write(XmlEvent::end_element())
-                .map_err(to_xml_write_error(COMPOSITIONS_TAG))?;
+            write_close_tag(writer, COMPOSITIONS_TAG)?;
+
             Ok(())
         }
     }
@@ -90,11 +88,17 @@ pub(crate) mod base {
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(rename_all = "camelCase")]
     pub(crate) struct Composition {
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        bom_ref: Option<String>,
         aggregate: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         assemblies: Option<Vec<BomReference>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         dependencies: Option<Vec<BomReference>>,
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        vulnerabilities: Option<Vec<BomReference>>,
         #[versioned("1.4", "1.5")]
         #[serde(skip_serializing_if = "Option::is_none")]
         signature: Option<Signature>,
@@ -103,9 +107,13 @@ pub(crate) mod base {
     impl From<models::composition::Composition> for Composition {
         fn from(other: models::composition::Composition) -> Self {
             Self {
+                #[versioned("1.5")]
+                bom_ref: other.bom_ref.map(|b| b.0),
                 aggregate: other.aggregate.to_string(),
                 assemblies: convert_optional_vec(other.assemblies),
                 dependencies: convert_optional_vec(other.dependencies),
+                #[versioned("1.5")]
+                vulnerabilities: convert_optional_vec(other.vulnerabilities),
                 #[versioned("1.4", "1.5")]
                 signature: convert_optional(other.signature),
             }
@@ -115,9 +123,17 @@ pub(crate) mod base {
     impl From<Composition> for models::composition::Composition {
         fn from(other: Composition) -> Self {
             Self {
+                #[versioned("1.3", "1.4")]
+                bom_ref: None,
+                #[versioned("1.5")]
+                bom_ref: other.bom_ref.map(models::bom::BomReference),
                 aggregate: models::composition::AggregateType::new_unchecked(other.aggregate),
                 assemblies: convert_optional_vec(other.assemblies),
                 dependencies: convert_optional_vec(other.dependencies),
+                #[versioned("1.3", "1.4")]
+                vulnerabilities: None,
+                #[versioned("1.5")]
+                vulnerabilities: convert_optional_vec(other.vulnerabilities),
                 #[versioned("1.3")]
                 signature: None,
                 #[versioned("1.4", "1.5")]
@@ -126,12 +142,18 @@ pub(crate) mod base {
         }
     }
 
+    #[versioned("1.5")]
+    const BOM_REF_ATTR: &str = "bom-ref";
     const COMPOSITION_TAG: &str = "composition";
     const AGGREGATE_TAG: &str = "aggregate";
     const ASSEMBLIES_TAG: &str = "assemblies";
     const ASSEMBLY_TAG: &str = "assembly";
     const DEPENDENCIES_TAG: &str = "dependencies";
     const DEPENDENCY_TAG: &str = "dependency";
+    #[versioned("1.5")]
+    const VULNERABILITIES_TAG: &str = "vulnerabilities";
+    #[versioned("1.5")]
+    const VULNERABILITY_TAG: &str = "vulnerability";
     #[versioned("1.4", "1.5")]
     const SIGNATURE_TAG: &str = "signature";
 
@@ -140,38 +162,50 @@ pub(crate) mod base {
             &self,
             writer: &mut xml::EventWriter<W>,
         ) -> Result<(), crate::errors::XmlWriteError> {
+            #[versioned("1.3", "1.4")]
+            let start_tag = xml::writer::XmlEvent::start_element(COMPOSITION_TAG);
+
+            #[versioned("1.5")]
+            let mut start_tag = xml::writer::XmlEvent::start_element(COMPOSITION_TAG);
+            #[versioned("1.5")]
+            if let Some(bom_ref) = &self.bom_ref {
+                start_tag = start_tag.attr(BOM_REF_ATTR, bom_ref);
+            }
             writer
-                .write(XmlEvent::start_element(COMPOSITION_TAG))
+                .write(start_tag)
                 .map_err(to_xml_write_error(COMPOSITION_TAG))?;
 
             write_simple_tag(writer, AGGREGATE_TAG, &self.aggregate)?;
 
             if let Some(assemblies) = &self.assemblies {
-                writer
-                    .write(XmlEvent::start_element(ASSEMBLIES_TAG))
-                    .map_err(to_xml_write_error(ASSEMBLIES_TAG))?;
+                write_start_tag(writer, ASSEMBLIES_TAG)?;
 
                 for assembly in assemblies {
                     assembly.write_xml_named_element(writer, ASSEMBLY_TAG)?;
                 }
 
-                writer
-                    .write(XmlEvent::end_element())
-                    .map_err(to_xml_write_error(ASSEMBLIES_TAG))?;
+                write_close_tag(writer, ASSEMBLIES_TAG)?;
             }
 
             if let Some(dependencies) = &self.dependencies {
-                writer
-                    .write(XmlEvent::start_element(DEPENDENCIES_TAG))
-                    .map_err(to_xml_write_error(DEPENDENCIES_TAG))?;
+                write_start_tag(writer, DEPENDENCIES_TAG)?;
 
                 for dependency in dependencies {
                     dependency.write_xml_named_element(writer, DEPENDENCY_TAG)?;
                 }
 
-                writer
-                    .write(XmlEvent::end_element())
-                    .map_err(to_xml_write_error(DEPENDENCIES_TAG))?;
+                write_close_tag(writer, DEPENDENCIES_TAG)?;
+            }
+
+            #[versioned("1.5")]
+            if let Some(vulnerabilities) = &self.vulnerabilities {
+                write_start_tag(writer, VULNERABILITIES_TAG)?;
+
+                for vulnerability in vulnerabilities {
+                    vulnerability.write_xml_named_element(writer, VULNERABILITY_TAG)?;
+                }
+
+                write_close_tag(writer, VULNERABILITIES_TAG)?;
             }
 
             #[versioned("1.4", "1.5")]
@@ -191,14 +225,18 @@ pub(crate) mod base {
         fn read_xml_element<R: std::io::Read>(
             event_reader: &mut xml::EventReader<R>,
             element_name: &xml::name::OwnedName,
-            _attributes: &[xml::attribute::OwnedAttribute],
+            #[allow(unused)] attributes: &[xml::attribute::OwnedAttribute],
         ) -> Result<Self, crate::errors::XmlReadError>
         where
             Self: Sized,
         {
+            #[versioned("1.5")]
+            let bom_ref: Option<String> = crate::xml::optional_attribute(&attributes, BOM_REF_ATTR);
             let mut aggregate: Option<String> = None;
             let mut assemblies: Option<Vec<BomReference>> = None;
             let mut dependencies: Option<Vec<BomReference>> = None;
+            #[versioned("1.5")]
+            let mut vulnerabilities: Option<Vec<BomReference>> = None;
             #[versioned("1.4", "1.5")]
             let mut signature: Option<Signature> = None;
 
@@ -231,6 +269,16 @@ pub(crate) mod base {
                             DEPENDENCY_TAG,
                         )?)
                     }
+                    #[versioned("1.5")]
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == VULNERABILITIES_TAG =>
+                    {
+                        vulnerabilities = Some(read_lax_validation_list_tag(
+                            event_reader,
+                            &name,
+                            VULNERABILITY_TAG,
+                        )?);
+                    }
                     #[versioned("1.4", "1.5")]
                     reader::XmlEvent::StartElement {
                         name, attributes, ..
@@ -254,9 +302,13 @@ pub(crate) mod base {
             })?;
 
             Ok(Self {
+                #[versioned("1.5")]
+                bom_ref,
                 aggregate,
                 assemblies,
                 dependencies,
+                #[versioned("1.5")]
+                vulnerabilities,
                 #[versioned("1.4", "1.5")]
                 signature,
             })
@@ -266,6 +318,8 @@ pub(crate) mod base {
     #[cfg(test)]
     pub(crate) mod test {
         use super::*;
+        use pretty_assertions::assert_eq;
+
         #[versioned("1.4", "1.5")]
         use crate::specs::common::signature::test::{corresponding_signature, example_signature};
         use crate::xml::test::{read_element_from_string, write_element_to_string};
@@ -280,9 +334,13 @@ pub(crate) mod base {
 
         pub(crate) fn example_composition() -> Composition {
             Composition {
+                #[versioned("1.5")]
+                bom_ref: Some("composition-ref".to_string()),
                 aggregate: "aggregate".to_string(),
-                assemblies: Some(vec![BomReference::new("assembly")]),
-                dependencies: Some(vec![BomReference::new("dependency")]),
+                assemblies: Some(vec![BomReference::new("assembly-ref")]),
+                dependencies: Some(vec![BomReference::new("dependency-ref")]),
+                #[versioned("1.5")]
+                vulnerabilities: Some(vec![BomReference::new("vulnerability-ref")]),
                 #[versioned("1.4", "1.5")]
                 signature: Some(example_signature()),
             }
@@ -290,11 +348,19 @@ pub(crate) mod base {
 
         pub(crate) fn corresponding_composition() -> models::composition::Composition {
             models::composition::Composition {
+                #[versioned("1.3", "1.4")]
+                bom_ref: None,
+                #[versioned("1.5")]
+                bom_ref: Some(models::bom::BomReference::new("composition-ref")),
                 aggregate: models::composition::AggregateType::UnknownAggregateType(
                     "aggregate".to_string(),
                 ),
-                assemblies: Some(vec![models::bom::BomReference::new("assembly")]),
-                dependencies: Some(vec![models::bom::BomReference::new("dependency")]),
+                assemblies: Some(vec![models::bom::BomReference::new("assembly-ref")]),
+                dependencies: Some(vec![models::bom::BomReference::new("dependency-ref")]),
+                #[versioned("1.3", "1.4")]
+                vulnerabilities: None,
+                #[versioned("1.5")]
+                vulnerabilities: Some(vec![models::bom::BomReference::new("vulnerability-ref")]),
                 #[versioned("1.3")]
                 signature: None,
                 #[versioned("1.4", "1.5")]
@@ -316,25 +382,46 @@ pub(crate) mod base {
   <composition>
     <aggregate>aggregate</aggregate>
     <assemblies>
-      <assembly ref="assembly" />
+      <assembly ref="assembly-ref" />
     </assemblies>
     <dependencies>
-      <dependency ref="dependency" />
+      <dependency ref="dependency-ref" />
     </dependencies>
   </composition>
 </compositions>
 "#;
-            #[versioned("1.4", "1.5")]
+            #[versioned("1.4")]
             let input = r#"
 <compositions>
   <composition>
     <aggregate>aggregate</aggregate>
     <assemblies>
-      <assembly ref="assembly" />
+      <assembly ref="assembly-ref" />
     </assemblies>
     <dependencies>
-      <dependency ref="dependency" />
+      <dependency ref="dependency-ref" />
     </dependencies>
+    <signature>
+      <algorithm>HS512</algorithm>
+      <value>1234567890</value>
+    </signature>
+  </composition>
+</compositions>
+"#;
+            #[versioned("1.5")]
+            let input = r#"
+<compositions>
+  <composition bom-ref="composition-ref">
+    <aggregate>aggregate</aggregate>
+    <assemblies>
+      <assembly ref="assembly-ref" />
+    </assemblies>
+    <dependencies>
+      <dependency ref="dependency-ref" />
+    </dependencies>
+    <vulnerabilities>
+      <vulnerability ref="vulnerability-ref" />
+    </vulnerabilities>
     <signature>
       <algorithm>HS512</algorithm>
       <value>1234567890</value>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 606
+assertion_line: 592
 expression: actual
 ---
 {
@@ -425,10 +425,10 @@ expression: actual
     {
       "aggregate": "aggregate",
       "assemblies": [
-        "assembly"
+        "assembly-ref"
       ],
       "dependencies": [
-        "dependency"
+        "dependency-ref"
       ]
     }
   ]

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_3__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -306,10 +306,10 @@ expression: xml_output
     <composition>
       <aggregate>aggregate</aggregate>
       <assemblies>
-        <assembly ref="assembly" />
+        <assembly ref="assembly-ref" />
       </assemblies>
       <dependencies>
-        <dependency ref="dependency" />
+        <dependency ref="dependency-ref" />
       </dependencies>
     </composition>
   </compositions>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
@@ -437,10 +437,10 @@ expression: actual
     {
       "aggregate": "aggregate",
       "assemblies": [
-        "assembly"
+        "assembly-ref"
       ],
       "dependencies": [
-        "dependency"
+        "dependency-ref"
       ],
       "signature": {
         "algorithm": "HS512",

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 612
+assertion_line: 598
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -318,10 +318,10 @@ expression: xml_output
     <composition>
       <aggregate>aggregate</aggregate>
       <assemblies>
-        <assembly ref="assembly" />
+        <assembly ref="assembly-ref" />
       </assemblies>
       <dependencies>
-        <dependency ref="dependency" />
+        <dependency ref="dependency-ref" />
       </dependencies>
       <signature>
         <algorithm>HS512</algorithm>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -658,12 +658,16 @@ expression: actual
   ],
   "compositions": [
     {
+      "bomRef": "composition-ref",
       "aggregate": "aggregate",
       "assemblies": [
-        "assembly"
+        "assembly-ref"
       ],
       "dependencies": [
-        "dependency"
+        "dependency-ref"
+      ],
+      "vulnerabilities": [
+        "vulnerability-ref"
       ],
       "signature": {
         "algorithm": "HS512",

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -458,14 +458,17 @@ expression: xml_output
     </dependency>
   </dependencies>
   <compositions>
-    <composition>
+    <composition bom-ref="composition-ref">
       <aggregate>aggregate</aggregate>
       <assemblies>
-        <assembly ref="assembly" />
+        <assembly ref="assembly-ref" />
       </assemblies>
       <dependencies>
-        <dependency ref="dependency" />
+        <dependency ref="dependency-ref" />
       </dependencies>
+      <vulnerabilities>
+        <vulnerability ref="vulnerability-ref" />
+      </vulnerabilities>
       <signature>
         <algorithm>HS512</algorithm>
         <value>1234567890</value>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__composition__v1_3__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__composition__v1_3__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/composition.rs
+assertion_line: 361
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -7,10 +8,10 @@ expression: xml_output
   <composition>
     <aggregate>aggregate</aggregate>
     <assemblies>
-      <assembly ref="assembly" />
+      <assembly ref="assembly-ref" />
     </assemblies>
     <dependencies>
-      <dependency ref="dependency" />
+      <dependency ref="dependency-ref" />
     </dependencies>
   </composition>
 </compositions>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__composition__v1_4__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__composition__v1_4__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/composition.rs
+assertion_line: 361
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -7,10 +8,10 @@ expression: xml_output
   <composition>
     <aggregate>aggregate</aggregate>
     <assemblies>
-      <assembly ref="assembly" />
+      <assembly ref="assembly-ref" />
     </assemblies>
     <dependencies>
-      <dependency ref="dependency" />
+      <dependency ref="dependency-ref" />
     </dependencies>
     <signature>
       <algorithm>HS512</algorithm>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__composition__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__composition__v1_5__test__it_should_write_xml_full.snap
@@ -1,17 +1,21 @@
 ---
 source: cyclonedx-bom/src/specs/common/composition.rs
+assertion_line: 374
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <compositions>
-  <composition>
+  <composition bom-ref="composition-ref">
     <aggregate>aggregate</aggregate>
     <assemblies>
-      <assembly ref="assembly" />
+      <assembly ref="assembly-ref" />
     </assemblies>
     <dependencies>
-      <dependency ref="dependency" />
+      <dependency ref="dependency-ref" />
     </dependencies>
+    <vulnerabilities>
+      <vulnerability ref="vulnerability-ref" />
+    </vulnerabilities>
     <signature>
       <algorithm>HS512</algorithm>
       <value>1234567890</value>

--- a/cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.json
+++ b/cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.json
@@ -45,8 +45,18 @@
       ]
     }
   ],
+  "vulnerabilities": [
+    {
+      "bom-ref": "vulnerability-1",
+      "id": "ACME-12345",
+      "source": {
+        "name": "Acme Inc"
+      }
+    }
+  ],
   "compositions": [
     {
+      "bom-ref": "composition-1",
       "aggregate": "complete",
       "assemblies": [
         "pkg:maven/partner/shaded-library@1.0"
@@ -59,6 +69,12 @@
       "aggregate": "unknown",
       "assemblies": [
         "pkg:maven/acme/library@3.0"
+      ]
+    },
+    {
+      "aggregate": "incomplete_first_party_only",
+      "vulnerabilities": [
+        "vulnerability-1"
       ]
     }
   ]

--- a/cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.xml
+++ b/cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.xml
@@ -32,7 +32,7 @@
         </dependency>
     </dependencies>
     <compositions>
-        <composition>
+        <composition bom-ref="composition-1">
             <aggregate>complete</aggregate>
             <assemblies>
                 <assembly ref="pkg:maven/partner/shaded-library@1.0"/>
@@ -47,5 +47,19 @@
                 <assembly ref="pkg:maven/acme/library@3.0"/>
             </assemblies>
         </composition>
+        <composition>
+            <aggregate>incomplete_first_party_only</aggregate>
+            <assemblies>
+                <assembly ref="vulnerability-1"/>
+            </assemblies>
+        </composition>
     </compositions>
+    <vulnerabilities>
+        <vulnerability bom-ref="vulnerability-1">
+            <id>ACME-12345</id>
+            <source>
+                <name>Acme Inc</name>
+            </source>
+        </vulnerability>
+    </vulnerabilities>
 </bom>

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-compositions-1.5.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-compositions-1.5.json.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_5.rs
-assertion_line: 54
+assertion_line: 52
 expression: bom_output
 input_file: cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.json
 ---
@@ -66,6 +66,21 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.json
       "assemblies": [
         "pkg:maven/acme/library@3.0"
       ]
+    },
+    {
+      "aggregate": "incomplete_first_party_only",
+      "vulnerabilities": [
+        "vulnerability-1"
+      ]
+    }
+  ],
+  "vulnerabilities": [
+    {
+      "bom-ref": "vulnerability-1",
+      "id": "ACME-12345",
+      "source": {
+        "name": "Acme Inc"
+      }
     }
   ]
 }

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_xml_specifications@valid-compositions-1.5.xml.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_xml_specifications@valid-compositions-1.5.xml.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_5.rs
-assertion_line: 27
+assertion_line: 29
 expression: bom_output
 input_file: cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.xml
 ---
@@ -38,7 +38,7 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.xml
     </dependency>
   </dependencies>
   <compositions>
-    <composition>
+    <composition bom-ref="composition-1">
       <aggregate>complete</aggregate>
       <assemblies>
         <assembly ref="pkg:maven/partner/shaded-library@1.0" />
@@ -53,5 +53,20 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-compositions-1.5.xml
         <assembly ref="pkg:maven/acme/library@3.0" />
       </assemblies>
     </composition>
+    <composition>
+      <aggregate>incomplete_first_party_only</aggregate>
+      <assemblies>
+        <assembly ref="vulnerability-1" />
+      </assemblies>
+    </composition>
   </compositions>
+  <vulnerabilities>
+    <vulnerability bom-ref="vulnerability-1">
+      <id>ACME-12345</id>
+      <source>
+        <name>Acme Inc</name>
+      </source>
+      <detail></detail>
+    </vulnerability>
+  </vulnerabilities>
 </bom>

--- a/cyclonedx-bom/tests/specification_tests_v1_5.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_5.rs
@@ -10,9 +10,12 @@ mod v1_5 {
         }, {
             insta::glob!("spec/1.5/valid*.xml", |path| {
                 let file = std::fs::File::open(path).unwrap_or_else(|_| panic!("Failed to read file: {path:?}"));
-                let bom = Bom::parse_from_xml_v1_5(file).unwrap_or_else(|_| panic!("Failed to parse the document as an BOM: {path:?}"));
+                let bom = Bom::parse_from_xml_v1_5(file).unwrap_or_else(|e| panic!("Failed to parse the document as an BOM: {path:?} {:#?}", e));
 
                 let validation_result = bom.validate_version(SpecVersion::V1_5);
+                if !validation_result.passed() {
+                    dbg!(&validation_result);
+                }
                 assert!(
                     validation_result.passed(),
                     "{path:?} unexpectedly failed validation"


### PR DESCRIPTION
This adds fields `bom_ref` & `vulnerabilities` to the `Composition` type to support [spec version 1.5](https://cyclonedx.org/docs/1.5/json/#compositions).

* expand & update tests
* adjust reference strings in test data to reflect their usage
* refactor writing start & close tags using helpers

**Please note** this does not change `assemblies` or the `aggregateType` yet.