### PR TITLE
Fix tools type in metadata

### DIFF
--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -36,8 +36,8 @@ pub enum Tools {
 
     /// Added in 1.5
     Object {
-        services: Services,
-        components: Components,
+        services: Option<Services>,
+        components: Option<Components>,
     },
 }
 
@@ -59,12 +59,8 @@ impl Validate for Tools {
                 services,
                 components,
             } => {
-                context.add_list("components", &components.0, |component| {
-                    component.validate_version(version)
-                });
-                context.add_list("services", &services.0, |service| {
-                    service.validate_version(version)
-                });
+                context.add_struct_option("components", components.as_ref(), version);
+                context.add_struct_option("services", services.as_ref(), version);
             }
         }
 
@@ -244,14 +240,14 @@ mod test {
             .passed());
 
         assert!(Tools::Object {
-            services: Services(vec![service.clone()]),
-            components: Components(vec![component.clone()])
+            services: Some(Services(vec![service.clone()])),
+            components: Some(Components(vec![component.clone()]))
         }
         .validate_version(SpecVersion::V1_4)
         .has_errors());
         assert!(Tools::Object {
-            services: Services(vec![service.clone()]),
-            components: Components(vec![component.clone()])
+            services: Some(Services(vec![service.clone()])),
+            components: Some(Components(vec![component.clone()]))
         }
         .validate_version(SpecVersion::V1_5)
         .passed());

--- a/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-components-only-1.5.json
+++ b/cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-components-only-1.5.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "metadata": {
+    "timestamp": "2024-03-20T09:57:38Z",
+    "tools": {
+      "components": [
+        {
+          "author": "anchore",
+          "name": "syft",
+          "type": "application",
+          "version": "0.101.1"
+        }
+      ]
+    }
+  },
+  "serialNumber": "urn:uuid:41f45e5d-dfd6-4ecb-93b5-9c1bfb734cb3",
+  "specVersion": "1.5",
+  "version": 1
+}

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-metadata-tool-components-only-1.5.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-metadata-tool-components-only-1.5.json.snap
@@ -1,0 +1,25 @@
+---
+source: cyclonedx-bom/tests/specification_tests_v1_5.rs
+assertion_line: 55
+expression: bom_output
+input_file: cyclonedx-bom/tests/spec/1.5/valid-metadata-tool-components-only-1.5.json
+---
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "serialNumber": "urn:uuid:41f45e5d-dfd6-4ecb-93b5-9c1bfb734cb3",
+  "metadata": {
+    "timestamp": "2024-03-20T09:57:38Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "author": "anchore",
+          "name": "syft",
+          "version": "0.101.1"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The `tools` type in `metadata` allows optional `services` & `components` fields according the [1.5 specification](https://cyclonedx.org/docs/1.5/json/#metadata_tools_oneOf_i0_components). These are not required therefore these fields have changed to `Option` fields.

Previously this has not been covered by tests.