### PR TITLE
Release cargo-cyclonedx 0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-cyclonedx"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-cyclonedx/CHANGELOG.md
+++ b/cargo-cyclonedx/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.5.4 - 2024-07-17
+
+### Fixed
+
+ - Fixed PURLs being percent-encoded incorrectly when using the `purl` crate v0.1.3 or later ([#746])
+
 ## 0.5.3 - 2024-06-04
 
 ### Added
@@ -124,3 +130,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#722]: https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/722
 [#724]: https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/724
 [#727]: https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/727
+[#746]: https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/746

--- a/cargo-cyclonedx/Cargo.toml
+++ b/cargo-cyclonedx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-cyclonedx"
-version = "0.5.3"
+version = "0.5.4"
 categories = ["command-line-utilities", "development-tools", "development-tools::cargo-plugins"]
 description = "CycloneDX Software Bill of Materials (SBOM) for Rust Crates"
 keywords = ["sbom", "bom", "components", "dependencies", "owasp"]

--- a/cargo-cyclonedx/README.md
+++ b/cargo-cyclonedx/README.md
@@ -82,7 +82,7 @@ This produces a `bom.xml` file adjacent to every `Cargo.toml` file that exists i
           Add license names which will not be warned about when parsing them as a SPDX expression fails
 
       --spec-version <SPEC_VERSION>
-          The CycloneDX specification version to output: `1.3` or `1.4`. Defaults to 1.3
+          The CycloneDX specification version to output: `1.3`, `1.4` or `1.5`. Defaults to 1.3
 
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
Not going to wait on #750 because dead code elimination does its job, and the extra dependencies do not affect the binary size at all.