### PR TITLE
more explicit build dependency handling

### DIFF
--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -100,6 +100,10 @@ Defaults to the host target, as printed by 'rustc -vV'"
     /// The CycloneDX specification version to output: `1.3`, `1.4` or `1.5`. Defaults to 1.3
     #[clap(long = "spec-version")]
     pub spec_version: Option<SpecVersion>,
+
+    /// List only dependencies of kind normal (no build deps, no dev deps)
+    #[clap(name = "only-normal-deps", long = "only-normal-deps")]
+    pub only_normal_deps: bool,
 }
 
 impl Args {
@@ -170,6 +174,7 @@ impl Args {
 
         let describe = self.describe;
         let spec_version = self.spec_version;
+        let only_normal_deps = Some(self.only_normal_deps);
 
         Ok(SbomConfig {
             format: self.format,
@@ -180,6 +185,7 @@ impl Args {
             license_parser,
             describe,
             spec_version,
+            only_normal_deps,
         })
     }
 }

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -197,6 +197,11 @@ pub enum ArgsError {
 }
 
 #[cfg(test)]
+pub fn parse_to_config(args: &[&str]) -> SbomConfig {
+    Args::parse_from(args.iter()).as_config().unwrap()
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -226,10 +231,6 @@ mod tests {
         assert!(contains_feature(&config, "foo"));
         assert!(contains_feature(&config, "bar"));
         assert!(!contains_feature(&config, ""));
-    }
-
-    fn parse_to_config(args: &[&str]) -> SbomConfig {
-        Args::parse_from(args.iter()).as_config().unwrap()
     }
 
     fn contains_feature(config: &SbomConfig, feature: &str) -> bool {

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -33,6 +33,7 @@ pub struct SbomConfig {
     pub license_parser: Option<LicenseParserOptions>,
     pub describe: Option<Describe>,
     pub spec_version: Option<SpecVersion>,
+    pub only_normal_deps: Option<bool>,
 }
 
 impl SbomConfig {
@@ -57,6 +58,7 @@ impl SbomConfig {
                 .or_else(|| self.license_parser.clone()),
             describe: other.describe.or(self.describe),
             spec_version: other.spec_version.or(self.spec_version),
+            only_normal_deps: other.only_normal_deps.or(self.only_normal_deps),
         }
     }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -1,4 +1,5 @@
 use crate::config::Describe;
+use std::cmp::min;
 /*
  * This file is part of CycloneDX Rust Cargo.
  *
@@ -54,8 +55,8 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use log::Level;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::{BTreeMap, LinkedList};
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::BufWriter;
@@ -68,6 +69,42 @@ use validator::validate_email;
 // Maps from PackageId to Package for efficiency - faster lookups than in a Vec
 type PackageMap = BTreeMap<PackageId, Package>;
 type ResolveMap = BTreeMap<PackageId, Node>;
+type DependencyKindMap = BTreeMap<PackageId, DependencyKind>;
+
+/// The values are ordered from weakest to strongest so that casting to integer would make sense
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+enum PrivateDepKind {
+    Development,
+    Build,
+    Runtime,
+}
+impl From<PrivateDepKind> for DependencyKind {
+    fn from(priv_kind: PrivateDepKind) -> Self {
+        match priv_kind {
+            PrivateDepKind::Development => DependencyKind::Development,
+            PrivateDepKind::Build => DependencyKind::Build,
+            PrivateDepKind::Runtime => DependencyKind::Normal,
+        }
+    }
+}
+
+impl From<&DependencyKind> for PrivateDepKind {
+    fn from(kind: &DependencyKind) -> Self {
+        match kind {
+            DependencyKind::Normal => PrivateDepKind::Runtime,
+            DependencyKind::Development => PrivateDepKind::Development,
+            DependencyKind::Build => PrivateDepKind::Build,
+            _ => panic!("Unknown dependency kind"),
+        }
+    }
+}
+
+fn strongest_dep_kind(deps: &[cargo_metadata::DepKindInfo]) -> PrivateDepKind {
+    deps.iter()
+        .map(|d| PrivateDepKind::from(&d.kind))
+        .max()
+        .unwrap_or(PrivateDepKind::Runtime) // for compatibility with Rust earlier than 1.41
+}
 
 pub struct SbomGenerator {
     config: SbomConfig,
@@ -97,6 +134,8 @@ impl SbomGenerator {
         let mut result = Vec::with_capacity(members.len());
         for member in members.iter() {
             log::trace!("Processing the package {}", member);
+
+            let dep_kinds = index_dep_kinds(member, &resolve);
 
             let (dependencies, pruned_resolve) =
                 if config.included_dependencies() == IncludedDependencies::AllDependencies {
@@ -128,7 +167,7 @@ impl SbomGenerator {
                 crate_hashes,
             };
             let (bom, target_kinds) =
-                generator.create_bom(member, &dependencies, &pruned_resolve)?;
+                generator.create_bom(member, &dependencies, &pruned_resolve, &dep_kinds)?;
 
             let generated = GeneratedSbom {
                 bom,
@@ -149,6 +188,7 @@ impl SbomGenerator {
         package: &PackageId,
         packages: &PackageMap,
         resolve: &ResolveMap,
+        dep_kinds: &DependencyKindMap,
     ) -> Result<(Bom, TargetKinds), GeneratorError> {
         let mut bom = Bom::default();
         let root_package = &packages[package];
@@ -156,7 +196,7 @@ impl SbomGenerator {
         let components: Vec<_> = packages
             .values()
             .filter(|p| &p.id != package)
-            .map(|component| self.create_component(component, root_package))
+            .map(|component| self.create_component(component, root_package, dep_kinds))
             .collect();
 
         bom.components = Some(Components(components));
@@ -170,7 +210,12 @@ impl SbomGenerator {
         Ok((bom, target_kinds))
     }
 
-    fn create_component(&self, package: &Package, root_package: &Package) -> Component {
+    fn create_component(
+        &self,
+        package: &Package,
+        root_package: &Package,
+        dep_kinds: &DependencyKindMap,
+    ) -> Component {
         let name = package.name.to_owned().trim().to_string();
         let version = package.version.to_string();
 
@@ -190,7 +235,13 @@ impl SbomGenerator {
         );
 
         component.purl = purl;
-        component.scope = Some(Scope::Required);
+        component.scope = match dep_kinds
+            .get(&package.id)
+            .unwrap_or(&DependencyKind::Normal)
+        {
+            DependencyKind::Normal => Some(Scope::Required),
+            _ => Some(Scope::Excluded),
+        };
         component.external_references = Self::get_external_references(package);
         component.licenses = self.get_licenses(package);
         component.hashes = self.get_hashes(package);
@@ -206,7 +257,7 @@ impl SbomGenerator {
     /// Same as [Self::create_component] but also includes information
     /// on binaries and libraries comprising it as subcomponents
     fn create_toplevel_component(&self, package: &Package) -> (Component, TargetKinds) {
-        let mut top_component = self.create_component(package, package);
+        let mut top_component = self.create_component(package, package, &DependencyKindMap::new());
         let mut subcomponents: Vec<Component> = Vec::new();
         let mut target_kinds = HashMap::new();
         for tgt in filter_targets(&package.targets) {
@@ -542,6 +593,49 @@ fn index_resolve(packages: Vec<Node>) -> ResolveMap {
         .collect()
 }
 
+fn index_dep_kinds(root: &PackageId, resolve: &ResolveMap) -> DependencyKindMap {
+    // cache strongest found dependency kind for every node
+    let mut id_to_dep_kind: HashMap<&PackageId, PrivateDepKind> = HashMap::new();
+    id_to_dep_kind.insert(root, PrivateDepKind::Runtime);
+
+    let root_node = &resolve[root];
+    let mut nodes_to_visit = LinkedList::<&Node>::new();
+    nodes_to_visit.push_front(root_node);
+
+    // perform a simple iterative DFS over the dependencies,
+    // mark child deps with the minimum of parent kind and their own strongest value
+    // therefore e.g. mark decendants of build dependencies as build dependencies,
+    // as long as they never occur as normal dependency.
+    while !nodes_to_visit.is_empty() {
+        let node = nodes_to_visit.pop_front().unwrap();
+        let parent_node_kind = id_to_dep_kind[&node.id];
+
+        for child_dep in &node.deps {
+            let child_node = &resolve[&child_dep.pkg];
+            let dep_kind = strongest_dep_kind(child_dep.dep_kinds.as_slice());
+            let child_node_kind = min(parent_node_kind, dep_kind);
+
+            let dep_kind_on_previous_visit = id_to_dep_kind.get(&child_node.id);
+            // insert/update a nodes dependency kind, when its new or stronger than the previous value
+            if dep_kind_on_previous_visit.is_none()
+                || child_node_kind > *dep_kind_on_previous_visit.unwrap()
+            {
+                let _ = id_to_dep_kind.insert(&child_node.id, child_node_kind);
+            }
+
+            // cargo metadata already return a DAG, so assume this will terminate
+            // and don't mark already visited notes. It's ok and necessary to visit
+            // deps as often as they occur.
+            nodes_to_visit.push_front(child_node);
+        }
+    }
+
+    id_to_dep_kind
+        .iter()
+        .map(|(x, y)| ((*x).clone(), DependencyKind::from(*y)))
+        .collect()
+}
+
 #[derive(Error, Debug)]
 pub enum GeneratorError {
     #[error("Expected a root package in the cargo config: {config_filepath}")]
@@ -592,6 +686,7 @@ fn top_level_dependencies(
     let root_node = add_filtered_dependencies(&resolve[root], config);
 
     let mut pkg_result = PackageMap::new();
+
     // Record the root package, then its direct non-dev dependencies
     pkg_result.insert(root.to_owned(), packages[root].to_owned());
     for id in &root_node.dependencies {

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -783,6 +783,7 @@ fn filtered_dependencies<'a>(
 /// * `package_name` - Package from which this SBOM was generated
 /// * `sbom_config` - Configuration options used during generation
 /// * `target_kinds` - Detailed information on the kinds of targets in `sbom`
+#[derive(Debug)]
 pub struct GeneratedSbom {
     pub bom: Bom,
     pub manifest_path: PathBuf,

--- a/cargo-cyclonedx/src/purl.rs
+++ b/cargo-cyclonedx/src/purl.rs
@@ -107,7 +107,7 @@ mod tests {
         )
         .unwrap();
         // Validate that data roundtripped correctly
-        let parsed_purl = Purl::from_str(&purl.to_string()).unwrap();
+        let parsed_purl = Purl::from_str(purl.as_ref()).unwrap();
         assert_eq!(parsed_purl.name(), "aho-corasick");
         assert_eq!(parsed_purl.version(), Some("1.1.2"));
         assert!(parsed_purl.qualifiers().is_empty());
@@ -120,7 +120,7 @@ mod tests {
         let git_package: Package = serde_json::from_str(GIT_PACKAGE_JSON).unwrap();
         let purl = get_purl(&git_package, &git_package, Utf8Path::new("/foo/bar"), None).unwrap();
         // Validate that data roundtripped correctly
-        let parsed_purl = Purl::from_str(&purl.to_string()).unwrap();
+        let parsed_purl = Purl::from_str(purl.as_ref()).unwrap();
         assert_eq!(parsed_purl.name(), "auditable-extract");
         assert_eq!(parsed_purl.version(), Some("0.3.2"));
         assert_eq!(parsed_purl.qualifiers().len(), 1);
@@ -142,7 +142,7 @@ mod tests {
         )
         .unwrap();
         // Validate that data roundtripped correctly
-        let parsed_purl = Purl::from_str(&purl.to_string()).unwrap();
+        let parsed_purl = Purl::from_str(purl.as_ref()).unwrap();
         assert_eq!(parsed_purl.name(), "cargo-cyclonedx");
         assert_eq!(parsed_purl.version(), Some("0.3.8"));
         assert_eq!(parsed_purl.qualifiers().len(), 1);
@@ -165,7 +165,7 @@ mod tests {
         )
         .unwrap();
         // Validate that data roundtripped correctly
-        let parsed_purl = Purl::from_str(&purl.to_string()).unwrap();
+        let parsed_purl = Purl::from_str(purl.as_ref()).unwrap();
         assert_eq!(parsed_purl.name(), "cargo-cyclonedx");
         assert_eq!(parsed_purl.version(), Some("0.3.8"));
         assert_eq!(parsed_purl.qualifiers().len(), 1);
@@ -189,7 +189,7 @@ mod tests {
         )
         .unwrap();
         // Validate that data roundtripped correctly
-        let parsed_purl = Purl::from_str(&purl.to_string()).unwrap();
+        let parsed_purl = Purl::from_str(purl.as_ref()).unwrap();
         assert_eq!(parsed_purl.name(), "cyclonedx-bom");
         assert_eq!(parsed_purl.version(), Some("0.4.1"));
         assert_eq!(parsed_purl.qualifiers().len(), 1);
@@ -213,7 +213,7 @@ mod tests {
         )
         .unwrap();
         // Validate that data roundtripped correctly
-        let parsed_purl = Purl::from_str(&purl.to_string()).unwrap();
+        let parsed_purl = Purl::from_str(purl.as_ref()).unwrap();
         assert_eq!(parsed_purl.name(), "cyclonedx-bom");
         assert_eq!(parsed_purl.version(), Some("0.4.1"));
         assert_eq!(parsed_purl.qualifiers().len(), 1);

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/Cargo.toml
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+resolver = "2"
+members = [
+    "top_level_crate",
+    "build_dep",
+    "runtime_dep_of_build_dep",
+]

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/build_dep/Cargo.toml
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/build_dep/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "build_dep"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+runtime_dep_of_build_dep = {path = "../runtime_dep_of_build_dep"}

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/build_dep/src/lib.rs
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/build_dep/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/runtime_dep_of_build_dep/Cargo.toml
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/runtime_dep_of_build_dep/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "runtime_dep_of_build_dep"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/runtime_dep_of_build_dep/src/lib.rs
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/runtime_dep_of_build_dep/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/top_level_crate/Cargo.toml
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/top_level_crate/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "top_level_crate"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+build_dep = {path = "../build_dep"}

--- a/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/top_level_crate/src/main.rs
+++ b/cargo-cyclonedx/tests/fixtures/build_then_runtime_dep/top_level_crate/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
I was wondering, why pkg-config is listed in my SBOM.

SBOMs should IMHO only contain dependencies which are not only used during build or development. It would also be possible to check against DependencyKind::Normal.