### PR TITLE
Actually wire up writing v1.5

### DIFF
--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -732,6 +732,7 @@ impl GeneratedSbom {
                 match spec_version {
                     V1_3 => bom.output_as_json_v1_3(&mut writer),
                     V1_4 => bom.output_as_json_v1_4(&mut writer),
+                    V1_5 => bom.output_as_json_v1_5(&mut writer),
                     _ => unimplemented!(),
                 }
                 .map_err(SbomWriterError::JsonWriteError)?;
@@ -740,6 +741,7 @@ impl GeneratedSbom {
                 match spec_version {
                     V1_3 => bom.output_as_xml_v1_3(&mut writer),
                     V1_4 => bom.output_as_xml_v1_4(&mut writer),
+                    V1_5 => bom.output_as_xml_v1_5(&mut writer),
                     _ => unimplemented!(),
                 }
                 .map_err(SbomWriterError::XmlWriteError)?;


### PR DESCRIPTION
Right now it would just panic.

This wasn't caught statically because of a confluence of two things:

1. Non-exhaustive enum for the specification version requiring the `_` arm
2. The APIs using version strings instead of accepting an enum with the version

Both are bad API design and we should fix that eventually.