### PR TITLE
Drop OpenSSL dependency from Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,7 +52,6 @@
           pname = "cyclonedx-rust-cargo";
           version = "0.1.0";
 
-          buildInputs = with pkgs; [ openssl ];
           nativeBuildInputs = with pkgs; [ pkg-config ];
         };
 


### PR DESCRIPTION
Now that we no longer depend on `cargo` as a library which in turn depends on OpenSSL, we don't need OpenSSL as dependency anywhere.

I don't know Nix, so...

![712be92c4bd4a36bbc01d63b7e431770ed65615201ea3c12e541b84b024edf45](https://github.com/user-attachments/assets/56e488c1-8f0d-4621-bc47-e0b72844a3f1)
