### PR TITLE
Bump libc from 0.2.150 to 0.2.180

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linked-hash-map"


### PR DESCRIPTION
Fixes https://github.com/CycloneDX/cyclonedx-rust-cargo/issues/814