### PR TITLE
Add spec version to bom

### DIFF
--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -119,6 +119,7 @@ pub struct Bom {
     pub annotations: Option<Annotations>,
     /// Added in version 1.5
     pub formulation: Option<Vec<Formula>>,
+    pub spec_version: SpecVersion,
 }
 
 impl Bom {
@@ -350,6 +351,7 @@ impl Default for Bom {
             signature: None,
             annotations: None,
             formulation: None,
+            spec_version: SpecVersion::V1_3,
         }
     }
 }
@@ -651,6 +653,7 @@ mod test {
     fn it_should_validate_an_empty_bom_as_passed() {
         let bom = Bom {
             version: 1,
+            spec_version: SpecVersion::V1_3,
             serial_number: None,
             metadata: None,
             components: None,
@@ -674,6 +677,7 @@ mod test {
     fn it_should_validate_broken_dependency_refs_as_failed() {
         let bom = Bom {
             version: 1,
+            spec_version: SpecVersion::V1_3,
             serial_number: None,
             metadata: None,
             components: None,
@@ -713,6 +717,7 @@ mod test {
     fn it_should_validate_broken_composition_refs_as_failed() {
         let bom = Bom {
             version: 1,
+            spec_version: SpecVersion::V1_3,
             serial_number: None,
             metadata: None,
             components: None,
@@ -752,6 +757,7 @@ mod test {
     fn it_should_validate_a_bom_with_multiple_validation_issues_as_failed() {
         let bom = Bom {
             version: 1,
+            spec_version: SpecVersion::V1_3,
             serial_number: Some(UrnUuid("invalid uuid".to_string())),
             metadata: Some(Metadata {
                 timestamp: Some(DateTime("invalid datetime".to_string())),
@@ -941,6 +947,7 @@ mod test {
 
         let validation_result = Bom {
             version: 1,
+            spec_version: SpecVersion::V1_3,
             serial_number: None,
             metadata: Some(Metadata {
                 timestamp: None,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -457,6 +457,10 @@ impl Validate for Bom {
 
         context.into()
     }
+
+    fn validate(&self) -> ValidationResult {
+        return self.validate_version(self.spec_version);
+    }
 }
 
 #[derive(Default)]
@@ -717,7 +721,7 @@ mod test {
     fn it_should_validate_broken_composition_refs_as_failed() {
         let bom = Bom {
             version: 1,
-            spec_version: SpecVersion::V1_3,
+            spec_version: SpecVersion::V1_5,
             serial_number: None,
             metadata: None,
             components: None,
@@ -947,7 +951,7 @@ mod test {
 
         let validation_result = Bom {
             version: 1,
-            spec_version: SpecVersion::V1_3,
+            spec_version: SpecVersion::V1_4,
             serial_number: None,
             metadata: Some(Metadata {
                 timestamp: None,

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -514,7 +514,6 @@ pub(crate) mod base {
             },
             metadata::test::{corresponding_metadata, example_metadata},
             service::test::{corresponding_services, example_services},
-            //spec_version::test::{SpecVersion::V1_3,SpecVersion::V1_3},
         };
         #[versioned("1.5")]
         use crate::specs::{
@@ -531,7 +530,6 @@ pub(crate) mod base {
                 metadata::test::{corresponding_metadata, example_metadata},
                 service::test::{corresponding_services, example_services},
                 vulnerability::test::{corresponding_vulnerabilities, example_vulnerabilities},
-                //spec_version::test::{SpecVersion::V1_5,SpecVersion::V1_5},
             },
         };
         #[versioned("1.4")]
@@ -546,7 +544,6 @@ pub(crate) mod base {
                 metadata::test::{corresponding_metadata, example_metadata},
                 service::test::{corresponding_services, example_services},
                 vulnerability::test::{corresponding_vulnerabilities, example_vulnerabilities},
-                //spec_version::test::{SpecVersion::V1_4,SpecVersion::V1_4},
             },
         };
         use crate::{

--- a/cyclonedx-bom/src/specs/common/bom.rs
+++ b/cyclonedx-bom/src/specs/common/bom.rs
@@ -180,6 +180,7 @@ pub(crate) mod base {
                 formulation: None,
                 #[versioned("1.5")]
                 formulation: convert_optional_vec(other.formulation),
+                spec_version: other.spec_version,
             }
         }
     }
@@ -513,6 +514,7 @@ pub(crate) mod base {
             },
             metadata::test::{corresponding_metadata, example_metadata},
             service::test::{corresponding_services, example_services},
+            //spec_version::test::{SpecVersion::V1_3,SpecVersion::V1_3},
         };
         #[versioned("1.5")]
         use crate::specs::{
@@ -529,6 +531,7 @@ pub(crate) mod base {
                 metadata::test::{corresponding_metadata, example_metadata},
                 service::test::{corresponding_services, example_services},
                 vulnerability::test::{corresponding_vulnerabilities, example_vulnerabilities},
+                //spec_version::test::{SpecVersion::V1_5,SpecVersion::V1_5},
             },
         };
         #[versioned("1.4")]
@@ -543,6 +546,7 @@ pub(crate) mod base {
                 metadata::test::{corresponding_metadata, example_metadata},
                 service::test::{corresponding_services, example_services},
                 vulnerability::test::{corresponding_vulnerabilities, example_vulnerabilities},
+                //spec_version::test::{SpecVersion::V1_4,SpecVersion::V1_4},
             },
         };
         use crate::{
@@ -606,6 +610,7 @@ pub(crate) mod base {
         pub(crate) fn corresponding_internal_model() -> models::bom::Bom {
             models::bom::Bom {
                 version: 1,
+                spec_version: SPEC_VERSION,
                 serial_number: Some(models::bom::UrnUuid("fake-uuid".to_string())),
                 metadata: Some(corresponding_metadata()),
                 components: Some(corresponding_components()),


### PR DESCRIPTION
When trying to load CycloneDX files in rust using this library, calling parse_from_json (because we  might get files of any spec version input) correctly detects the spec version and parses the json file. 

However to validate the parsed bom returned, the `validate` method always validates against the default, v1.3. That means I have to call `validate_version` and pass in the spec version of the file but there's no method to retrieve that from the parsed bom.

This PR adds a spec_version field to the bom model so that the spec_version can be retrieved from the parsed bom and passed into `validate_version`

as discussed on slack with @justahero 