### PR TITLE
Remove Bug Bounty program

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ However, the only way to generate the `Cargo.lock` file for them to scan is to i
 Contributions are welcome.
 See our [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.
 
-### Bug Bounty
-
-We are running a [Bug Bounty](https://yeswehack.com/programs/cyclonedx-rust-cargo-bounty-program) program financed by the [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience/faq) of the [Sovereign Tech Fund](https://www.sovereigntechfund.de/). Thank you very much!
-
 ## Copyright & License
 
 CycloneDX Rust Cargo is Copyright (c) OWASP Foundation. All Rights Reserved.

--- a/cargo-cyclonedx/README.md
+++ b/cargo-cyclonedx/README.md
@@ -115,10 +115,6 @@ However, the only way to generate the `Cargo.lock` file for them to scan is to i
 
 See [CONTRIBUTING](../CONTRIBUTING.md) for details.
 
-### Bug Bounty
-
-We are running a [Bug Bounty](https://yeswehack.com/programs/cyclonedx-rust-cargo-bounty-program) program financed by the [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience/faq) of the [Sovereign Tech Fund](https://www.sovereigntechfund.de/). Thank you very much!
-
 ## Copyright & License
 
 CycloneDX Rust Cargo is Copyright (c) OWASP Foundation. All Rights Reserved.

--- a/cyclonedx-bom/README.md
+++ b/cyclonedx-bom/README.md
@@ -95,10 +95,6 @@ See [README](./tests/README.md) for details.
 
 See [CONTRIBUTING](../CONTRIBUTING.md) for details.
 
-### Bug Bounty
-
-We are running a [Bug Bounty](https://yeswehack.com/programs/cyclonedx-rust-cargo-bounty-program) program financed by the [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience/faq) of the [Sovereign Tech Fund](https://www.sovereigntechfund.de/). Thank you very much!
-
 ## Copyright & License
 
 CycloneDX Rust Cargo is Copyright (c) OWASP Foundation. All Rights Reserved.


### PR DESCRIPTION
We received almost entirely AI slop reports that are irrelevant to our tool. It's a library and most reporters didn't even bother to read the rules or even look at what the intended purpose of the tool is/was.

This caused a lot of extra work which is why we decided to abandon the program. Thanks AI.