### PR TITLE
Update spdx to 0.10.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "spdx"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b19b32ed6d899ab23174302ff105c1577e45a06b08d4fe0a9dd13ce804bbbf71"
+checksum = "47317bbaf63785b53861e1ae2d11b80d6b624211d42cb20efcd210ee6f8a14bc"
 dependencies = [
  "smallvec",
 ]

--- a/cyclonedx-bom/Cargo.toml
+++ b/cyclonedx-bom/Cargo.toml
@@ -24,7 +24,7 @@ packageurl = "0.3.0"
 regex = "1.9.3"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
-spdx = "0.10.2"
+spdx = "0.10.6"
 thiserror = "1.0.48"
 time = { version = "0.3.29", features = ["formatting", "parsing"] }
 uuid = { version = "1.6.1", features = ["v4"] }


### PR DESCRIPTION
This PR updates spdx to 0.10.6.

In particular, in 0.10.4 a couple of new licenses have been added: https://github.com/EmbarkStudios/spdx/blob/main/CHANGELOG.md. For example, it added the the Unicode-3.0 license.

This fixes warnings such as:

```
[2024-07-12T06:39:49Z WARN  cargo_cyclonedx::generator] Package icu_collections has an invalid license expression (Unicode-3.0), using as named license: Invalid Lax SPDX expression: unknown term
[2024-07-12T06:39:49Z WARN  cargo_cyclonedx::generator] Package icu_locid has an invalid license expression (Unicode-3.0), using as named license: Invalid Lax SPDX expression: unknown term
[2024-07-12T06:39:49Z WARN  cargo_cyclonedx::generator] Package icu_locid_transform has an invalid license expression (Unicode-3.0), using as named license: Invalid Lax SPDX expression: unknown term
[2024-07-12T06:39:49Z WARN  cargo_cyclonedx::generator] Package icu_locid_transform_data has an invalid license expression (Unicode-3.0), using as named license: Invalid Lax SPDX expression: unknown term
[2024-07-12T06:39:49Z WARN  cargo_cyclonedx::generator] Package icu_normalizer has an invalid license expression (Unicode-3.0), using as named license: Invalid Lax SPDX expression: unknown term
[2024-07-12T06:39:49Z WARN  cargo_cyclonedx::generator] Package icu_normalizer_data has an invalid license expression (Unicode-3.0), using as named license: Invalid Lax SPDX expression: unknown term
```

These happen to me because I have a crate which depends on https://crates.io/crates/idna, which in turn depends on icu_normalizer, icu_properties, etc. which are licensed under Unicode-3.0.