### PR TITLE
Expand `Vulnerability` type to support spec version 15

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -760,6 +760,7 @@ mod test {
                 detail: None,
                 recommendation: None,
                 workaround: None,
+                proof_of_concept: None,
                 advisories: None,
                 created: None,
                 published: None,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -765,6 +765,7 @@ mod test {
                 created: None,
                 published: None,
                 updated: None,
+                rejected: None,
                 vulnerability_credits: None,
                 tools: None,
                 vulnerability_analysis: None,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -759,6 +759,7 @@ mod test {
                 description: None,
                 detail: None,
                 recommendation: None,
+                workaround: None,
                 advisories: None,
                 created: None,
                 published: None,

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -31,6 +31,7 @@ use crate::models::vulnerability_target::VulnerabilityTargets;
 use crate::validation::{Validate, ValidationContext, ValidationResult};
 
 use super::bom::SpecVersion;
+use super::modelcard::Attachment;
 
 /// Represents a vulnerability as described in the [CycloneDX use cases](https://cyclonedx.org/use-cases/#vulnerability-exploitability)
 ///
@@ -47,6 +48,7 @@ pub struct Vulnerability {
     pub detail: Option<String>,
     pub recommendation: Option<String>,
     pub workaround: Option<String>,
+    pub proof_of_concept: Option<VulnerabilityProofOfConcept>,
     pub advisories: Option<Advisories>,
     pub created: Option<DateTime>,
     pub published: Option<DateTime>,
@@ -77,6 +79,7 @@ impl Vulnerability {
             detail: None,
             recommendation: None,
             workaround: None,
+            proof_of_concept: None,
             advisories: None,
             created: None,
             published: None,
@@ -149,6 +152,13 @@ impl Validate for Vulnerabilities {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VulnerabilityProofOfConcept {
+    pub reproduction_steps: Option<String>,
+    pub environment: Option<String>,
+    pub supporting_material: Option<Vec<Attachment>>,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -202,6 +212,15 @@ mod test {
             detail: Some("detail".to_string()),
             recommendation: Some("recommendation".to_string()),
             workaround: Some("workaround".to_string()),
+            proof_of_concept: Some(VulnerabilityProofOfConcept {
+                reproduction_steps: Some("reproduction steps".to_string()),
+                environment: Some("production".to_string()),
+                supporting_material: Some(vec![Attachment {
+                    content: "abcdefgh".to_string(),
+                    content_type: Some("image/jpeg".to_string()),
+                    encoding: Some("base64".to_string()),
+                }]),
+            }),
             advisories: Some(Advisories(vec![Advisory {
                 title: Some(NormalizedString::new("title")),
                 url: Uri("https://example.com".to_string()),
@@ -269,6 +288,15 @@ mod test {
             detail: Some("detail".to_string()),
             recommendation: Some("recommendation".to_string()),
             workaround: Some("workaround".to_string()),
+            proof_of_concept: Some(VulnerabilityProofOfConcept {
+                reproduction_steps: Some("reproduction steps".to_string()),
+                environment: Some("production".to_string()),
+                supporting_material: Some(vec![Attachment {
+                    content: "abcdefgh".to_string(),
+                    content_type: Some("image/jpeg".to_string()),
+                    encoding: Some("base64".to_string()),
+                }]),
+            }),
             advisories: Some(Advisories(vec![Advisory {
                 title: Some(NormalizedString("invalid\ttitle".to_string())),
                 url: Uri("invalid url".to_string()),

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -53,6 +53,7 @@ pub struct Vulnerability {
     pub created: Option<DateTime>,
     pub published: Option<DateTime>,
     pub updated: Option<DateTime>,
+    pub rejected: Option<DateTime>,
     pub vulnerability_credits: Option<VulnerabilityCredits>,
     pub tools: Option<Tools>,
     pub vulnerability_analysis: Option<VulnerabilityAnalysis>,
@@ -84,6 +85,7 @@ impl Vulnerability {
             created: None,
             published: None,
             updated: None,
+            rejected: None,
             vulnerability_credits: None,
             tools: None,
             vulnerability_analysis: None,
@@ -228,6 +230,7 @@ mod test {
             created: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
             published: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
             updated: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
+            rejected: Some(DateTime("1969-06-28T01:20:00.00-04:00".to_string())),
             vulnerability_credits: Some(VulnerabilityCredits {
                 organizations: Some(vec![OrganizationalEntity::new("name")]),
                 individuals: None,
@@ -304,6 +307,7 @@ mod test {
             created: Some(DateTime("Thursday".to_string())),
             published: Some(DateTime("1970-01-01".to_string())),
             updated: Some(DateTime("invalid date".to_string())),
+            rejected: Some(DateTime("1970-01-01".to_string())),
             vulnerability_credits: None,
             tools: None,
             vulnerability_analysis: Some(VulnerabilityAnalysis {

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -241,6 +241,8 @@ mod test {
                 justification: Some(ImpactAnalysisJustification::CodeNotReachable),
                 responses: Some(vec![ImpactAnalysisResponse::Update]),
                 detail: Some("detail".to_string()),
+                first_issued: Some(DateTime("2024-01-02T01:20:00.00-04:00".to_string())),
+                last_updated: Some(DateTime("2024-01-10T01:20:00.00-04:00".to_string())),
             }),
             vulnerability_targets: Some(VulnerabilityTargets(vec![VulnerabilityTarget {
                 bom_ref: "bom ref".to_string(),
@@ -323,6 +325,8 @@ mod test {
                     "undefined".to_string(),
                 )]),
                 detail: Some("detail".to_string()),
+                first_issued: Some(DateTime("invalid".to_string())),
+                last_updated: Some(DateTime("invalid".to_string())),
             }),
             vulnerability_targets: None,
             properties: Some(Properties(vec![Property {
@@ -425,6 +429,8 @@ mod test {
                                         validation::custom("", ["Undefined response"])
                                     )]
                                 ),
+                                validation::field("first_issued", "DateTime does not conform to ISO 8601"),
+                                validation::field("last_updated", "DateTime does not conform to ISO 8601"),
                             ]
                         ),
                         validation::r#struct(

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -46,6 +46,7 @@ pub struct Vulnerability {
     pub description: Option<String>,
     pub detail: Option<String>,
     pub recommendation: Option<String>,
+    pub workaround: Option<String>,
     pub advisories: Option<Advisories>,
     pub created: Option<DateTime>,
     pub published: Option<DateTime>,
@@ -75,6 +76,7 @@ impl Vulnerability {
             description: None,
             detail: None,
             recommendation: None,
+            workaround: None,
             advisories: None,
             created: None,
             published: None,
@@ -199,6 +201,7 @@ mod test {
             description: Some("description".to_string()),
             detail: Some("detail".to_string()),
             recommendation: Some("recommendation".to_string()),
+            workaround: Some("workaround".to_string()),
             advisories: Some(Advisories(vec![Advisory {
                 title: Some(NormalizedString::new("title")),
                 url: Uri("https://example.com".to_string()),
@@ -265,6 +268,7 @@ mod test {
             description: Some("description".to_string()),
             detail: Some("detail".to_string()),
             recommendation: Some("recommendation".to_string()),
+            workaround: Some("workaround".to_string()),
             advisories: Some(Advisories(vec![Advisory {
                 title: Some(NormalizedString("invalid\ttitle".to_string())),
                 url: Uri("invalid url".to_string()),

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -16,7 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+use crate::{
+    external_models::validate_date_time,
+    prelude::DateTime,
+    validation::{Validate, ValidationContext, ValidationError, ValidationResult},
+};
 
 use super::bom::SpecVersion;
 
@@ -29,6 +33,10 @@ pub struct VulnerabilityAnalysis {
     pub justification: Option<ImpactAnalysisJustification>,
     pub responses: Option<Vec<ImpactAnalysisResponse>>,
     pub detail: Option<String>,
+    /// Added in spec version 1.5
+    pub first_issued: Option<DateTime>,
+    /// Added in spec version 1.5
+    pub last_updated: Option<DateTime>,
 }
 
 impl VulnerabilityAnalysis {
@@ -52,6 +60,8 @@ impl VulnerabilityAnalysis {
             justification,
             responses,
             detail: None,
+            first_issued: None,
+            last_updated: None,
         }
     }
 }
@@ -68,6 +78,16 @@ impl Validate for VulnerabilityAnalysis {
             .add_list_option("responses", self.responses.as_ref(), |response| {
                 validate_impact_analysis_response(response)
             })
+            .add_field_option(
+                "first_issued",
+                self.first_issued.as_ref(),
+                validate_date_time,
+            )
+            .add_field_option(
+                "last_updated",
+                self.first_issued.as_ref(),
+                validate_date_time,
+            )
             .into()
     }
 }
@@ -211,6 +231,8 @@ mod test {
             justification: Some(ImpactAnalysisJustification::CodeNotReachable),
             responses: Some(vec![ImpactAnalysisResponse::Update]),
             detail: Some("detail".to_string()),
+            first_issued: Some(DateTime("2024-01-02T01:20:00.00-04:00".to_string())),
+            last_updated: Some(DateTime("2024-01-10T01:20:00.00-04:00".to_string())),
         }
         .validate();
 
@@ -232,6 +254,8 @@ mod test {
                 "undefined".to_string(),
             )]),
             detail: Some("detail".to_string()),
+            first_issued: Some(DateTime("invalid".to_string())),
+            last_updated: Some(DateTime("invalid".to_string())),
         }
         .validate();
 
@@ -243,7 +267,9 @@ mod test {
                 validation::list(
                     "responses",
                     [(0, validation::custom("", ["Undefined response"]))]
-                )
+                ),
+                validation::field("first_issued", "DateTime does not conform to ISO 8601"),
+                validation::field("last_updated", "DateTime does not conform to ISO 8601")
             ]
             .into()
         );

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -1980,6 +1980,7 @@ pub(crate) mod base {
       <description>description</description>
       <detail>detail</detail>
       <recommendation>recommendation</recommendation>
+      <workaround>workaround</workaround>
       <advisories>
         <advisory>
           <title>title</title>

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -1997,6 +1997,7 @@ pub(crate) mod base {
       <created>created</created>
       <published>published</published>
       <updated>updated</updated>
+      <rejected>rejected</rejected>
       <credits>
         <organizations>
           <organization>

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -1981,6 +1981,13 @@ pub(crate) mod base {
       <detail>detail</detail>
       <recommendation>recommendation</recommendation>
       <workaround>workaround</workaround>
+      <proofOfConcept>
+        <reproductionSteps>reproduction steps</reproductionSteps>
+        <environment>production</environment>
+        <supportingMaterial>
+          <attachment content-type="image/jpeg" encoding="base64">abcdefgh</attachment>
+        </supportingMaterial>
+      </proofOfConcept>
       <advisories>
         <advisory>
           <title>title</title>

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -2035,6 +2035,8 @@ pub(crate) mod base {
           <response>update</response>
         </responses>
         <detail>detail</detail>
+        <firstIssued>2024-01-02</firstIssued>
+        <lastUpdated>2024-01-10</lastUpdated>
       </analysis>
       <affects>
         <target>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 606
+assertion_line: 603
 expression: actual
 ---
 {
@@ -713,6 +713,7 @@ expression: actual
       "description": "description",
       "detail": "detail",
       "recommendation": "recommendation",
+      "workaround": "workaround",
       "advisories": [
         {
           "title": "title",

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -778,7 +778,9 @@ expression: actual
         "responses": [
           "update"
         ],
-        "detail": "detail"
+        "detail": "detail",
+        "firstIssued": "2024-01-02",
+        "lastUpdated": "2024-01-10"
       },
       "affects": [
         {

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -734,6 +734,7 @@ expression: actual
       "created": "created",
       "published": "published",
       "updated": "updated",
+      "rejected": "rejected",
       "credits": {
         "organizations": [
           {

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -714,6 +714,17 @@ expression: actual
       "detail": "detail",
       "recommendation": "recommendation",
       "workaround": "workaround",
+      "proofOfConcept": {
+        "reproductionSteps": "reproduction steps",
+        "environment": "production",
+        "supportingMaterial": [
+          {
+            "content": "abcdefgh",
+            "contentType": "image/jpeg",
+            "encoding": "base64"
+          }
+        ]
+      },
       "advisories": [
         {
           "title": "title",

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -524,6 +524,7 @@ expression: xml_output
       <created>created</created>
       <published>published</published>
       <updated>updated</updated>
+      <rejected>rejected</rejected>
       <credits>
         <organizations>
           <organization>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -562,6 +562,8 @@ expression: xml_output
           <response>update</response>
         </responses>
         <detail>detail</detail>
+        <firstIssued>2024-01-02</firstIssued>
+        <lastUpdated>2024-01-10</lastUpdated>
       </analysis>
       <affects>
         <target>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 598
+assertion_line: 609
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -580,6 +580,7 @@ expression: xml_output
       <properties>
         <property name="name">value</property>
       </properties>
+      <workaround>workaround</workaround>
     </vulnerability>
   </vulnerabilities>
 </bom>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/vulnerability.rs
-assertion_line: 688
+assertion_line: 750
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -50,6 +50,7 @@ expression: xml_output
     <created>created</created>
     <published>published</published>
     <updated>updated</updated>
+    <rejected>rejected</rejected>
     <credits>
       <organizations>
         <organization>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/vulnerability.rs
+assertion_line: 688
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -105,5 +106,6 @@ expression: xml_output
     <properties>
       <property name="name">value</property>
     </properties>
+    <workaround>workaround</workaround>
   </vulnerability>
 </vulnerabilities>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/vulnerability.rs
-assertion_line: 750
+assertion_line: 758
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -88,6 +88,8 @@ expression: xml_output
         <response>update</response>
       </responses>
       <detail>detail</detail>
+      <firstIssued>2024-01-02</firstIssued>
+      <lastUpdated>2024-01-10</lastUpdated>
     </analysis>
     <affects>
       <target>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability_analysis__v1_4__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability_analysis__v1_4__test__it_should_write_xml_full.snap
@@ -1,0 +1,14 @@
+---
+source: cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
+assertion_line: 361
+expression: xml_output
+---
+<?xml version="1.0" encoding="utf-8"?>
+<analysis>
+  <state>not_affected</state>
+  <justification>code_not_reachable</justification>
+  <responses>
+    <response>update</response>
+  </responses>
+  <detail>detail</detail>
+</analysis>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability_analysis__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability_analysis__v1_5__test__it_should_write_xml_full.snap
@@ -1,0 +1,16 @@
+---
+source: cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
+assertion_line: 361
+expression: xml_output
+---
+<?xml version="1.0" encoding="utf-8"?>
+<analysis>
+  <state>not_affected</state>
+  <justification>code_not_reachable</justification>
+  <responses>
+    <response>update</response>
+  </responses>
+  <detail>detail</detail>
+  <firstIssued>2024-01-02</firstIssued>
+  <lastUpdated>2024-01-10</lastUpdated>
+</analysis>

--- a/cyclonedx-bom/src/specs/common/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability.rs
@@ -24,7 +24,7 @@ pub(crate) mod base {
     use crate::{
         errors::{BomError, XmlReadError},
         external_models::{date_time::DateTime, normalized_string::NormalizedString},
-        models,
+        models::{self},
         utilities::{
             convert_optional, convert_optional_vec, convert_vec, try_convert_optional,
             try_convert_vec,
@@ -48,7 +48,7 @@ pub(crate) mod base {
     #[versioned("1.4")]
     use crate::specs::v1_4::tool::Tools;
     #[versioned("1.5")]
-    use crate::specs::v1_5::tool::Tools;
+    use crate::specs::v1_5::{proof_of_concept::ProofOfConcept, tool::Tools};
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(transparent)]
@@ -125,6 +125,9 @@ pub(crate) mod base {
         #[versioned("1.5")]
         #[serde(skip_serializing_if = "Option::is_none")]
         workaround: Option<String>,
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        proof_of_concept: Option<ProofOfConcept>,
         #[serde(skip_serializing_if = "Option::is_none")]
         advisories: Option<Advisories>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -161,6 +164,8 @@ pub(crate) mod base {
                 recommendation: other.recommendation,
                 #[versioned("1.5")]
                 workaround: convert_optional(other.workaround),
+                #[versioned("1.5")]
+                proof_of_concept: convert_optional(other.proof_of_concept),
                 advisories: convert_optional(other.advisories),
                 created: other.created.map(|c| c.to_string()),
                 published: other.published.map(|p| p.to_string()),
@@ -190,6 +195,10 @@ pub(crate) mod base {
                 workaround: None,
                 #[versioned("1.5")]
                 workaround: convert_optional(other.workaround),
+                #[versioned("1.4")]
+                proof_of_concept: None,
+                #[versioned("1.5")]
+                proof_of_concept: convert_optional(other.proof_of_concept),
                 advisories: convert_optional(other.advisories),
                 created: other.created.map(DateTime),
                 published: other.published.map(DateTime),
@@ -225,6 +234,8 @@ pub(crate) mod base {
     const PROPERTIES_TAG: &str = "properties";
     #[versioned("1.5")]
     const WORKAROUND_TAG: &str = "workaround";
+    #[versioned("1.5")]
+    const PROOF_OF_CONCEPT_TAG: &str = "proofOfConcept";
 
     impl ToXml for Vulnerability {
         fn write_xml_element<W: std::io::Write>(
@@ -360,6 +371,8 @@ pub(crate) mod base {
             let mut properties: Option<Properties> = None;
             #[versioned("1.5")]
             let mut workaround: Option<String> = None;
+            #[versioned("1.5")]
+            let mut proof_of_concept: Option<ProofOfConcept> = None;
 
             let mut got_end_tag = false;
             while !got_end_tag {
@@ -504,6 +517,17 @@ pub(crate) mod base {
                         workaround = Some(read_simple_tag(event_reader, &name)?);
                     }
 
+                    #[versioned("1.5")]
+                    reader::XmlEvent::StartElement {
+                        name, attributes, ..
+                    } if name.local_name == PROOF_OF_CONCEPT_TAG => {
+                        proof_of_concept = Some(ProofOfConcept::read_xml_element(
+                            event_reader,
+                            &name,
+                            &attributes,
+                        )?);
+                    }
+
                     // lax validation of any elements from a different schema
                     reader::XmlEvent::StartElement { name, .. } => {
                         read_lax_validation_tag(event_reader, &name)?
@@ -527,6 +551,8 @@ pub(crate) mod base {
                 recommendation,
                 #[versioned("1.5")]
                 workaround,
+                #[versioned("1.5")]
+                proof_of_concept,
                 advisories,
                 created,
                 published,
@@ -548,7 +574,10 @@ pub(crate) mod base {
         #[versioned("1.4")]
         use crate::specs::v1_4::tool::test::{corresponding_tools, example_tools};
         #[versioned("1.5")]
-        use crate::specs::v1_5::tool::test::{corresponding_tools, example_tools};
+        use crate::specs::v1_5::{
+            proof_of_concept::test::{corresponding_proof_of_concept, example_proof_of_concept},
+            tool::test::{corresponding_tools, example_tools},
+        };
         use crate::{
             specs::common::{
                 advisory::test::{corresponding_advisories, example_advisories},
@@ -620,6 +649,7 @@ pub(crate) mod base {
                 detail: Some("detail".to_string()),
                 recommendation: Some("recommendation".to_string()),
                 workaround: Some("workaround".to_string()),
+                proof_of_concept: Some(example_proof_of_concept()),
                 advisories: Some(example_advisories()),
                 created: Some("created".to_string()),
                 published: Some("published".to_string()),
@@ -645,6 +675,7 @@ pub(crate) mod base {
                 detail: Some("detail".to_string()),
                 recommendation: Some("recommendation".to_string()),
                 workaround: None,
+                proof_of_concept: None,
                 advisories: Some(corresponding_advisories()),
                 created: Some(DateTime("created".to_string())),
                 published: Some(DateTime("published".to_string())),
@@ -670,6 +701,7 @@ pub(crate) mod base {
                 detail: Some("detail".to_string()),
                 recommendation: Some("recommendation".to_string()),
                 workaround: Some("workaround".to_string()),
+                proof_of_concept: Some(corresponding_proof_of_concept()),
                 advisories: Some(corresponding_advisories()),
                 created: Some(DateTime("created".to_string())),
                 published: Some(DateTime("published".to_string())),
@@ -844,6 +876,13 @@ pub(crate) mod base {
     <detail>detail</detail>
     <recommendation>recommendation</recommendation>
     <workaround>workaround</workaround>
+    <proofOfConcept>
+      <reproductionSteps>reproduction steps</reproductionSteps>
+      <environment>production</environment>
+      <supportingMaterial>
+        <attachment content-type="image/jpeg" encoding="base64">abcdefgh</attachment>
+      </supportingMaterial>
+    </proofOfConcept>
     <advisories>
       <advisory>
         <title>title</title>

--- a/cyclonedx-bom/src/specs/common/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability.rs
@@ -136,6 +136,9 @@ pub(crate) mod base {
         published: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         updated: Option<String>,
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rejected: Option<String>,
         #[serde(rename = "credits", skip_serializing_if = "Option::is_none")]
         vulnerability_credits: Option<VulnerabilityCredits>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -170,6 +173,8 @@ pub(crate) mod base {
                 created: other.created.map(|c| c.to_string()),
                 published: other.published.map(|p| p.to_string()),
                 updated: other.updated.map(|u| u.to_string()),
+                #[versioned("1.5")]
+                rejected: other.rejected.map(|r| r.to_string()),
                 vulnerability_credits: convert_optional(other.vulnerability_credits),
                 tools: try_convert_optional(other.tools)?,
                 vulnerability_analysis: convert_optional(other.vulnerability_analysis),
@@ -203,6 +208,10 @@ pub(crate) mod base {
                 created: other.created.map(DateTime),
                 published: other.published.map(DateTime),
                 updated: other.updated.map(DateTime),
+                #[versioned("1.4")]
+                rejected: None,
+                #[versioned("1.5")]
+                rejected: other.rejected.map(DateTime),
                 vulnerability_credits: convert_optional(other.vulnerability_credits),
                 tools: convert_optional(other.tools),
                 vulnerability_analysis: convert_optional(other.vulnerability_analysis),
@@ -227,6 +236,8 @@ pub(crate) mod base {
     const CREATED_TAG: &str = "created";
     const PUBLISHED_TAG: &str = "published";
     const UPDATED_TAG: &str = "updated";
+    #[versioned("1.5")]
+    const REJECTED_TAG: &str = "rejected";
     const VULNERABILITY_CREDITS_TAG: &str = "credits";
     const TOOLS_TAG: &str = "tools";
     const VULNERABILITY_ANALYSIS_TAG: &str = "analysis";
@@ -308,6 +319,11 @@ pub(crate) mod base {
                 write_simple_tag(writer, UPDATED_TAG, updated)?;
             }
 
+            #[versioned("1.5")]
+            if let Some(rejected) = &self.rejected {
+                write_simple_tag(writer, REJECTED_TAG, rejected)?;
+            }
+
             if let Some(vulnerability_credits) = &self.vulnerability_credits {
                 vulnerability_credits.write_xml_element(writer)?;
             }
@@ -364,6 +380,8 @@ pub(crate) mod base {
             let mut created: Option<String> = None;
             let mut published: Option<String> = None;
             let mut updated: Option<String> = None;
+            #[versioned("1.5")]
+            let mut rejected: Option<String> = None;
             let mut vulnerability_credits: Option<VulnerabilityCredits> = None;
             let mut tools: Option<Tools> = None;
             let mut vulnerability_analysis: Option<VulnerabilityAnalysis> = None;
@@ -464,6 +482,13 @@ pub(crate) mod base {
                         updated = Some(read_simple_tag(event_reader, &name)?);
                     }
 
+                    #[versioned("1.5")]
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == REJECTED_TAG =>
+                    {
+                        rejected = Some(read_simple_tag(event_reader, &name)?);
+                    }
+
                     reader::XmlEvent::StartElement {
                         name, attributes, ..
                     } if name.local_name == VULNERABILITY_CREDITS_TAG => {
@@ -557,6 +582,8 @@ pub(crate) mod base {
                 created,
                 published,
                 updated,
+                #[versioned("1.5")]
+                rejected,
                 vulnerability_credits,
                 tools,
                 vulnerability_analysis,
@@ -654,6 +681,7 @@ pub(crate) mod base {
                 created: Some("created".to_string()),
                 published: Some("published".to_string()),
                 updated: Some("updated".to_string()),
+                rejected: Some("rejected".to_string()),
                 vulnerability_credits: Some(example_vulnerability_credits()),
                 tools: Some(example_tools()),
                 vulnerability_analysis: Some(example_vulnerability_analysis()),
@@ -680,6 +708,7 @@ pub(crate) mod base {
                 created: Some(DateTime("created".to_string())),
                 published: Some(DateTime("published".to_string())),
                 updated: Some(DateTime("updated".to_string())),
+                rejected: None,
                 vulnerability_credits: Some(corresponding_vulnerability_credits()),
                 tools: Some(corresponding_tools()),
                 vulnerability_analysis: Some(corresponding_vulnerability_analysis()),
@@ -706,6 +735,7 @@ pub(crate) mod base {
                 created: Some(DateTime("created".to_string())),
                 published: Some(DateTime("published".to_string())),
                 updated: Some(DateTime("updated".to_string())),
+                rejected: Some(DateTime("rejected".to_string())),
                 vulnerability_credits: Some(corresponding_vulnerability_credits()),
                 tools: Some(corresponding_tools()),
                 vulnerability_analysis: Some(corresponding_vulnerability_analysis()),
@@ -892,6 +922,7 @@ pub(crate) mod base {
     <created>created</created>
     <published>published</published>
     <updated>updated</updated>
+    <rejected>rejected</rejected>
     <credits>
       <organizations>
         <organization>

--- a/cyclonedx-bom/src/specs/common/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability.rs
@@ -122,6 +122,9 @@ pub(crate) mod base {
         detail: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         recommendation: Option<String>,
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        workaround: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         advisories: Option<Advisories>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -156,6 +159,8 @@ pub(crate) mod base {
                 description: other.description,
                 detail: other.detail,
                 recommendation: other.recommendation,
+                #[versioned("1.5")]
+                workaround: convert_optional(other.workaround),
                 advisories: convert_optional(other.advisories),
                 created: other.created.map(|c| c.to_string()),
                 published: other.published.map(|p| p.to_string()),
@@ -181,6 +186,10 @@ pub(crate) mod base {
                 description: other.description,
                 detail: other.detail,
                 recommendation: other.recommendation,
+                #[versioned("1.4")]
+                workaround: None,
+                #[versioned("1.5")]
+                workaround: convert_optional(other.workaround),
                 advisories: convert_optional(other.advisories),
                 created: other.created.map(DateTime),
                 published: other.published.map(DateTime),
@@ -214,6 +223,8 @@ pub(crate) mod base {
     const VULNERABILITY_ANALYSIS_TAG: &str = "analysis";
     const VULNERABILITY_TARGETS_TAG: &str = "affects";
     const PROPERTIES_TAG: &str = "properties";
+    #[versioned("1.5")]
+    const WORKAROUND_TAG: &str = "workaround";
 
     impl ToXml for Vulnerability {
         fn write_xml_element<W: std::io::Write>(
@@ -306,6 +317,11 @@ pub(crate) mod base {
                 properties.write_xml_element(writer)?;
             }
 
+            #[versioned("1.5")]
+            if let Some(workaround) = &self.workaround {
+                write_simple_tag(writer, WORKAROUND_TAG, workaround)?;
+            }
+
             writer
                 .write(XmlEvent::end_element())
                 .map_err(to_xml_write_error(VULNERABILITY_TAG))?;
@@ -342,6 +358,8 @@ pub(crate) mod base {
             let mut vulnerability_analysis: Option<VulnerabilityAnalysis> = None;
             let mut vulnerability_targets: Option<VulnerabilityTargets> = None;
             let mut properties: Option<Properties> = None;
+            #[versioned("1.5")]
+            let mut workaround: Option<String> = None;
 
             let mut got_end_tag = false;
             while !got_end_tag {
@@ -479,6 +497,13 @@ pub(crate) mod base {
                         )?)
                     }
 
+                    #[versioned("1.5")]
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == WORKAROUND_TAG =>
+                    {
+                        workaround = Some(read_simple_tag(event_reader, &name)?);
+                    }
+
                     // lax validation of any elements from a different schema
                     reader::XmlEvent::StartElement { name, .. } => {
                         read_lax_validation_tag(event_reader, &name)?
@@ -500,6 +525,8 @@ pub(crate) mod base {
                 description,
                 detail,
                 recommendation,
+                #[versioned("1.5")]
+                workaround,
                 advisories,
                 created,
                 published,
@@ -556,6 +583,7 @@ pub(crate) mod base {
             models::vulnerability::Vulnerabilities(vec![corresponding_vulnerability()])
         }
 
+        #[versioned("1.4")]
         pub(crate) fn example_vulnerability() -> Vulnerability {
             Vulnerability {
                 bom_ref: Some("bom-ref".to_string()),
@@ -579,6 +607,32 @@ pub(crate) mod base {
             }
         }
 
+        #[versioned("1.5")]
+        pub(crate) fn example_vulnerability() -> Vulnerability {
+            Vulnerability {
+                bom_ref: Some("bom-ref".to_string()),
+                id: Some("id".to_string()),
+                vulnerability_source: Some(example_vulnerability_source()),
+                vulnerability_references: Some(example_vulnerability_references()),
+                vulnerability_ratings: Some(example_vulnerability_ratings()),
+                cwes: Some(vec![1, 2, 3]),
+                description: Some("description".to_string()),
+                detail: Some("detail".to_string()),
+                recommendation: Some("recommendation".to_string()),
+                workaround: Some("workaround".to_string()),
+                advisories: Some(example_advisories()),
+                created: Some("created".to_string()),
+                published: Some("published".to_string()),
+                updated: Some("updated".to_string()),
+                vulnerability_credits: Some(example_vulnerability_credits()),
+                tools: Some(example_tools()),
+                vulnerability_analysis: Some(example_vulnerability_analysis()),
+                vulnerability_targets: Some(example_vulnerability_targets()),
+                properties: Some(example_properties()),
+            }
+        }
+
+        #[versioned("1.4")]
         pub(crate) fn corresponding_vulnerability() -> models::vulnerability::Vulnerability {
             models::vulnerability::Vulnerability {
                 bom_ref: Some("bom-ref".to_string()),
@@ -590,6 +644,32 @@ pub(crate) mod base {
                 description: Some("description".to_string()),
                 detail: Some("detail".to_string()),
                 recommendation: Some("recommendation".to_string()),
+                workaround: None,
+                advisories: Some(corresponding_advisories()),
+                created: Some(DateTime("created".to_string())),
+                published: Some(DateTime("published".to_string())),
+                updated: Some(DateTime("updated".to_string())),
+                vulnerability_credits: Some(corresponding_vulnerability_credits()),
+                tools: Some(corresponding_tools()),
+                vulnerability_analysis: Some(corresponding_vulnerability_analysis()),
+                vulnerability_targets: Some(corresponding_vulnerability_targets()),
+                properties: Some(corresponding_properties()),
+            }
+        }
+
+        #[versioned("1.5")]
+        pub(crate) fn corresponding_vulnerability() -> models::vulnerability::Vulnerability {
+            models::vulnerability::Vulnerability {
+                bom_ref: Some("bom-ref".to_string()),
+                id: Some(NormalizedString::new_unchecked("id".to_string())),
+                vulnerability_source: Some(corresponding_vulnerability_source()),
+                vulnerability_references: Some(corresponding_vulnerability_references()),
+                vulnerability_ratings: Some(corresponding_vulnerability_ratings()),
+                cwes: Some(vec![1, 2, 3]),
+                description: Some("description".to_string()),
+                detail: Some("detail".to_string()),
+                recommendation: Some("recommendation".to_string()),
+                workaround: Some("workaround".to_string()),
                 advisories: Some(corresponding_advisories()),
                 created: Some(DateTime("created".to_string())),
                 published: Some(DateTime("published".to_string())),
@@ -608,6 +688,7 @@ pub(crate) mod base {
             insta::assert_snapshot!(xml_output);
         }
 
+        #[versioned("1.4")]
         #[test]
         fn it_should_read_xml_full() {
             let input = r#"
@@ -648,6 +729,121 @@ pub(crate) mod base {
     <description>description</description>
     <detail>detail</detail>
     <recommendation>recommendation</recommendation>
+    <advisories>
+      <advisory>
+        <title>title</title>
+        <url>url</url>
+      </advisory>
+    </advisories>
+    <created>created</created>
+    <published>published</published>
+    <updated>updated</updated>
+    <credits>
+      <organizations>
+        <organization>
+          <name>name</name>
+          <url>url</url>
+          <contact>
+            <name>name</name>
+            <email>email</email>
+            <phone>phone</phone>
+          </contact>
+        </organization>
+      </organizations>
+      <individuals>
+        <individual>
+          <name>name</name>
+          <email>email</email>
+          <phone>phone</phone>
+        </individual>
+      </individuals>
+    </credits>
+    <tools>
+      <tool>
+        <vendor>vendor</vendor>
+        <name>name</name>
+        <version>version</version>
+        <hashes>
+          <hash alg="algorithm">hash value</hash>
+        </hashes>
+      </tool>
+    </tools>
+    <analysis>
+      <state>not_affected</state>
+      <justification>code_not_reachable</justification>
+      <responses>
+        <response>update</response>
+      </responses>
+      <detail>detail</detail>
+    </analysis>
+    <affects>
+      <target>
+        <ref>ref</ref>
+        <versions>
+          <version>
+            <version>5.0.0</version>
+            <status>unaffected</status>
+          </version>
+          <version>
+            <range>vers:npm/1.2.3|>=2.0.0|&lt;5.0.0</range>
+            <status>affected</status>
+          </version>
+        </versions>
+      </target>
+    </affects>
+    <properties>
+      <property name="name">value</property>
+    </properties>
+  </vulnerability>
+</vulnerabilities>
+"#;
+            let actual: Vulnerabilities = read_element_from_string(input);
+            let expected = example_vulnerabilities();
+            assert_eq!(actual, expected);
+        }
+
+        #[versioned("1.5")]
+        #[test]
+        fn it_should_read_xml_full() {
+            let input = r#"
+<vulnerabilities>
+  <vulnerability bom-ref="bom-ref">
+    <id>id</id>
+    <source>
+      <name>name</name>
+      <url>url</url>
+    </source>
+    <references>
+      <reference>
+        <id>id</id>
+        <source>
+          <name>name</name>
+          <url>url</url>
+        </source>
+      </reference>
+    </references>
+    <ratings>
+      <rating>
+        <source>
+          <name>name</name>
+          <url>url</url>
+        </source>
+        <score>9.8</score>
+        <severity>info</severity>
+        <method>CVSSv3</method>
+        <vector>vector</vector>
+        <justification>justification</justification>
+      </rating>
+    </ratings>
+    <cwes>
+      <cwe>1</cwe>
+      <cwe>2</cwe>
+      <cwe>3</cwe>
+    </cwes>
+    <description>description</description>
+    <detail>detail</detail>
+    <recommendation>recommendation</recommendation>
+    <workaround>workaround</workaround>
     <advisories>
       <advisory>
         <title>title</title>

--- a/cyclonedx-bom/src/specs/common/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability.rs
@@ -40,15 +40,18 @@ pub(crate) mod base {
     use xml::{reader, writer::XmlEvent};
 
     use crate::specs::common::{
-        advisory::Advisories, property::Properties, vulnerability_analysis::VulnerabilityAnalysis,
-        vulnerability_credits::VulnerabilityCredits, vulnerability_rating::VulnerabilityRatings,
+        advisory::Advisories, property::Properties, vulnerability_credits::VulnerabilityCredits,
+        vulnerability_rating::VulnerabilityRatings,
         vulnerability_reference::VulnerabilityReferences,
         vulnerability_source::VulnerabilitySource, vulnerability_target::VulnerabilityTargets,
     };
     #[versioned("1.4")]
-    use crate::specs::v1_4::tool::Tools;
+    use crate::specs::v1_4::{tool::Tools, vulnerability_analysis::VulnerabilityAnalysis};
     #[versioned("1.5")]
-    use crate::specs::v1_5::{proof_of_concept::ProofOfConcept, tool::Tools};
+    use crate::specs::v1_5::{
+        proof_of_concept::ProofOfConcept, tool::Tools,
+        vulnerability_analysis::VulnerabilityAnalysis,
+    };
 
     #[derive(Debug, Deserialize, Serialize, PartialEq)]
     #[serde(transparent)]
@@ -599,19 +602,24 @@ pub(crate) mod base {
         use pretty_assertions::assert_eq;
 
         #[versioned("1.4")]
-        use crate::specs::v1_4::tool::test::{corresponding_tools, example_tools};
+        use crate::specs::v1_4::{
+            tool::test::{corresponding_tools, example_tools},
+            vulnerability_analysis::test::{
+                corresponding_vulnerability_analysis, example_vulnerability_analysis,
+            },
+        };
         #[versioned("1.5")]
         use crate::specs::v1_5::{
             proof_of_concept::test::{corresponding_proof_of_concept, example_proof_of_concept},
             tool::test::{corresponding_tools, example_tools},
+            vulnerability_analysis::test::{
+                corresponding_vulnerability_analysis, example_vulnerability_analysis,
+            },
         };
         use crate::{
             specs::common::{
                 advisory::test::{corresponding_advisories, example_advisories},
                 property::test::{corresponding_properties, example_properties},
-                vulnerability_analysis::test::{
-                    corresponding_vulnerability_analysis, example_vulnerability_analysis,
-                },
                 vulnerability_credits::test::{
                     corresponding_vulnerability_credits, example_vulnerability_credits,
                 },
@@ -960,6 +968,8 @@ pub(crate) mod base {
         <response>update</response>
       </responses>
       <detail>detail</detail>
+      <firstIssued>2024-01-02</firstIssued>
+      <lastUpdated>2024-01-10</lastUpdated>
     </analysis>
     <affects>
       <target>

--- a/cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
@@ -16,264 +16,368 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::utilities::convert_optional_vec;
-use crate::xml::{write_close_tag, write_start_tag};
-use crate::{
-    errors::XmlReadError,
-    models,
-    utilities::convert_optional,
-    xml::{
-        read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
-        unexpected_element_error, write_simple_tag, FromXml, ToXml,
-    },
-};
-use serde::{Deserialize, Serialize};
-use xml::reader;
+use cyclonedx_bom_macros::versioned;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct VulnerabilityAnalysis {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<ImpactAnalysisState>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    justification: Option<ImpactAnalysisJustification>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    responses: Option<Vec<ImpactAnalysisResponse>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    detail: Option<String>,
-}
+#[versioned("1.4", "1.5")]
+pub(crate) mod base {
+    #[versioned("1.5")]
+    use crate::external_models::date_time::DateTime;
+    use crate::utilities::convert_optional_vec;
+    use crate::xml::{write_close_tag, write_start_tag};
+    use crate::{
+        errors::XmlReadError,
+        models,
+        utilities::convert_optional,
+        xml::{
+            read_lax_validation_tag, read_list_tag, read_simple_tag, to_xml_read_error,
+            unexpected_element_error, write_simple_tag, FromXml, ToXml,
+        },
+    };
+    use serde::{Deserialize, Serialize};
+    use xml::reader;
 
-impl From<models::vulnerability_analysis::VulnerabilityAnalysis> for VulnerabilityAnalysis {
-    fn from(other: models::vulnerability_analysis::VulnerabilityAnalysis) -> Self {
-        Self {
-            state: convert_optional(other.state),
-            justification: convert_optional(other.justification),
-            responses: convert_optional_vec(other.responses),
-            detail: other.detail,
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct VulnerabilityAnalysis {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        state: Option<ImpactAnalysisState>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        justification: Option<ImpactAnalysisJustification>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        responses: Option<Vec<ImpactAnalysisResponse>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        detail: Option<String>,
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        first_issued: Option<String>,
+        #[versioned("1.5")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        last_updated: Option<String>,
+    }
+
+    impl From<models::vulnerability_analysis::VulnerabilityAnalysis> for VulnerabilityAnalysis {
+        fn from(other: models::vulnerability_analysis::VulnerabilityAnalysis) -> Self {
+            Self {
+                state: convert_optional(other.state),
+                justification: convert_optional(other.justification),
+                responses: convert_optional_vec(other.responses),
+                detail: other.detail,
+                #[versioned("1.5")]
+                first_issued: other.first_issued.map(|d| d.to_string()),
+                #[versioned("1.5")]
+                last_updated: other.last_updated.map(|d| d.to_string()),
+            }
         }
     }
-}
 
-impl From<VulnerabilityAnalysis> for models::vulnerability_analysis::VulnerabilityAnalysis {
-    fn from(other: VulnerabilityAnalysis) -> Self {
-        Self {
-            state: convert_optional(other.state),
-            justification: convert_optional(other.justification),
-            responses: convert_optional_vec(other.responses),
-            detail: other.detail,
+    impl From<VulnerabilityAnalysis> for models::vulnerability_analysis::VulnerabilityAnalysis {
+        fn from(other: VulnerabilityAnalysis) -> Self {
+            Self {
+                state: convert_optional(other.state),
+                justification: convert_optional(other.justification),
+                responses: convert_optional_vec(other.responses),
+                detail: other.detail,
+                #[versioned("1.4")]
+                first_issued: None,
+                #[versioned("1.5")]
+                first_issued: other.first_issued.map(DateTime),
+                #[versioned("1.4")]
+                last_updated: None,
+                #[versioned("1.5")]
+                last_updated: other.last_updated.map(DateTime),
+            }
         }
     }
-}
 
-const VULNERABILITY_ANALYSIS_TAG: &str = "analysis";
-const STATE_TAG: &str = "state";
-const JUSTIFICATION_TAG: &str = "justification";
-const RESPONSES_TAG: &str = "responses";
-const RESPONSE_TAG: &str = "response";
-const DETAIL_TAG: &str = "detail";
+    const VULNERABILITY_ANALYSIS_TAG: &str = "analysis";
+    const STATE_TAG: &str = "state";
+    const JUSTIFICATION_TAG: &str = "justification";
+    const RESPONSES_TAG: &str = "responses";
+    const RESPONSE_TAG: &str = "response";
+    const DETAIL_TAG: &str = "detail";
+    #[versioned("1.5")]
+    const FIRST_ISSUED_TAG: &str = "firstIssued";
+    #[versioned("1.5")]
+    const LAST_UPDATED_TAG: &str = "lastUpdated";
 
-impl ToXml for VulnerabilityAnalysis {
-    fn write_xml_element<W: std::io::Write>(
-        &self,
-        writer: &mut xml::EventWriter<W>,
-    ) -> Result<(), crate::errors::XmlWriteError> {
-        write_start_tag(writer, VULNERABILITY_ANALYSIS_TAG)?;
+    impl ToXml for VulnerabilityAnalysis {
+        fn write_xml_element<W: std::io::Write>(
+            &self,
+            writer: &mut xml::EventWriter<W>,
+        ) -> Result<(), crate::errors::XmlWriteError> {
+            write_start_tag(writer, VULNERABILITY_ANALYSIS_TAG)?;
 
-        if let Some(state) = &self.state {
-            write_simple_tag(writer, STATE_TAG, &state.0)?;
-        }
-
-        if let Some(justification) = &self.justification {
-            write_simple_tag(writer, JUSTIFICATION_TAG, &justification.0)?;
-        }
-
-        if let Some(responses) = &self.responses {
-            write_start_tag(writer, RESPONSES_TAG)?;
-
-            for response in responses {
-                write_simple_tag(writer, RESPONSE_TAG, &response.0)?;
+            if let Some(state) = &self.state {
+                write_simple_tag(writer, STATE_TAG, &state.0)?;
             }
 
-            write_close_tag(writer, RESPONSES_TAG)?;
+            if let Some(justification) = &self.justification {
+                write_simple_tag(writer, JUSTIFICATION_TAG, &justification.0)?;
+            }
+
+            if let Some(responses) = &self.responses {
+                write_start_tag(writer, RESPONSES_TAG)?;
+
+                for response in responses {
+                    write_simple_tag(writer, RESPONSE_TAG, &response.0)?;
+                }
+
+                write_close_tag(writer, RESPONSES_TAG)?;
+            }
+
+            if let Some(detail) = &self.detail {
+                write_simple_tag(writer, DETAIL_TAG, detail)?;
+            }
+
+            #[versioned("1.5")]
+            if let Some(first_issued) = &self.first_issued {
+                write_simple_tag(writer, FIRST_ISSUED_TAG, first_issued)?;
+            }
+
+            #[versioned("1.5")]
+            if let Some(last_updated) = &self.last_updated {
+                write_simple_tag(writer, LAST_UPDATED_TAG, last_updated)?;
+            }
+
+            write_close_tag(writer, VULNERABILITY_ANALYSIS_TAG)?;
+
+            Ok(())
         }
-
-        if let Some(detail) = &self.detail {
-            write_simple_tag(writer, DETAIL_TAG, detail)?;
-        }
-
-        write_close_tag(writer, VULNERABILITY_ANALYSIS_TAG)?;
-
-        Ok(())
     }
-}
 
-impl FromXml for VulnerabilityAnalysis {
-    fn read_xml_element<R: std::io::Read>(
-        event_reader: &mut xml::EventReader<R>,
-        element_name: &xml::name::OwnedName,
-        _attributes: &[xml::attribute::OwnedAttribute],
-    ) -> Result<Self, XmlReadError>
-    where
-        Self: Sized,
+    impl FromXml for VulnerabilityAnalysis {
+        fn read_xml_element<R: std::io::Read>(
+            event_reader: &mut xml::EventReader<R>,
+            element_name: &xml::name::OwnedName,
+            _attributes: &[xml::attribute::OwnedAttribute],
+        ) -> Result<Self, XmlReadError>
+        where
+            Self: Sized,
+        {
+            let mut state: Option<ImpactAnalysisState> = None;
+            let mut justification: Option<ImpactAnalysisJustification> = None;
+            let mut responses: Option<Vec<ImpactAnalysisResponse>> = None;
+            let mut detail: Option<String> = None;
+            #[versioned("1.5")]
+            let mut first_issued: Option<String> = None;
+            #[versioned("1.5")]
+            let mut last_updated: Option<String> = None;
+
+            let mut got_end_tag = false;
+            while !got_end_tag {
+                let next_element = event_reader
+                    .next()
+                    .map_err(to_xml_read_error(VULNERABILITY_ANALYSIS_TAG))?;
+                match next_element {
+                    reader::XmlEvent::StartElement { name, .. } if name.local_name == STATE_TAG => {
+                        state = Some(ImpactAnalysisState(read_simple_tag(event_reader, &name)?))
+                    }
+
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == JUSTIFICATION_TAG =>
+                    {
+                        justification = Some(ImpactAnalysisJustification(read_simple_tag(
+                            event_reader,
+                            &name,
+                        )?))
+                    }
+
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == RESPONSES_TAG =>
+                    {
+                        responses = Some(
+                            read_list_tag(event_reader, &name, RESPONSE_TAG)?
+                                .into_iter()
+                                .map(ImpactAnalysisResponse)
+                                .collect(),
+                        );
+                    }
+
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == DETAIL_TAG =>
+                    {
+                        detail = Some(read_simple_tag(event_reader, &name)?)
+                    }
+
+                    #[versioned("1.5")]
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == FIRST_ISSUED_TAG =>
+                    {
+                        first_issued = Some(read_simple_tag(event_reader, &name)?)
+                    }
+
+                    #[versioned("1.5")]
+                    reader::XmlEvent::StartElement { name, .. }
+                        if name.local_name == LAST_UPDATED_TAG =>
+                    {
+                        last_updated = Some(read_simple_tag(event_reader, &name)?)
+                    }
+
+                    // lax validation of any elements from a different schema
+                    reader::XmlEvent::StartElement { name, .. } => {
+                        read_lax_validation_tag(event_reader, &name)?
+                    }
+                    reader::XmlEvent::EndElement { name } if &name == element_name => {
+                        got_end_tag = true;
+                    }
+                    unexpected => return Err(unexpected_element_error(element_name, unexpected)),
+                }
+            }
+
+            Ok(Self {
+                state,
+                justification,
+                responses,
+                detail,
+                #[versioned("1.5")]
+                first_issued,
+                #[versioned("1.5")]
+                last_updated,
+            })
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    pub(crate) struct ImpactAnalysisState(String);
+
+    impl From<models::vulnerability_analysis::ImpactAnalysisState> for ImpactAnalysisState {
+        fn from(other: models::vulnerability_analysis::ImpactAnalysisState) -> Self {
+            Self(other.to_string())
+        }
+    }
+
+    impl From<ImpactAnalysisState> for models::vulnerability_analysis::ImpactAnalysisState {
+        fn from(other: ImpactAnalysisState) -> Self {
+            models::vulnerability_analysis::ImpactAnalysisState::new_unchecked(other.0)
+        }
+    }
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq)]
+    pub(crate) struct ImpactAnalysisJustification(String);
+
+    impl From<models::vulnerability_analysis::ImpactAnalysisJustification>
+        for ImpactAnalysisJustification
     {
-        let mut state: Option<ImpactAnalysisState> = None;
-        let mut justification: Option<ImpactAnalysisJustification> = None;
-        let mut responses: Option<Vec<ImpactAnalysisResponse>> = None;
-        let mut detail: Option<String> = None;
+        fn from(other: models::vulnerability_analysis::ImpactAnalysisJustification) -> Self {
+            Self(other.to_string())
+        }
+    }
 
-        let mut got_end_tag = false;
-        while !got_end_tag {
-            let next_element = event_reader
-                .next()
-                .map_err(to_xml_read_error(VULNERABILITY_ANALYSIS_TAG))?;
-            match next_element {
-                reader::XmlEvent::StartElement { name, .. } if name.local_name == STATE_TAG => {
-                    state = Some(ImpactAnalysisState(read_simple_tag(event_reader, &name)?))
-                }
+    impl From<ImpactAnalysisJustification>
+        for models::vulnerability_analysis::ImpactAnalysisJustification
+    {
+        fn from(other: ImpactAnalysisJustification) -> Self {
+            models::vulnerability_analysis::ImpactAnalysisJustification::new_unchecked(other.0)
+        }
+    }
 
-                reader::XmlEvent::StartElement { name, .. }
-                    if name.local_name == JUSTIFICATION_TAG =>
-                {
-                    justification = Some(ImpactAnalysisJustification(read_simple_tag(
-                        event_reader,
-                        &name,
-                    )?))
-                }
+    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+    pub struct ImpactAnalysisResponse(String);
 
-                reader::XmlEvent::StartElement { name, .. } if name.local_name == RESPONSES_TAG => {
-                    responses = Some(
-                        read_list_tag(event_reader, &name, RESPONSE_TAG)?
-                            .into_iter()
-                            .map(ImpactAnalysisResponse)
-                            .collect(),
-                    );
-                }
+    impl From<models::vulnerability_analysis::ImpactAnalysisResponse> for ImpactAnalysisResponse {
+        fn from(other: models::vulnerability_analysis::ImpactAnalysisResponse) -> Self {
+            Self(other.to_string())
+        }
+    }
 
-                reader::XmlEvent::StartElement { name, .. } if name.local_name == DETAIL_TAG => {
-                    detail = Some(read_simple_tag(event_reader, &name)?)
-                }
+    impl From<ImpactAnalysisResponse> for models::vulnerability_analysis::ImpactAnalysisResponse {
+        fn from(other: ImpactAnalysisResponse) -> Self {
+            models::vulnerability_analysis::ImpactAnalysisResponse::new_unchecked(other.0)
+        }
+    }
 
-                // lax validation of any elements from a different schema
-                reader::XmlEvent::StartElement { name, .. } => {
-                    read_lax_validation_tag(event_reader, &name)?
-                }
-                reader::XmlEvent::EndElement { name } if &name == element_name => {
-                    got_end_tag = true;
-                }
-                unexpected => return Err(unexpected_element_error(element_name, unexpected)),
+    #[cfg(test)]
+    pub(crate) mod test {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[versioned("1.5")]
+        use crate::external_models::date_time::DateTime;
+        use crate::xml::test::{read_element_from_string, write_element_to_string};
+
+        #[versioned("1.4")]
+        pub(crate) fn example_vulnerability_analysis() -> VulnerabilityAnalysis {
+            VulnerabilityAnalysis {
+                state: Some(ImpactAnalysisState("not_affected".to_string())),
+                justification: Some(ImpactAnalysisJustification(
+                    "code_not_reachable".to_string(),
+                )),
+                responses: Some(vec![ImpactAnalysisResponse("update".to_string())]),
+                detail: Some("detail".to_string()),
             }
         }
 
-        Ok(Self {
-            state,
-            justification,
-            responses,
-            detail,
-        })
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-pub(crate) struct ImpactAnalysisState(String);
-
-impl From<models::vulnerability_analysis::ImpactAnalysisState> for ImpactAnalysisState {
-    fn from(other: models::vulnerability_analysis::ImpactAnalysisState) -> Self {
-        Self(other.to_string())
-    }
-}
-
-impl From<ImpactAnalysisState> for models::vulnerability_analysis::ImpactAnalysisState {
-    fn from(other: ImpactAnalysisState) -> Self {
-        models::vulnerability_analysis::ImpactAnalysisState::new_unchecked(other.0)
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-pub(crate) struct ImpactAnalysisJustification(String);
-
-impl From<models::vulnerability_analysis::ImpactAnalysisJustification>
-    for ImpactAnalysisJustification
-{
-    fn from(other: models::vulnerability_analysis::ImpactAnalysisJustification) -> Self {
-        Self(other.to_string())
-    }
-}
-
-impl From<ImpactAnalysisJustification>
-    for models::vulnerability_analysis::ImpactAnalysisJustification
-{
-    fn from(other: ImpactAnalysisJustification) -> Self {
-        models::vulnerability_analysis::ImpactAnalysisJustification::new_unchecked(other.0)
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ImpactAnalysisResponse(String);
-
-impl From<models::vulnerability_analysis::ImpactAnalysisResponse> for ImpactAnalysisResponse {
-    fn from(other: models::vulnerability_analysis::ImpactAnalysisResponse) -> Self {
-        Self(other.to_string())
-    }
-}
-
-impl From<ImpactAnalysisResponse> for models::vulnerability_analysis::ImpactAnalysisResponse {
-    fn from(other: ImpactAnalysisResponse) -> Self {
-        models::vulnerability_analysis::ImpactAnalysisResponse::new_unchecked(other.0)
-    }
-}
-
-#[cfg(test)]
-pub(crate) mod test {
-    use super::*;
-    use pretty_assertions::assert_eq;
-
-    use crate::xml::test::{read_element_from_string, write_element_to_string};
-
-    pub(crate) fn example_vulnerability_analysis() -> VulnerabilityAnalysis {
-        VulnerabilityAnalysis {
-            state: Some(ImpactAnalysisState("not_affected".to_string())),
-            justification: Some(ImpactAnalysisJustification(
-                "code_not_reachable".to_string(),
-            )),
-            responses: Some(vec![ImpactAnalysisResponse("update".to_string())]),
-            detail: Some("detail".to_string()),
+        #[versioned("1.5")]
+        pub(crate) fn example_vulnerability_analysis() -> VulnerabilityAnalysis {
+            VulnerabilityAnalysis {
+                state: Some(ImpactAnalysisState("not_affected".to_string())),
+                justification: Some(ImpactAnalysisJustification(
+                    "code_not_reachable".to_string(),
+                )),
+                responses: Some(vec![ImpactAnalysisResponse("update".to_string())]),
+                detail: Some("detail".to_string()),
+                first_issued: Some("2024-01-02".to_string()),
+                last_updated: Some("2024-01-10".to_string()),
+            }
         }
-    }
 
-    pub(crate) fn corresponding_vulnerability_analysis(
-    ) -> models::vulnerability_analysis::VulnerabilityAnalysis {
-        models::vulnerability_analysis::VulnerabilityAnalysis {
-            state: Some(models::vulnerability_analysis::ImpactAnalysisState::NotAffected),
-            justification: Some(
-                models::vulnerability_analysis::ImpactAnalysisJustification::CodeNotReachable,
-            ),
-            responses: Some(vec![
-                models::vulnerability_analysis::ImpactAnalysisResponse::Update,
-            ]),
-            detail: Some("detail".to_string()),
+        #[versioned("1.4")]
+        pub(crate) fn corresponding_vulnerability_analysis(
+        ) -> models::vulnerability_analysis::VulnerabilityAnalysis {
+            models::vulnerability_analysis::VulnerabilityAnalysis {
+                state: Some(models::vulnerability_analysis::ImpactAnalysisState::NotAffected),
+                justification: Some(
+                    models::vulnerability_analysis::ImpactAnalysisJustification::CodeNotReachable,
+                ),
+                responses: Some(vec![
+                    models::vulnerability_analysis::ImpactAnalysisResponse::Update,
+                ]),
+                detail: Some("detail".to_string()),
+                first_issued: None,
+                last_updated: None,
+            }
         }
-    }
 
-    #[test]
-    fn it_should_write_xml_full() {
-        let xml_output = write_element_to_string(example_vulnerability_analysis());
-        insta::assert_snapshot!(xml_output);
-    }
+        #[versioned("1.5")]
+        pub(crate) fn corresponding_vulnerability_analysis(
+        ) -> models::vulnerability_analysis::VulnerabilityAnalysis {
+            models::vulnerability_analysis::VulnerabilityAnalysis {
+                state: Some(models::vulnerability_analysis::ImpactAnalysisState::NotAffected),
+                justification: Some(
+                    models::vulnerability_analysis::ImpactAnalysisJustification::CodeNotReachable,
+                ),
+                responses: Some(vec![
+                    models::vulnerability_analysis::ImpactAnalysisResponse::Update,
+                ]),
+                detail: Some("detail".to_string()),
+                first_issued: Some(DateTime("2024-01-02".to_string())),
+                last_updated: Some(DateTime("2024-01-10".to_string())),
+            }
+        }
 
-    #[test]
-    fn it_should_read_xml_full() {
-        let input = r#"
-<analysis>
-  <state>not_affected</state>
-  <justification>code_not_reachable</justification>
-  <responses>
-    <response>update</response>
-  </responses>
-  <detail>detail</detail>
-</analysis>
-"#;
-        let actual: VulnerabilityAnalysis = read_element_from_string(input);
-        let expected = example_vulnerability_analysis();
-        assert_eq!(actual, expected);
+        #[test]
+        fn it_should_write_xml_full() {
+            let xml_output = write_element_to_string(example_vulnerability_analysis());
+            insta::assert_snapshot!(xml_output);
+        }
+
+        #[test]
+        fn it_should_read_xml_full() {
+            let input = r#"
+    <analysis>
+      <state>not_affected</state>
+      <justification>code_not_reachable</justification>
+      <responses>
+        <response>update</response>
+      </responses>
+      <detail>detail</detail>
+      <firstIssued>2024-01-02</firstIssued>
+      <lastUpdated>2024-01-10</lastUpdated>
+    </analysis>
+    "#;
+            let actual: VulnerabilityAnalysis = read_element_from_string(input);
+            let expected = example_vulnerability_analysis();
+            assert_eq!(actual, expected);
+        }
     }
 }

--- a/cyclonedx-bom/src/specs/v1_4/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_4/mod.rs
@@ -24,3 +24,4 @@ pub(crate) use crate::specs::common::metadata::v1_4 as metadata;
 pub(crate) use crate::specs::common::service::v1_4 as service;
 pub(crate) use crate::specs::common::tool::v1_4 as tool;
 pub(crate) use crate::specs::common::vulnerability::v1_4 as vulnerability;
+pub(crate) use crate::specs::common::vulnerability_analysis::v1_4 as vulnerability_analysis;

--- a/cyclonedx-bom/src/specs/v1_5/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_5/mod.rs
@@ -31,3 +31,4 @@ pub(crate) use crate::specs::common::metadata::v1_5 as metadata;
 pub(crate) use crate::specs::common::service::v1_5 as service;
 pub(crate) use crate::specs::common::tool::v1_5 as tool;
 pub(crate) use crate::specs::common::vulnerability::v1_5 as vulnerability;
+pub(crate) use crate::specs::common::vulnerability_analysis::v1_5 as vulnerability_analysis;

--- a/cyclonedx-bom/src/specs/v1_5/mod.rs
+++ b/cyclonedx-bom/src/specs/v1_5/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod annotation;
 pub(crate) mod evidence;
 pub(crate) mod lifecycles;
 pub(crate) mod modelcard;
+pub(crate) mod proof_of_concept;
 pub(crate) mod service_data;
 
 pub(crate) use crate::specs::common::bom::v1_5 as bom;

--- a/cyclonedx-bom/src/specs/v1_5/modelcard.rs
+++ b/cyclonedx-bom/src/specs/v1_5/modelcard.rs
@@ -934,29 +934,37 @@ impl From<Attachment> for models::modelcard::Attachment {
 const ENCODING_ATTR: &str = "encoding";
 const CONTENT_TYPE_ATTR: &str = "content-type";
 
-impl ToXml for Attachment {
-    fn write_xml_element<W: std::io::Write>(
+impl ToInnerXml for Attachment {
+    fn write_xml_named_element<W: std::io::Write>(
         &self,
         writer: &mut xml::EventWriter<W>,
+        tag: &str,
     ) -> Result<(), crate::errors::XmlWriteError> {
-        let mut start_tag = writer::XmlEvent::start_element(IMAGE_TAG);
+        let mut start_tag = writer::XmlEvent::start_element(tag);
         if let Some(encoding) = &self.encoding {
             start_tag = start_tag.attr(ENCODING_ATTR, encoding);
         }
         if let Some(content_type) = &self.content_type {
             start_tag = start_tag.attr(ENCODING_ATTR, content_type);
         }
-        writer
-            .write(start_tag)
-            .map_err(to_xml_write_error(IMAGE_TAG))?;
+        writer.write(start_tag).map_err(to_xml_write_error(tag))?;
 
         writer
             .write(writer::XmlEvent::characters(&self.content))
-            .map_err(to_xml_write_error(IMAGE_TAG))?;
+            .map_err(to_xml_write_error(tag))?;
 
-        write_close_tag(writer, IMAGE_TAG)?;
+        write_close_tag(writer, tag)?;
 
         Ok(())
+    }
+}
+
+impl ToXml for Attachment {
+    fn write_xml_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        self.write_xml_named_element(writer, IMAGE_TAG)
     }
 }
 

--- a/cyclonedx-bom/src/specs/v1_5/proof_of_concept.rs
+++ b/cyclonedx-bom/src/specs/v1_5/proof_of_concept.rs
@@ -1,0 +1,223 @@
+/*
+ * This file is part of CycloneDX Rust Cargo.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use serde::{Deserialize, Serialize};
+use xml::reader;
+
+use crate::{
+    models,
+    utilities::{convert_optional, convert_vec},
+    xml::{
+        read_list_tag, read_simple_tag, to_xml_read_error, write_close_tag, write_simple_tag,
+        write_start_tag, FromXml, ToInnerXml, ToXml,
+    },
+};
+
+/// Represents the `ProofOfConcept` field.
+/// See https://cyclonedx.org/docs/1.5/json/#vulnerabilities_items_proofOfConcept
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProofOfConcept {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reproduction_steps: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    environment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    supporting_material: Option<Vec<crate::specs::v1_5::modelcard::Attachment>>,
+}
+
+impl From<ProofOfConcept> for models::vulnerability::VulnerabilityProofOfConcept {
+    fn from(other: ProofOfConcept) -> Self {
+        Self {
+            reproduction_steps: convert_optional(other.reproduction_steps),
+            environment: convert_optional(other.environment),
+            supporting_material: other
+                .supporting_material
+                .map(|material| convert_vec(material)),
+        }
+    }
+}
+
+impl From<models::vulnerability::VulnerabilityProofOfConcept> for ProofOfConcept {
+    fn from(other: models::vulnerability::VulnerabilityProofOfConcept) -> Self {
+        Self {
+            reproduction_steps: convert_optional(other.reproduction_steps),
+            environment: convert_optional(other.environment),
+            supporting_material: other
+                .supporting_material
+                .map(|material| convert_vec(material)),
+        }
+    }
+}
+
+const PROOF_OF_CONCEPT_TAG: &str = "proofOfConcept";
+const REPRODUCTION_STEPS_TAG: &str = "reproductionSteps";
+const ENVIRONMENT_TAG: &str = "environment";
+const SUPPORTING_MATERIAL_TAG: &str = "supportingMaterial";
+const ATTACHMENT_TAG: &str = "attachment";
+
+impl ToXml for ProofOfConcept {
+    fn write_xml_element<W: std::io::Write>(
+        &self,
+        writer: &mut xml::EventWriter<W>,
+    ) -> Result<(), crate::errors::XmlWriteError> {
+        write_start_tag(writer, PROOF_OF_CONCEPT_TAG)?;
+
+        if let Some(steps) = &self.reproduction_steps {
+            write_simple_tag(writer, REPRODUCTION_STEPS_TAG, &steps)?;
+        }
+
+        if let Some(environment) = &self.environment {
+            write_simple_tag(writer, ENVIRONMENT_TAG, &environment)?;
+        }
+
+        if let Some(attachments) = &self.supporting_material {
+            write_start_tag(writer, SUPPORTING_MATERIAL_TAG)?;
+
+            for attachment in attachments {
+                attachment.write_xml_named_element(writer, ATTACHMENT_TAG)?;
+            }
+
+            write_close_tag(writer, SUPPORTING_MATERIAL_TAG)?;
+        }
+
+        write_close_tag(writer, PROOF_OF_CONCEPT_TAG)?;
+
+        Ok(())
+    }
+}
+
+impl FromXml for ProofOfConcept {
+    fn read_xml_element<R: std::io::Read>(
+        event_reader: &mut xml::EventReader<R>,
+        element_name: &xml::name::OwnedName,
+        _attributes: &[xml::attribute::OwnedAttribute],
+    ) -> Result<Self, crate::errors::XmlReadError>
+    where
+        Self: Sized,
+    {
+        let mut reproduction_steps: Option<String> = None;
+        let mut environment: Option<String> = None;
+        let mut supporting_material: Option<Vec<crate::specs::v1_5::modelcard::Attachment>> = None;
+
+        let mut got_end_tag = false;
+        while !got_end_tag {
+            let next_element = event_reader
+                .next()
+                .map_err(to_xml_read_error(&element_name.local_name))?;
+            match next_element {
+                reader::XmlEvent::StartElement { name, .. }
+                    if name.local_name == REPRODUCTION_STEPS_TAG =>
+                {
+                    reproduction_steps = Some(read_simple_tag(event_reader, &name)?);
+                }
+
+                reader::XmlEvent::StartElement { name, .. }
+                    if name.local_name == ENVIRONMENT_TAG =>
+                {
+                    environment = Some(read_simple_tag(event_reader, &name)?);
+                }
+
+                reader::XmlEvent::StartElement { name, .. }
+                    if name.local_name == SUPPORTING_MATERIAL_TAG =>
+                {
+                    supporting_material = Some(read_list_tag(event_reader, &name, ATTACHMENT_TAG)?);
+                }
+
+                reader::XmlEvent::EndElement { name } if &name == element_name => {
+                    got_end_tag = true;
+                }
+                _ => (),
+            }
+        }
+
+        Ok(Self {
+            reproduction_steps,
+            environment,
+            supporting_material,
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        models,
+        specs::v1_5::modelcard::Attachment,
+        xml::test::{read_element_from_string, write_element_to_string},
+    };
+
+    use super::ProofOfConcept;
+
+    pub(crate) fn example_proof_of_concept() -> ProofOfConcept {
+        ProofOfConcept {
+            reproduction_steps: Some("reproduction steps".to_string()),
+            environment: Some("production".to_string()),
+            supporting_material: Some(vec![Attachment {
+                content: "abcdefgh".to_string(),
+                content_type: Some("image/jpeg".to_string()),
+                encoding: Some("base64".to_string()),
+            }]),
+        }
+    }
+
+    pub(crate) fn corresponding_proof_of_concept(
+    ) -> models::vulnerability::VulnerabilityProofOfConcept {
+        models::vulnerability::VulnerabilityProofOfConcept {
+            reproduction_steps: Some("reproduction steps".to_string()),
+            environment: Some("production".to_string()),
+            supporting_material: Some(vec![models::modelcard::Attachment {
+                content: "abcdefgh".to_string(),
+                content_type: Some("image/jpeg".to_string()),
+                encoding: Some("base64".to_string()),
+            }]),
+        }
+    }
+
+    #[test]
+    fn it_should_write_xml() {
+        let xml_output = write_element_to_string(example_proof_of_concept());
+        insta::assert_snapshot!(xml_output);
+    }
+
+    #[test]
+    fn it_should_read_xml() {
+        let input = r#"
+<proofOfConcept>
+  <reproductionSteps>Reproduction Steps</reproductionSteps>
+  <environment>Describe the environment</environment>
+  <supportingMaterial>
+    <attachment content-type="image/jpeg" encoding="base64">abcdfgh</attachment>
+  </supportingMaterial>
+</proofOfConcept>
+        "#;
+        let actual: ProofOfConcept = read_element_from_string(input);
+        let expected = ProofOfConcept {
+            reproduction_steps: Some("Reproduction Steps".to_string()),
+            environment: Some("Describe the environment".to_string()),
+            supporting_material: Some(vec![Attachment {
+                content: "abcdfgh".to_string(),
+                content_type: Some("image/jpeg".to_string()),
+                encoding: Some("base64".to_string()),
+            }]),
+        };
+        assert_eq!(actual, expected);
+    }
+}

--- a/cyclonedx-bom/src/specs/v1_5/snapshots/cyclonedx_bom__specs__v1_5__proof_of_concept__test__it_should_write_xml.snap
+++ b/cyclonedx-bom/src/specs/v1_5/snapshots/cyclonedx_bom__specs__v1_5__proof_of_concept__test__it_should_write_xml.snap
@@ -1,0 +1,13 @@
+---
+source: cyclonedx-bom/src/specs/v1_5/proof_of_concept.rs
+assertion_line: 197
+expression: xml_output
+---
+<?xml version="1.0" encoding="utf-8"?>
+<proofOfConcept>
+  <reproductionSteps>reproduction steps</reproductionSteps>
+  <environment>production</environment>
+  <supportingMaterial>
+    <attachment encoding="base64" encoding="image/jpeg">abcdefgh</attachment>
+  </supportingMaterial>
+</proofOfConcept>


### PR DESCRIPTION
This expands the `Vulnerability` & associated types to add fields to support spec version 1.5.

* add fields `workaround`, `proof_of_concept` & `rejected` to `Vulnerability` type
* add `ProofOfConcept` type
* add fields `first_issued` & `last_updated` fields to `VulnerabilityAnalysus` type