### PR TITLE
Rename `--only-normal-deps` to `--no-build-deps`

### DIFF
--- a/cargo-cyclonedx/README.md
+++ b/cargo-cyclonedx/README.md
@@ -72,6 +72,9 @@ This produces a `bom.xml` file adjacent to every `Cargo.toml` file that exists i
       --top-level
           List only top-level dependencies
 
+      --no-build-deps
+          Do not list build dependencies in the SBOM
+
       --override-filename <FILENAME>
           Custom string to use for the output filename
 
@@ -82,7 +85,7 @@ This produces a `bom.xml` file adjacent to every `Cargo.toml` file that exists i
           Add license names which will not be warned about when parsing them as a SPDX expression fails
 
       --spec-version <SPEC_VERSION>
-          The CycloneDX specification version to output: `1.3` or `1.4`. Defaults to 1.3
+          The CycloneDX specification version to output: `1.3`, `1.4` or `1.5`. Defaults to 1.3
 
   -h, --help
           Print help (see a summary with '-h')

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -81,6 +81,10 @@ Defaults to the host target, as printed by 'rustc -vV'"
     #[clap(name = "top-level", long = "top-level", conflicts_with = "all")]
     pub top_level: bool,
 
+    /// Do not list build dependencies in the SBOM
+    #[clap(long = "no-build-deps")]
+    pub no_build_deps: bool,
+
     /// Custom string to use for the output filename
     #[clap(
         long = "override-filename",
@@ -100,10 +104,6 @@ Defaults to the host target, as printed by 'rustc -vV'"
     /// The CycloneDX specification version to output: `1.3`, `1.4` or `1.5`. Defaults to 1.3
     #[clap(long = "spec-version")]
     pub spec_version: Option<SpecVersion>,
-
-    /// List only dependencies of kind normal (no build deps, no dev deps)
-    #[clap(name = "only-normal-deps", long = "only-normal-deps")]
-    pub only_normal_deps: bool,
 }
 
 impl Args {
@@ -174,7 +174,7 @@ impl Args {
 
         let describe = self.describe;
         let spec_version = self.spec_version;
-        let only_normal_deps = Some(self.only_normal_deps);
+        let no_build_deps = Some(self.no_build_deps);
 
         Ok(SbomConfig {
             format: self.format,
@@ -185,7 +185,7 @@ impl Args {
             license_parser,
             describe,
             spec_version,
-            only_normal_deps,
+            no_build_deps,
         })
     }
 }

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -33,7 +33,7 @@ pub struct SbomConfig {
     pub license_parser: Option<LicenseParserOptions>,
     pub describe: Option<Describe>,
     pub spec_version: Option<SpecVersion>,
-    pub only_normal_deps: Option<bool>,
+    pub no_build_deps: Option<bool>,
 }
 
 impl SbomConfig {
@@ -58,7 +58,7 @@ impl SbomConfig {
                 .or_else(|| self.license_parser.clone()),
             describe: other.describe.or(self.describe),
             spec_version: other.spec_version.or(self.spec_version),
-            only_normal_deps: other.only_normal_deps.or(self.only_normal_deps),
+            no_build_deps: other.no_build_deps.or(self.no_build_deps),
         }
     }
 

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -767,7 +767,7 @@ fn filtered_dependencies<'a>(
 ) -> impl Iterator<Item = &'a NodeDep> {
     input.iter().filter(|p| {
         p.dep_kinds.iter().any(|dep| {
-            if let Some(true) = config.only_normal_deps {
+            if let Some(true) = config.no_build_deps {
                 dep.kind == DependencyKind::Normal
             } else {
                 dep.kind != DependencyKind::Development

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -187,7 +187,7 @@ mod tests {
         test_cargo_toml.push("tests/fixtures/build_then_runtime_dep/Cargo.toml");
 
         let path_arg = &format!("--manifest-path={}", test_cargo_toml.display());
-        let args = ["cyclonedx", path_arg, "--only-normal-deps"];
+        let args = ["cyclonedx", path_arg, "--no-build-deps"];
         let args_parsed = cli::Args::parse_from(args.iter());
 
         let sboms = generate_sboms(&args_parsed).unwrap();


### PR DESCRIPTION
This should be more clear, since dev-dependencies are never listed, and there isn't a good term for "normal" or "regular" dependencies.

@thillux what do you think?