### PR TITLE
chore: allow turning a normalized string into a string

### DIFF
--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -51,6 +51,12 @@ impl From<&str> for NormalizedString {
     }
 }
 
+impl From<NormalizedString> for String {
+    fn from(value: NormalizedString) -> Self {
+        value.0
+    }
+}
+
 impl Deref for NormalizedString {
     type Target = str;
 


### PR DESCRIPTION
Having a `NormalizedString` and wanting to consume it as a `String` isn't possible right now without cloning the `String`. I think this is not necessary. This PR adds a way to turn it back into a `String`.