### PR TITLE
[SECURITY] bump validator version to avoid depending on idna 0.5 which present risks of privilege escalation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "validator"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
 dependencies = [
  "idna 1.0.3",
  "once_cell",

--- a/cargo-cyclonedx/Cargo.toml
+++ b/cargo-cyclonedx/Cargo.toml
@@ -35,7 +35,7 @@ purl = { version = "0.1.3", default-features = false, features = ["package-type"
 regex = "1.9.3"
 serde = { version = "1.0.193", features = ["derive"] }
 thiserror = "1.0.48"
-validator = { version = "0.19.0" }
+validator = { version = "0.20.0" }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"


### PR DESCRIPTION
# How ?

idna 5.0 and earlier accepts Punycode labels and doesn't produce any non-ASCII output. It means that eithers the ASCII labels or the empty root label can be masked such that they appear unequal without IDNA processing.

If a system uses hostname comparaison for a part of a priviledge check (which could be a vulnerability in case of SBOM CLI and SBOM softwares).

Idna isn't a direct dependency of cyclonedx, but of validator which cyclonedx depends. It has been fixed in the 0.20 version bump.