### PR TITLE
Remove `--allow-dirty` option …

### DIFF
--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo build
 
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --allow-dirty
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose
 
       - name: Configure git and add files
         run: |

--- a/.github/workflows/deploy_cyclonedx_bom.yml
+++ b/.github/workflows/deploy_cyclonedx_bom.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build one time, for sanity
         run: cargo build
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose --allow-dirty
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose
       - name: Configure git and add files
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
… from `cargo publish` calls in the CI/CD workflows, because this option prevents creating a `.cargo_vcs_info.json` file.  This should (really) close https://github.com/rust-lang/crates.io/issues/8551 , see there for details.

Signed-off-by: olf <Olf0@users.noreply.github.com>