### PR TITLE
Support parsing of empty XML string tags

### DIFF
--- a/cyclonedx-bom/tests/spec/1.3/valid-service-empty-description-1.3.xml
+++ b/cyclonedx-bom/tests/spec/1.3/valid-service-empty-description-1.3.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<bom serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1" xmlns="http://cyclonedx.org/schema/bom/1.3">
+    <components>
+        <component type="library" bom-ref="pkg:maven/com.acme/stock-java-client@1.0.12">
+            <group>com.acme</group>
+            <name>stock-java-client</name>
+            <version>1.0.12</version>
+            <hashes>
+                <hash alg="SHA-1">e6b1000b94e835ffd37f4c6dcbdad43f4b48a02a</hash>
+            </hashes>
+            <licenses>
+                <license>
+                    <id>Apache-2.0</id>
+                </license>
+            </licenses>
+            <purl>pkg:maven/com.acme/stock-java-client@1.0.12</purl>
+        </component>
+    </components>
+    <services>
+        <service bom-ref="b2a46a4b-8367-4bae-9820-95557cfe03a8">
+            <provider>
+                <name>Partner Org</name>
+                <url>https://partner.org</url>
+                <contact>
+                    <name>Support</name>
+                    <email>support@partner</email>
+                    <phone>800-555-1212</phone>
+                </contact>
+            </provider>
+            <group>org.partner</group>
+            <name>Stock ticker service</name>
+            <version>2020-Q2</version>
+            <description />
+            <authenticated>true</authenticated>
+            <x-trust-boundary>true</x-trust-boundary>
+            <licenses>
+                <license>
+                    <name>Partner license</name>
+                </license>
+            </licenses>
+        </service>
+    </services>
+    <dependencies>
+        <dependency ref="pkg:maven/com.acme/stock-java-client@1.0.12">
+            <dependency ref="b2a46a4b-8367-4bae-9820-95557cfe03a8"/>
+        </dependency>
+    </dependencies>
+</bom>

--- a/cyclonedx-bom/tests/spec/snapshots/1.3/it_should_parse_all_of_the_valid_xml_specifications@valid-service-empty-description-1.3.xml.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.3/it_should_parse_all_of_the_valid_xml_specifications@valid-service-empty-description-1.3.xml.snap
@@ -1,0 +1,54 @@
+---
+source: cyclonedx-bom/tests/specification_tests_v1_3.rs
+assertion_line: 27
+expression: bom_output
+input_file: cyclonedx-bom/tests/spec/1.3/valid-service-empty-description-1.3.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79" version="1">
+  <components>
+    <component type="library" bom-ref="pkg:maven/com.acme/stock-java-client@1.0.12">
+      <group>com.acme</group>
+      <name>stock-java-client</name>
+      <version>1.0.12</version>
+      <hashes>
+        <hash alg="SHA-1">e6b1000b94e835ffd37f4c6dcbdad43f4b48a02a</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+        </license>
+      </licenses>
+      <purl>pkg:maven/com.acme/stock-java-client@1.0.12</purl>
+    </component>
+  </components>
+  <services>
+    <service bom-ref="b2a46a4b-8367-4bae-9820-95557cfe03a8">
+      <provider>
+        <name>Partner Org</name>
+        <url>https://partner.org</url>
+        <contact>
+          <name>Support</name>
+          <email>support@partner</email>
+          <phone>800-555-1212</phone>
+        </contact>
+      </provider>
+      <group>org.partner</group>
+      <name>Stock ticker service</name>
+      <version>2020-Q2</version>
+      <description></description>
+      <authenticated>true</authenticated>
+      <x-trust-boundary>true</x-trust-boundary>
+      <licenses>
+        <license>
+          <name>Partner license</name>
+        </license>
+      </licenses>
+    </service>
+  </services>
+  <dependencies>
+    <dependency ref="pkg:maven/com.acme/stock-java-client@1.0.12">
+      <dependency ref="b2a46a4b-8367-4bae-9820-95557cfe03a8" />
+    </dependency>
+  </dependencies>
+</bom>


### PR DESCRIPTION
This adds support to parse either

```xml
<description>something</description>
```

or an empty XML tag.

```xml
<description />
```

The latter XML tag is an empty string (equivalent to `<description></description>`).

* fix `read_simple_tag` function to allow to parse empty XML tags
* add documentation
* add test sample with an empty `<description>` tag

Closes #738