### PR TITLE
Relax validation of license name field

### DIFF
--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -190,9 +190,7 @@ pub enum LicenseIdentifier {
 impl Validate for LicenseIdentifier {
     fn validate_version(&self, _version: SpecVersion) -> ValidationResult {
         match self {
-            LicenseIdentifier::Name(name) => ValidationContext::new()
-                .add_enum("Name", name, validate_normalized_string)
-                .into(),
+            LicenseIdentifier::Name(_name) => ValidationContext::new().into(),
             LicenseIdentifier::SpdxId(id) => ValidationContext::new()
                 .add_enum("SpdxId", id, validate_spdx_identifier)
                 .into(),
@@ -327,41 +325,6 @@ mod test {
     }
 
     #[test]
-    fn it_should_fail_validation_for_license_name() {
-        let validation_result = Licenses(vec![LicenseChoice::License(License {
-            bom_ref: None,
-            license_identifier: LicenseIdentifier::Name(NormalizedString(
-                "spaces and \ttabs".to_string(),
-            )),
-            text: None,
-            url: None,
-            licensing: None,
-            properties: None,
-        })])
-        .validate();
-
-        assert_eq!(
-            validation_result,
-            validation::list(
-                "inner",
-                [(
-                    0,
-                    validation::r#struct(
-                        "license",
-                        validation::r#struct(
-                            "license_identifier",
-                            validation::r#enum(
-                                "Name",
-                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                            )
-                        )
-                    )
-                )]
-            )
-        );
-    }
-
-    #[test]
     fn it_should_fail_validation_for_license_id() {
         let validation_result = Licenses(vec![LicenseChoice::License(License::license_id(
             "Apache=2.0",
@@ -444,18 +407,6 @@ mod test {
             validation::list(
                 "inner",
                 [(
-                    1,
-                    validation::r#struct(
-                        "license",
-                        validation::r#struct(
-                            "license_identifier",
-                            validation::r#enum(
-                                "Name",
-                                "NormalizedString contains invalid characters \\r \\n \\t or \\r\\n"
-                            )
-                        )
-                    )
-                ), (
                     2,
                     validation::r#struct(
                         "license",

--- a/cyclonedx-bom/tests/spec/1.5/valid-license-name-1.5.json
+++ b/cyclonedx-bom/tests/spec/1.5/valid-license-name-1.5.json
@@ -16,6 +16,12 @@
             "name": "Apache License 2.0",
             "bom-ref": "my-license"
           }
+        },
+        {
+          "license": {
+            "name": "\n                CDDL License\n            ",
+            "url": "http://www.opensource.org/licenses/cddl1.php"
+          }
         }
       ]
     }

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-license-name-1.5.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-license-name-1.5.json.snap
@@ -1,6 +1,6 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_5.rs
-assertion_line: 54
+assertion_line: 58
 expression: bom_output
 input_file: cyclonedx-bom/tests/spec/1.5/valid-license-name-1.5.json
 ---
@@ -20,6 +20,12 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-license-name-1.5.json
         {
           "license": {
             "name": "Apache License 2.0"
+          }
+        },
+        {
+          "license": {
+            "name": "\n                CDDL License\n            ",
+            "url": "http://www.opensource.org/licenses/cddl1.php"
           }
         }
       ]

--- a/cyclonedx-bom/tests/specification_tests_v1_5.rs
+++ b/cyclonedx-bom/tests/specification_tests_v1_5.rs
@@ -42,6 +42,9 @@ mod v1_5 {
                 let bom = Bom::parse_from_json_v1_5(file).unwrap_or_else(|e| panic!("Failed to parse the document as an BOM: {path:?} {:#?}", e));
 
                 let validation_result = bom.validate_version(SpecVersion::V1_5);
+                if !validation_result.passed() {
+                    dbg!(&validation_result);
+                }
                 assert!(
                     validation_result.passed(),
                     "{path:?} unexpectedly failed validation"


### PR DESCRIPTION
The `name` field of the `license` type is specified differently in the schema files. The [1.5 JSON schema](https://github.com/CycloneDX/specification/blob/master/schema/bom-1.5.schema.json#L753-L758) does not define any restriction or pattern for this field. On the other hand the [1.5 XML schema definition](https://github.com/CycloneDX/specification/blob/master/schema/bom-1.5.xsd#L649-L653) declares the `name` field a `NormalizedString`. The latter does not allow certain characters, e.g. `\n`, `\t`, to be present inside the string.

This change relaxes the validation of the license name field to allow validation for JSON loaded BOM files as well.

* remove validation checks for license name field