### PR TITLE
chore: allow parsing the timestamp as datetime without cloning it

### DIFF
--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -77,6 +77,12 @@ impl std::fmt::Display for DateTime {
     }
 }
 
+impl AsRef<str> for DateTime {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum DateTimeError {
     #[error("Invalid DateTime: {}", .0)]

--- a/cyclonedx-bom/src/external_models/uri.rs
+++ b/cyclonedx-bom/src/external_models/uri.rs
@@ -18,6 +18,7 @@
 
 use std::{convert::TryFrom, str::FromStr};
 
+use crate::prelude::DateTime;
 use fluent_uri::Uri as Url;
 use packageurl::PackageUrl;
 use thiserror::Error;
@@ -56,6 +57,12 @@ impl FromStr for Purl {
     }
 }
 
+impl AsRef<str> for Purl {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 pub fn validate_uri(uri: &Uri) -> Result<(), ValidationError> {
     if Url::parse(uri.0.as_str()).is_err() {
         return Err(ValidationError::new("Uri does not conform to RFC 3986"));
@@ -86,6 +93,12 @@ impl TryFrom<String> for Uri {
                 "Uri does not conform to RFC 3986".to_string(),
             )),
         }
+    }
+}
+
+impl AsRef<str> for Uri {
+    fn as_ref(&self) -> &str {
+        &self.0
     }
 }
 

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -321,6 +321,12 @@ pub fn validate_cpe(cpe: &Cpe) -> Result<(), ValidationError> {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Cpe(pub(crate) String);
 
+impl AsRef<str> for Cpe {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ComponentEvidence {
     pub licenses: Option<Licenses>,

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -19,6 +19,7 @@
 use once_cell::sync::Lazy;
 use ordered_float::OrderedFloat;
 use regex::Regex;
+use std::fmt::Formatter;
 
 use crate::external_models::normalized_string::validate_normalized_string;
 use crate::external_models::uri::{validate_purl, validate_uri as validate_url};
@@ -324,6 +325,18 @@ pub struct Cpe(pub(crate) String);
 impl AsRef<str> for Cpe {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+impl From<Cpe> for String {
+    fn from(value: Cpe) -> Self {
+        value.0
+    }
+}
+
+impl std::fmt::Display for Cpe {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 


### PR DESCRIPTION
Having a `DateTime` (which is actually a `String`), I would like to parse it into an actual `OffsetDateTime`. For that I only need a `&str`, however I can only get a clone of `DateTime`'s string.

This PR adds `AsRef<str>` for `DateTime`, so that it is possible working with the string data.