### PR TITLE
Document security considerations in the cargo-cyclonedx README

### DIFF
--- a/cargo-cyclonedx/README.md
+++ b/cargo-cyclonedx/README.md
@@ -102,6 +102,15 @@ By contrast, `cargo cyclonedx` sources data both from `Cargo.lock` and from [`ca
  - Omit dev-dependencies, which cannot affect the final executable
  - Record additional fields such as the license for every component
 
+## Security considerations
+
+`cargo-cyclonedx` calls into Cargo internally to get information about a Rust project. Like nearly any other build system,
+Cargo [may run arbitrary code](https://shnatsel.medium.com/do-not-run-any-cargo-commands-on-untrusted-projects-4c31c89a78d6)
+when invoked on an untrusted project, so `cargo-cyclonedx` should not be called on untrusted projects either.
+
+Some of the other tools for generating CycloneDX SBOMs do not invoke Cargo and only parse the `Cargo.lock` file.
+However, the only way to generate the `Cargo.lock` file for them to scan is to invoke Cargo, so this issue is currently unavoidable for any tool that describes a Cargo project.
+
 ## Contributing
 
 See [CONTRIBUTING](../CONTRIBUTING.md) for details.


### PR DESCRIPTION
Copy-pastes the text from #779 into the other README

I'm pushing this as a separate PR with signoff to satisfy the sign-off bot