### PR TITLE
Rewrite and simplify crates.io publishing actions

### DIFF
--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -1,41 +1,15 @@
 name: Deploy cargo-cyclonedx to Crates.io
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseType:
-        description: "cargo-cyclonedx release type (major, minor, patch)"
-        required: true
-        default: "patch"
+  push:
+    tags:
+      - 'cargo-cyclonedx-[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: JQ
-        run: |
-          sudo apt-get install -y jq
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Cargo bump
-        run: |
-          cargo install cargo-edit
-          cargo set-version --package cargo-cyclonedx --bump ${{ github.event.inputs.releaseType }}
-      - name: Retrieve new version
-        run: |
-          echo "::set-output name=CARGO_VERSION::$(cargo metadata | jq -r '.packages[] | select(.name == "cargo-cyclonedx") | .version')"
-        id: version
-      - name: Build one time, for sanity
-        run: cargo build
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --allow-dirty
-      - name: Configure git and add files
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -am "New development bump of cargo-cylonedx to ${{steps.version.outputs.CARGO_VERSION}}"
-          git tag -a "cargo-cyclonedx-${{steps.version.outputs.CARGO_VERSION}}" -m "cargo-cyclonedx ${{steps.version.outputs.CARGO_VERSION}} release"
-          git push --follow-tags
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --dry-run

--- a/.github/workflows/deploy_cargo_cyclonedx.yml
+++ b/.github/workflows/deploy_cargo_cyclonedx.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose --dry-run
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cargo-cyclonedx --verbose

--- a/.github/workflows/deploy_cyclonedx_bom.yml
+++ b/.github/workflows/deploy_cyclonedx_bom.yml
@@ -1,44 +1,15 @@
 name: Deploy cyclonedx-bom to Crates.io
 
 on:
-  workflow_dispatch:
-    inputs:
-      releaseType:
-        description: "cyclonedx-bom release type (major, minor, patch)"
-        required: true
-        default: "patch"
+  push:
+    tags:
+      - 'cyclonedx-bom-[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: JQ
-        run: |
-          sudo apt-get install -y jq
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Cargo bump
-        run: |
-          cargo install cargo-edit
-          cargo set-version --package cyclonedx-bom --bump ${{ github.event.inputs.releaseType }}
-      - name: Retrieve new version
-        run: |
-          echo "::set-output name=CARGO_VERSION::$(cargo metadata | jq -r '.packages[] | select(.name == "cyclonedx-bom") | .version')"
-        id: version
-      - name: Build one time, for sanity
-        run: cargo build
+      - uses: dtolnay/rust-toolchain@stable
       - name: Publish
-        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose --allow-dirty
-      - name: Configure git and add files
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git commit -am "New development bump of cyclonedx-bom to ${{steps.version.outputs.CARGO_VERSION}}"
-          git tag -a "cyclonedx-bom-${{steps.version.outputs.CARGO_VERSION}}" -m "cyclonedx-bom ${{steps.version.outputs.CARGO_VERSION}} release"
-          git push --follow-tags
+        run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --package cyclonedx-bom --verbose


### PR DESCRIPTION
This changes the workflow to be triggered by a tag, rather than create a tag automatically. We need the tag to be created by a human rather than by Github Actions so that cargo-dist workflows that publish binaries would work properly. (I had to do some manual fixup to build binaries for the latest release).

This also removes the `--allow-dirty` flag that prevents attribution to a specific commit and is known to cause issues for links in the way our documentation shows up on crates.io, previously attempted in #719

Drops cache because the check before publishing uses latest versions from crates.io rather than what we have in Cargo.lock, so caching isn't do much there. Also, clean builds have less of a risk of running into incremental compilation bugs in the compiler, and we run this workflow rarely enough that execution time is not a concern.