### PR TITLE
Expand ScoreMethod with variants

### DIFF
--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -257,7 +257,7 @@ mod test {
                 }),
                 score: Score::from_f32(10.0),
                 severity: Some(Severity::UndefinedSeverity("undefined".to_string())),
-                score_method: Some(ScoreMethod::Other("other method".to_string())),
+                score_method: Some(ScoreMethod::Unknown("other method".to_string())),
                 vector: Some(NormalizedString("invalid\tvector".to_string())),
                 justification: Some("justification".to_string()),
             }])),
@@ -343,6 +343,10 @@ mod test {
                                         0,
                                         vec![
                                             validation::r#enum("severity", "Undefined severity"),
+                                            validation::field(
+                                                "score_method",
+                                                "Unknown score method 'other method'",
+                                            ),
                                             validation::field(
                                                 "vector",
                                                 "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -70,6 +70,9 @@ impl Validate for VulnerabilityRating {
                 version,
             )
             .add_enum_option("severity", self.severity.as_ref(), validate_severity)
+            .add_field_option("score_method", self.score_method.as_ref(), |sm| {
+                validate_score_method(sm, version)
+            })
             .add_field_option("vector", self.vector.as_ref(), validate_normalized_string)
             .into()
     }
@@ -162,17 +165,38 @@ impl Severity {
     }
 }
 
+pub(crate) fn validate_score_method(
+    method: &ScoreMethod,
+    version: SpecVersion,
+) -> Result<(), ValidationError> {
+    if version <= SpecVersion::V1_4 {
+        if ScoreMethod::OWASP < *method {
+            return Err(format!("Unknown score method '{method}'").into());
+        }
+    } else if version <= SpecVersion::V1_5 {
+        if let ScoreMethod::Unknown(unknown) = method {
+            return Err(format!("Unknown score method '{unknown}'").into());
+        }
+    }
+    Ok(())
+}
+
 /// Specifies the risk scoring method or standard used.
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_scoreSourceType)
-#[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display)]
+#[repr(u16)]
 pub enum ScoreMethod {
-    CVSSv2,
-    CVSSv3,
-    CVSSv31,
-    OWASP,
+    CVSSv2 = 1,
+    CVSSv3 = 2,
+    CVSSv31 = 3,
+    OWASP = 4,
+    /// Added in version 1.5
+    CVSSv4 = 5,
+    /// Added in version 1.5
+    SSVC = 6,
     #[strum(default)]
-    Other(String),
+    Unknown(String),
 }
 
 impl ScoreMethod {
@@ -181,8 +205,10 @@ impl ScoreMethod {
             "CVSSv2" => Self::CVSSv2,
             "CVSSv3" => Self::CVSSv3,
             "CVSSv31" => Self::CVSSv31,
+            "CVSSv4" => Self::CVSSv4,
             "OWASP" => Self::OWASP,
-            score_method => Self::Other(score_method.to_string()),
+            "SSVC" => Self::SSVC,
+            unknown => Self::Unknown(unknown.to_string()),
         }
     }
 }
@@ -195,6 +221,22 @@ mod test {
     };
 
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn valid_vulnerability_score_method() {
+        assert!(
+            validate_score_method(&ScoreMethod::new_unchecked("OWASP"), SpecVersion::V1_4).is_ok()
+        );
+        assert!(
+            validate_score_method(&ScoreMethod::new_unchecked("OWASP"), SpecVersion::V1_5).is_ok()
+        );
+        assert!(
+            validate_score_method(&ScoreMethod::new_unchecked("SSVC"), SpecVersion::V1_4).is_err()
+        );
+        assert!(
+            validate_score_method(&ScoreMethod::new_unchecked("SSVC"), SpecVersion::V1_5).is_ok()
+        );
+    }
 
     #[test]
     fn valid_vulnerability_ratings_should_pass_validation() {


### PR DESCRIPTION
This PR expands the vulnerability `ScoreMethod` with a few more variants

* add validation method to check vulnerability score method
* rename variant `Other` to `Unknown` to be consistent