### PR TITLE
Update a snapshot in cyclonedx-bom-macros for Rust 1.91

### DIFF
--- a/cyclonedx-bom-macros/tests/ui/fail/duplicated_struct.stderr
+++ b/cyclonedx-bom-macros/tests/ui/fail/duplicated_struct.stderr
@@ -1,7 +1,7 @@
 error[E0428]: the name `Foo` is defined multiple times
-  --> $DIR/duplicated_struct.rs:10:5
-   |
-7  |     pub struct Foo;
+ --> tests/ui/fail/duplicated_struct.rs:10:5
+  |
+ 7 |     pub struct Foo;
    |     --------------- previous definition of the type `Foo` here
 ...
 10 |     pub struct Foo;


### PR DESCRIPTION
Based on testing in Fedora with Rust 1.91.1, while packaging this as a new dependency for https://github.com/astral-sh/uv.