### PR TITLE
Do not pretty-print JSON

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -242,7 +242,7 @@ impl Bom {
         writer: &mut W,
     ) -> Result<(), crate::errors::JsonWriteError> {
         let bom: crate::specs::v1_3::bom::Bom = self.try_into()?;
-        serde_json::to_writer_pretty(writer, &bom)?;
+        serde_json::to_writer(writer, &bom)?;
         Ok(())
     }
 
@@ -289,7 +289,7 @@ impl Bom {
         writer: &mut W,
     ) -> Result<(), crate::errors::JsonWriteError> {
         let bom: crate::specs::v1_4::bom::Bom = self.try_into()?;
-        serde_json::to_writer_pretty(writer, &bom)?;
+        serde_json::to_writer(writer, &bom)?;
         Ok(())
     }
 
@@ -329,7 +329,7 @@ impl Bom {
         writer: &mut W,
     ) -> Result<(), crate::errors::JsonWriteError> {
         let bom: crate::specs::v1_5::bom::Bom = self.try_into()?;
-        serde_json::to_writer_pretty(writer, &bom)?;
+        serde_json::to_writer(writer, &bom)?;
         Ok(())
     }
 


### PR DESCRIPTION
Do not include whitespace in the generated JSON by default. This saves storage and network bandwidth.

Humans that want to inspect it can pipe it to `jq`, open it in the browser to get a nice UI to explore it, or use one of the many other tools for JSON inspection and manipulation.

Addresses one of the items from #628