### PR TITLE
Update several dependencies across SemVer boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "validator",
 ]
 
@@ -291,7 +291,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -436,7 +436,7 @@ dependencies = [
  "spdx",
  "strum",
  "test-utils",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "uuid",
  "xml-rs",
@@ -1344,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -1360,7 +1360,7 @@ dependencies = [
  "hex",
  "percent-encoding",
  "phf",
- "thiserror",
+ "thiserror 1.0.69",
  "unicase",
 ]
 
@@ -1478,7 +1478,7 @@ checksum = "5b338d50bbf36e891c7e40337c8d4cf654094a14d50c3583c6022793c01a259c"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1706,18 +1706,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-cyclonedx/Cargo.toml
+++ b/cargo-cyclonedx/Cargo.toml
@@ -34,7 +34,7 @@ percent-encoding = "2.3.1"
 purl = { version = "0.1.3", default-features = false, features = ["package-type"] }
 regex = "1.9.3"
 serde = { version = "1.0.193", features = ["derive"] }
-thiserror = "1.0.48"
+thiserror = "2.0.0"
 validator = { version = "0.19.0" }
 
 [dev-dependencies]

--- a/cyclonedx-bom/Cargo.toml
+++ b/cyclonedx-bom/Cargo.toml
@@ -25,7 +25,7 @@ regex = "1.9.3"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 spdx = "0.10.6"
-thiserror = "1.0.48"
+thiserror = "2.0.0"
 time = { version = "0.3.29", features = ["formatting", "parsing"] }
 uuid = { version = "1.6.1", features = ["v4"] }
 xml-rs = "0.8.16"


### PR DESCRIPTION
This includes (applies on top of) https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/687.

No source-code changes seemed to be necessary *except for `spdx`*, https://github.com/CycloneDX/cyclonedx-rust-cargo/pull/812#issuecomment-3650687508. Release notes are linked below for information on breaking changes.

- https://github.com/marshallpierce/rust-base64/blob/v0.22.0/RELEASE-NOTES.md
- https://github.com/reem/rust-ordered-float/releases/tag/v5.0.0
- https://github.com/Peternator7/strum/blob/v0.27.0/CHANGELOG.md
- https://github.com/dtolnay/thiserror/releases/tag/2.0.0
- https://github.com/EmbarkStudios/spdx/blob/0.13.2/CHANGELOG.md