### PR TITLE
Add 'external_references' to Tool

### DIFF
--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -125,6 +125,7 @@ mod test {
                 name: None,
                 version: None,
                 hashes: None,
+                external_references: None,
             }])),
             authors: Some(vec![OrganizationalContact {
                 bom_ref: None,
@@ -195,6 +196,7 @@ mod test {
                 name: None,
                 version: None,
                 hashes: None,
+                external_references: None,
             }])),
             authors: Some(vec![OrganizationalContact {
                 bom_ref: None,

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -22,6 +22,7 @@ use crate::validation::{Validate, ValidationContext, ValidationResult};
 
 use super::bom::SpecVersion;
 use super::component::Components;
+use super::external_reference::ExternalReferences;
 use super::service::Services;
 
 /// Defines the creation tool(s)
@@ -80,6 +81,8 @@ pub struct Tool {
     pub name: Option<NormalizedString>,
     pub version: Option<NormalizedString>,
     pub hashes: Option<Hashes>,
+    /// Added in spec version 1.4
+    pub external_references: Option<ExternalReferences>,
 }
 
 impl Tool {
@@ -95,6 +98,7 @@ impl Tool {
             name: Some(NormalizedString::new(name)),
             version: Some(NormalizedString::new(version)),
             hashes: None,
+            external_references: None,
         }
     }
 }
@@ -108,6 +112,11 @@ impl Validate for Tool {
             .add_list("hashes", &self.hashes, |hashes| {
                 hashes.validate_version(version)
             })
+            .add_struct_option(
+                "external_references",
+                self.external_references.as_ref(),
+                version,
+            )
             .into()
     }
 }
@@ -134,6 +143,7 @@ mod test {
             name: None,
             version: None,
             hashes: None,
+            external_references: None,
         }])
         .validate();
 
@@ -147,6 +157,7 @@ mod test {
             name: None,
             version: None,
             hashes: None,
+            external_references: None,
         }])
         .validate();
 
@@ -173,18 +184,21 @@ mod test {
                 name: None,
                 version: None,
                 hashes: None,
+                external_references: None,
             },
             Tool {
                 vendor: Some(NormalizedString("spaces and\ttabs".to_string())),
                 name: None,
                 version: None,
                 hashes: None,
+                external_references: None,
             },
             Tool {
                 vendor: None,
                 name: Some(NormalizedString("spaces and\ttabs".to_string())),
                 version: None,
                 hashes: None,
+                external_references: None,
             },
         ])
         .validate();

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -1023,6 +1023,15 @@ pub(crate) mod base {
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <authors>
@@ -1414,6 +1423,15 @@ pub(crate) mod base {
           <hashes>
             <hash alg="algorithm">hash value</hash>
           </hashes>
+          <externalReferences>
+            <reference type="external reference type">
+              <url>url</url>
+              <comment>comment</comment>
+              <hashes>
+                <hash alg="algorithm">hash value</hash>
+              </hashes>
+            </reference>
+          </externalReferences>
         </tool>
       </tools>
       <analysis>
@@ -1467,6 +1485,15 @@ pub(crate) mod base {
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <authors>
@@ -2091,6 +2118,15 @@ pub(crate) mod base {
           <hashes>
             <hash alg="algorithm">hash value</hash>
           </hashes>
+          <externalReferences>
+            <reference type="external reference type">
+              <url>url</url>
+              <comment>comment</comment>
+              <hashes>
+                <hash alg="algorithm">hash value</hash>
+              </hashes>
+            </reference>
+          </externalReferences>
         </tool>
       </tools>
       <analysis>

--- a/cyclonedx-bom/src/specs/common/metadata.rs
+++ b/cyclonedx-bom/src/specs/common/metadata.rs
@@ -546,6 +546,15 @@ pub(crate) mod base {
       <hashes>
         <hash alg="algorithm">hash value</hash>
       </hashes>
+      <externalReferences>
+        <reference type="external reference type">
+          <url>url</url>
+          <comment>comment</comment>
+          <hashes>
+            <hash alg="algorithm">hash value</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
     </tool>
   </tools>
   <authors>
@@ -695,6 +704,15 @@ pub(crate) mod base {
       <hashes>
         <hash alg="algorithm">hash value</hash>
       </hashes>
+      <externalReferences>
+        <reference type="external reference type">
+          <url>url</url>
+          <comment>comment</comment>
+          <hashes>
+            <hash alg="algorithm">hash value</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
     </tool>
   </tools>
   <authors>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 606
+assertion_line: 654
 expression: actual
 ---
 {
@@ -19,6 +19,19 @@ expression: actual
           {
             "alg": "algorithm",
             "content": "hash value"
+          }
+        ],
+        "externalReferences": [
+          {
+            "type": "external reference type",
+            "url": "url",
+            "comment": "comment",
+            "hashes": [
+              {
+                "alg": "algorithm",
+                "content": "hash value"
+              }
+            ]
           }
         ]
       }
@@ -528,6 +541,19 @@ expression: actual
             {
               "alg": "algorithm",
               "content": "hash value"
+            }
+          ],
+          "externalReferences": [
+            {
+              "type": "external reference type",
+              "url": "url",
+              "comment": "comment",
+              "hashes": [
+                {
+                  "alg": "algorithm",
+                  "content": "hash value"
+                }
+              ]
             }
           ]
         }

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 598
+assertion_line: 660
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -15,6 +15,15 @@ expression: xml_output
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <authors>
@@ -403,6 +412,15 @@ expression: xml_output
           <hashes>
             <hash alg="algorithm">hash value</hash>
           </hashes>
+          <externalReferences>
+            <reference type="external reference type">
+              <url>url</url>
+              <comment>comment</comment>
+              <hashes>
+                <hash alg="algorithm">hash value</hash>
+              </hashes>
+            </reference>
+          </externalReferences>
         </tool>
       </tools>
       <analysis>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
+assertion_line: 654
 expression: actual
 ---
 {
@@ -18,6 +19,19 @@ expression: actual
           {
             "alg": "algorithm",
             "content": "hash value"
+          }
+        ],
+        "externalReferences": [
+          {
+            "type": "external reference type",
+            "url": "url",
+            "comment": "comment",
+            "hashes": [
+              {
+                "alg": "algorithm",
+                "content": "hash value"
+              }
+            ]
           }
         ]
       }
@@ -781,6 +795,19 @@ expression: actual
             {
               "alg": "algorithm",
               "content": "hash value"
+            }
+          ],
+          "externalReferences": [
+            {
+              "type": "external reference type",
+              "url": "url",
+              "comment": "comment",
+              "hashes": [
+                {
+                  "alg": "algorithm",
+                  "content": "hash value"
+                }
+              ]
             }
           ]
         }

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_xml.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
+assertion_line: 660
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -14,6 +15,15 @@ expression: xml_output
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <authors>
@@ -568,6 +578,15 @@ expression: xml_output
           <hashes>
             <hash alg="algorithm">hash value</hash>
           </hashes>
+          <externalReferences>
+            <reference type="external reference type">
+              <url>url</url>
+              <comment>comment</comment>
+              <hashes>
+                <hash alg="algorithm">hash value</hash>
+              </hashes>
+            </reference>
+          </externalReferences>
         </tool>
       </tools>
       <analysis>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__metadata__v1_4__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__metadata__v1_4__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/metadata.rs
+assertion_line: 387
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -13,6 +14,15 @@ expression: xml_output
       <hashes>
         <hash alg="algorithm">hash value</hash>
       </hashes>
+      <externalReferences>
+        <reference type="external reference type">
+          <url>url</url>
+          <comment>comment</comment>
+          <hashes>
+            <hash alg="algorithm">hash value</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
     </tool>
   </tools>
   <authors>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__metadata__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__metadata__v1_5__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/metadata.rs
+assertion_line: 387
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -13,6 +14,15 @@ expression: xml_output
       <hashes>
         <hash alg="algorithm">hash value</hash>
       </hashes>
+      <externalReferences>
+        <reference type="external reference type">
+          <url>url</url>
+          <comment>comment</comment>
+          <hashes>
+            <hash alg="algorithm">hash value</hash>
+          </hashes>
+        </reference>
+      </externalReferences>
     </tool>
   </tools>
   <authors>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__tool__v1_4__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__tool__v1_4__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/tool.rs
+assertion_line: 474
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -11,5 +12,14 @@ expression: xml_output
     <hashes>
       <hash alg="algorithm">hash value</hash>
     </hashes>
+    <externalReferences>
+      <reference type="external reference type">
+        <url>url</url>
+        <comment>comment</comment>
+        <hashes>
+          <hash alg="algorithm">hash value</hash>
+        </hashes>
+      </reference>
+    </externalReferences>
   </tool>
 </tools>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__tool__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__tool__v1_5__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/tool.rs
+assertion_line: 474
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -11,5 +12,14 @@ expression: xml_output
     <hashes>
       <hash alg="algorithm">hash value</hash>
     </hashes>
+    <externalReferences>
+      <reference type="external reference type">
+        <url>url</url>
+        <comment>comment</comment>
+        <hashes>
+          <hash alg="algorithm">hash value</hash>
+        </hashes>
+      </reference>
+    </externalReferences>
   </tool>
 </tools>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_4__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_4__test__it_should_write_xml_full.snap
@@ -1,5 +1,6 @@
 ---
 source: cyclonedx-bom/src/specs/common/vulnerability.rs
+assertion_line: 758
 expression: xml_output
 ---
 <?xml version="1.0" encoding="utf-8"?>
@@ -77,6 +78,15 @@ expression: xml_output
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <analysis>

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__vulnerability__v1_5__test__it_should_write_xml_full.snap
@@ -79,6 +79,15 @@ expression: xml_output
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <analysis>

--- a/cyclonedx-bom/src/specs/common/vulnerability.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability.rs
@@ -836,6 +836,15 @@ pub(crate) mod base {
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <analysis>
@@ -959,6 +968,15 @@ pub(crate) mod base {
         <hashes>
           <hash alg="algorithm">hash value</hash>
         </hashes>
+        <externalReferences>
+          <reference type="external reference type">
+            <url>url</url>
+            <comment>comment</comment>
+            <hashes>
+              <hash alg="algorithm">hash value</hash>
+            </hashes>
+          </reference>
+        </externalReferences>
       </tool>
     </tools>
     <analysis>


### PR DESCRIPTION
The field `external_references` is added to the `Tool` type to support spec version 1.4 & 1.5.

* update examples & tests

Closes #703 