### PR TITLE
Refactor & fix handling of external reference URI

### DIFF
--- a/cyclonedx-bom/src/external_models/uri.rs
+++ b/cyclonedx-bom/src/external_models/uri.rs
@@ -66,6 +66,16 @@ pub fn validate_uri(uri: &Uri) -> Result<(), ValidationError> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Uri(pub(crate) String);
 
+impl Uri {
+    pub fn new(uri: &str) -> Self {
+        Self(uri.to_string())
+    }
+
+    pub fn is_bomlink(&self) -> bool {
+        self.0.starts_with("urn:cdx")
+    }
+}
+
 impl TryFrom<String> for Uri {
     type Error = UriError;
 


### PR DESCRIPTION
This refactors the logic to convert & validate the `url` field of the `ExternalReference`. Instead of converting the type during serialization the URL or BOM-Link is read as a String first, similar to how all other URLs are handled. Only during validation the content is checked specifically, then it's determined if it's a URL or a BOM-Link. BOM-Links are only supported in spec version 1.5, all associated tests are updated to reflect this.

* refactor `url` to be of type `String` in `ExternalReference`
* simplify serialization code, no error is raised, validation is done separately
* fix validation of `Uri` type (that can be `Url` or `BomLink`) checking the provided `SpecVersion`
* add test to check validation of an `ExternalReference`
* simplify conversion methods between model & spec type
* remove a lot of code