### PR TITLE
Add support for serde traits to `cyclonedx-bom` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
 dependencies = [
  "num-traits",
+ "rand",
+ "serde",
 ]
 
 [[package]]
@@ -1374,6 +1376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -1381,6 +1384,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/cyclonedx-bom/Cargo.toml
+++ b/cyclonedx-bom/Cargo.toml
@@ -36,3 +36,7 @@ strum = { version = "0.28.0", features = ["derive"] }
 insta = { version = "1.33.0", features = ["glob", "json"] }
 pretty_assertions = "1.4.0"
 test-utils = {path = "test-utils"}
+
+[features]
+default = []
+serde = ["ordered-float/serde"]

--- a/cyclonedx-bom/src/external_models/date_time.rs
+++ b/cyclonedx-bom/src/external_models/date_time.rs
@@ -18,6 +18,8 @@
 
 use std::convert::TryFrom;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use time::{format_description::well_known::Iso8601, OffsetDateTime};
 
@@ -39,6 +41,7 @@ use crate::validation::ValidationError;
 /// assert_eq!(date_time.to_string(), timestamp);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DateTime(pub(crate) String);
 
 pub fn validate_date_time(date_time: &DateTime) -> Result<(), ValidationError> {

--- a/cyclonedx-bom/src/external_models/normalized_string.rs
+++ b/cyclonedx-bom/src/external_models/normalized_string.rs
@@ -17,6 +17,8 @@
  */
 
 use crate::validation::ValidationError;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::ops::Deref;
 
@@ -24,6 +26,7 @@ use std::ops::Deref;
 ///
 /// Defined via the [XML schema](https://www.w3.org/TR/xmlschema-2/#normalizedString)
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NormalizedString(pub(crate) String);
 
 impl NormalizedString {

--- a/cyclonedx-bom/src/external_models/spdx.rs
+++ b/cyclonedx-bom/src/external_models/spdx.rs
@@ -18,6 +18,8 @@
 
 use std::convert::TryFrom;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use spdx::{Expression, ParseMode};
 use thiserror::Error;
 
@@ -37,6 +39,7 @@ use crate::{models::bom::BomReference, validation::ValidationError};
 /// # Ok::<(), SpdxIdentifierError>(())
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpdxIdentifier(pub(crate) String);
 
 impl SpdxIdentifier {
@@ -111,6 +114,7 @@ pub enum SpdxIdentifierError {
 /// # Ok::<(), SpdxExpressionError>(())
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SpdxExpression {
     pub(crate) bom_ref: Option<BomReference>,
     pub(crate) expression: String,

--- a/cyclonedx-bom/src/external_models/uri.rs
+++ b/cyclonedx-bom/src/external_models/uri.rs
@@ -20,6 +20,8 @@ use std::{convert::TryFrom, str::FromStr};
 
 use fluent_uri::UriRef as Url;
 use purl::{GenericPurl, GenericPurlBuilder};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::validation::ValidationError;
@@ -32,6 +34,7 @@ pub fn validate_purl(purl: &Purl) -> Result<(), ValidationError> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Purl(pub(crate) String);
 
 impl Purl {
@@ -72,6 +75,7 @@ pub fn validate_uri(uri: &Uri) -> Result<(), ValidationError> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Uri(pub(crate) String);
 
 impl Uri {

--- a/cyclonedx-bom/src/models/advisory.rs
+++ b/cyclonedx-bom/src/models/advisory.rs
@@ -20,6 +20,8 @@ use crate::external_models::normalized_string::validate_normalized_string;
 use crate::external_models::uri::validate_uri;
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -27,6 +29,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_advisoryType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Advisory {
     pub title: Option<NormalizedString>,
     pub url: Uri,
@@ -58,6 +61,7 @@ impl Validate for Advisory {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Advisories(pub Vec<Advisory>);
 
 impl Validate for Advisories {

--- a/cyclonedx-bom/src/models/annotation.rs
+++ b/cyclonedx-bom/src/models/annotation.rs
@@ -27,10 +27,13 @@ use crate::{
     prelude::{Validate, ValidationResult},
     validation::ValidationContext,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Annotations(pub Vec<Annotation>);
 
 impl Validate for Annotations {
@@ -44,6 +47,7 @@ impl Validate for Annotations {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Annotation {
     pub bom_ref: Option<String>,
     pub subjects: Vec<String>,
@@ -64,6 +68,7 @@ impl Validate for Annotation {
 
 /// Represents an Annotator: organization, individual, component or service.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Annotator {
     Organization(OrganizationalEntity),
     Individual(OrganizationalContact),

--- a/cyclonedx-bom/src/models/attached_text.rs
+++ b/cyclonedx-bom/src/models/attached_text.rs
@@ -22,10 +22,13 @@ use crate::{
     external_models::normalized_string::{validate_normalized_string, NormalizedString},
     validation::{Validate, ValidationContext, ValidationError, ValidationResult},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AttachedText {
     pub content_type: Option<NormalizedString>,
     pub encoding: Option<Encoding>,
@@ -82,6 +85,8 @@ pub fn validate_encoding(encoding: &Encoding) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Encoding {
     Base64,

--- a/cyclonedx-bom/src/models/attachment.rs
+++ b/cyclonedx-bom/src/models/attachment.rs
@@ -20,10 +20,13 @@ use crate::{
     prelude::{Validate, ValidationResult},
     validation::{ValidationContext, ValidationError},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Attachment {
     pub content: String,
     pub content_type: Option<String>,

--- a/cyclonedx-bom/src/models/bom.rs
+++ b/cyclonedx-bom/src/models/bom.rs
@@ -89,6 +89,7 @@ pub fn validate_bom_ref(
 
 /// A reference to a Bom element
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BomReference(pub String);
 
 impl BomReference {
@@ -101,6 +102,7 @@ impl BomReference {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Bom {
     pub version: u32,
     pub serial_number: Option<UrnUuid>,
@@ -569,6 +571,7 @@ fn validate_vulnerabilities_bom_refs(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct UrnUuid(pub String);
 
 impl UrnUuid {

--- a/cyclonedx-bom/src/models/code.rs
+++ b/cyclonedx-bom/src/models/code.rs
@@ -25,10 +25,13 @@ use crate::{
     },
     validation::{Validate, ValidationContext, ValidationError, ValidationResult},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{attached_text::AttachedText, bom::SpecVersion};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Commit {
     pub uid: Option<NormalizedString>,
     pub url: Option<Uri>,
@@ -50,6 +53,7 @@ impl Validate for Commit {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Commits(pub Vec<Commit>);
 
 impl Validate for Commits {
@@ -61,6 +65,7 @@ impl Validate for Commits {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Diff {
     pub text: Option<AttachedText>,
     pub url: Option<Uri>,
@@ -76,6 +81,7 @@ impl Validate for Diff {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct IdentifiableAction {
     pub timestamp: Option<DateTime>,
     pub name: Option<NormalizedString>,
@@ -93,6 +99,7 @@ impl Validate for IdentifiableAction {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Issue {
     pub issue_type: IssueClassification,
     pub id: Option<NormalizedString>,
@@ -136,6 +143,8 @@ pub fn validate_issue_classification(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "snake_case")]
 pub enum IssueClassification {
     Defect,
@@ -158,6 +167,7 @@ impl IssueClassification {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Patch {
     pub patch_type: PatchClassification,
     pub diff: Option<Diff>,
@@ -181,6 +191,7 @@ impl Validate for Patch {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Patches(pub Vec<Patch>);
 
 impl Validate for Patches {
@@ -204,6 +215,8 @@ pub fn validate_patch_classification(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum PatchClassification {
     Unofficial,
@@ -228,6 +241,7 @@ impl PatchClassification {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Source {
     pub name: Option<NormalizedString>,
     pub url: Option<Uri>,

--- a/cyclonedx-bom/src/models/component.rs
+++ b/cyclonedx-bom/src/models/component.rs
@@ -19,6 +19,8 @@
 use once_cell::sync::Lazy;
 use ordered_float::OrderedFloat;
 use regex::Regex;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
 
 use crate::external_models::normalized_string::validate_normalized_string;
@@ -46,6 +48,7 @@ use super::modelcard::ModelCard;
 use super::signature::Signature;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Component {
     pub component_type: Classification,
     pub mime_type: Option<MimeType>,
@@ -163,6 +166,7 @@ impl Validate for Component {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Components(pub Vec<Component>);
 
 impl Validate for Components {
@@ -193,6 +197,8 @@ pub fn validate_classification(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 #[repr(u16)]
 pub enum Classification {
@@ -245,6 +251,8 @@ pub fn validate_scope(scope: &Scope) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Scope {
     Required,
@@ -281,9 +289,11 @@ pub fn validate_mime_type(mime_type: &MimeType) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MimeType(pub String);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Swid {
     pub tag_id: String,
     pub name: String,
@@ -320,6 +330,7 @@ pub fn validate_cpe(cpe: &Cpe) -> Result<(), ValidationError> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Cpe(pub(crate) String);
 
 impl Cpe {
@@ -359,6 +370,7 @@ impl std::fmt::Display for Cpe {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ComponentEvidence {
     pub licenses: Option<Licenses>,
     pub copyright: Option<CopyrightTexts>,
@@ -386,6 +398,7 @@ impl Validate for ComponentEvidence {
 /// https://cyclonedx.org/docs/1.5/json/#components_items_evidence_occurrences
 /// Added in version 1.5
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Occurrences(pub Vec<Occurrence>);
 
 impl Validate for Occurrences {
@@ -399,6 +412,7 @@ impl Validate for Occurrences {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Occurrence {
     pub bom_ref: Option<BomReference>,
     pub location: String,
@@ -424,6 +438,7 @@ impl Validate for Occurrence {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Callstack {
     pub frames: Frames,
 }
@@ -441,6 +456,7 @@ impl Validate for Callstack {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Frames(pub Vec<Frame>);
 
 impl Validate for Frames {
@@ -455,6 +471,7 @@ impl Validate for Frames {
 /// https://cyclonedx.org/docs/1.5/json/#components_items_evidence_callstack
 /// Added in version 1.5
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Frame {
     pub package: Option<NormalizedString>,
     pub module: NormalizedString,
@@ -497,6 +514,7 @@ pub fn validate_confidence(confidence: &ConfidenceScore) -> Result<(), Validatio
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ConfidenceScore(pub OrderedFloat<f32>);
 
 impl ConfidenceScore {
@@ -517,6 +535,8 @@ pub fn validate_identity_field(field: &IdentityField) -> Result<(), ValidationEr
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 #[repr(u16)]
 pub enum IdentityField {
@@ -549,6 +569,7 @@ impl IdentityField {
 /// https://cyclonedx.org/docs/1.5/json/#components_items_evidence_identity
 /// Added in version 1.5
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Identity {
     pub field: IdentityField,
     /// Level between 0.0-1.0 (where 1.0 is highest confidence)
@@ -569,9 +590,11 @@ impl Validate for Identity {
 /// For more information see
 /// https://cyclonedx.org/docs/1.5/json/#components_items_evidence_identity_methods
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Methods(pub Vec<Method>);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Method {
     pub technique: String,
     pub confidence: ConfidenceScore,
@@ -579,9 +602,11 @@ pub struct Method {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ToolsReferences(pub Vec<String>);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Pedigree {
     pub ancestors: Option<Components>,
     pub descendants: Option<Components>,
@@ -608,9 +633,11 @@ pub fn validate_copyright(_copyright: &Copyright) -> Result<(), ValidationError>
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Copyright(pub String);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CopyrightTexts(pub Vec<Copyright>);
 
 impl Validate for CopyrightTexts {

--- a/cyclonedx-bom/src/models/component_data.rs
+++ b/cyclonedx-bom/src/models/component_data.rs
@@ -22,6 +22,8 @@ use crate::{
     prelude::{Uri, Validate, ValidationResult},
     validation::{ValidationContext, ValidationError},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{
     bom::{BomReference, SpecVersion},
@@ -30,6 +32,7 @@ use super::{
 
 /// Inline Component Data
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ComponentData {
     pub bom_ref: Option<BomReference>,
     /// 'type' field
@@ -63,6 +66,8 @@ fn validate_datatype(datatype: &ComponentDataType) -> Result<(), ValidationError
 
 /// Type of data
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, strum::EnumString, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum ComponentDataType {
     SourceCode,
@@ -82,6 +87,7 @@ impl From<String> for ComponentDataType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DataContents {
     pub attachment: Option<Attachment>,
     pub url: Option<Uri>,
@@ -100,6 +106,7 @@ impl Validate for DataContents {
 
 /// bom-1.5.schema.json #definitions/graphicsCollection
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct GraphicsCollection {
     pub description: Option<String>,
     pub collection: Option<Vec<Graphic>>,
@@ -117,6 +124,7 @@ impl Validate for GraphicsCollection {
 
 /// bom-1.5.schema.json #definitions/graphic
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Graphic {
     pub name: Option<String>,
     pub image: Option<Attachment>,

--- a/cyclonedx-bom/src/models/composition.rs
+++ b/cyclonedx-bom/src/models/composition.rs
@@ -17,6 +17,8 @@
  */
 
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{
     bom::{BomReference, SpecVersion},
@@ -24,6 +26,7 @@ use super::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Composition {
     pub bom_ref: Option<BomReference>,
     pub aggregate: AggregateType,
@@ -45,6 +48,7 @@ impl Validate for Composition {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Compositions(pub Vec<Composition>);
 
 impl Validate for Compositions {
@@ -75,6 +79,8 @@ pub fn validate_aggregate_type(
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "snake_case")]
 #[repr(u16)]
 pub enum AggregateType {

--- a/cyclonedx-bom/src/models/data_governance.rs
+++ b/cyclonedx-bom/src/models/data_governance.rs
@@ -20,6 +20,8 @@ use crate::{
     prelude::{Validate, ValidationResult},
     validation::ValidationContext,
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{
     bom::SpecVersion,
@@ -27,6 +29,7 @@ use super::{
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DataGovernance {
     pub custodians: Option<Vec<DataGovernanceResponsibleParty>>,
     pub stewards: Option<Vec<DataGovernanceResponsibleParty>>,
@@ -50,6 +53,7 @@ impl Validate for DataGovernance {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DataGovernanceResponsibleParty {
     Organization(OrganizationalEntity),
     Contact(OrganizationalContact),

--- a/cyclonedx-bom/src/models/dependency.rs
+++ b/cyclonedx-bom/src/models/dependency.rs
@@ -16,10 +16,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dependencies(pub Vec<Dependency>);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dependency {
     pub dependency_ref: String,
     pub dependencies: Vec<String>,

--- a/cyclonedx-bom/src/models/external_reference.rs
+++ b/cyclonedx-bom/src/models/external_reference.rs
@@ -18,6 +18,8 @@
 
 use once_cell::sync::Lazy;
 use regex::Regex;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::external_models::uri::{validate_uri as validate_url, Uri as Url};
 use crate::models::hash::Hashes;
@@ -29,6 +31,7 @@ use super::bom::SpecVersion;
 ///
 /// Please see the [CycloneDX use case](https://cyclonedx.org/use-cases/#external-references) for more information and examples.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExternalReference {
     pub external_reference_type: ExternalReferenceType,
     pub url: Uri,
@@ -72,6 +75,7 @@ impl Validate for ExternalReference {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExternalReferences(pub Vec<ExternalReference>);
 
 impl Validate for ExternalReferences {
@@ -98,6 +102,8 @@ pub fn validate_external_reference_type(
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_externalReferenceType).
 #[derive(Clone, Debug, PartialEq, Eq, Hash, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum ExternalReferenceType {
     Vcs,
@@ -192,6 +198,7 @@ impl ExternalReferenceType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Uri {
     Url(Url),
     BomLink(BomLink),
@@ -226,6 +233,7 @@ impl std::fmt::Display for Uri {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BomLink(pub String);
 
 fn validate_bom_link(bom_link: &BomLink, version: SpecVersion) -> Result<(), ValidationError> {

--- a/cyclonedx-bom/src/models/formulation/mod.rs
+++ b/cyclonedx-bom/src/models/formulation/mod.rs
@@ -4,12 +4,15 @@ use crate::{
     prelude::{SpecVersion, Validate, ValidationResult},
     validation::{ValidationContext, ValidationError},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use self::workflow::Workflow;
 
 use super::{bom::BomReference, component::Components, property::Properties, service::Services};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Formula {
     pub bom_ref: Option<BomReference>,
     pub components: Option<Components>,

--- a/cyclonedx-bom/src/models/formulation/workflow/input.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/input.rs
@@ -4,8 +4,12 @@ use crate::{
     validation::ValidationContext,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::{resource_reference::ResourceReference, EnvironmentVar};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Input {
     pub required: RequiredInputField,
@@ -38,6 +42,7 @@ impl Validate for Input {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RequiredInputField {
     Resource(ResourceReference),
@@ -46,6 +51,7 @@ pub enum RequiredInputField {
     Data(Attachment),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Parameter {
     pub name: Option<String>,

--- a/cyclonedx-bom/src/models/formulation/workflow/mod.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/mod.rs
@@ -11,6 +11,8 @@ use crate::{
     prelude::{DateTime, Validate, ValidationResult},
     validation::{ValidationContext, ValidationError},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use self::{
     input::Input, output::Output, resource_reference::ResourceReference, step::Step,
@@ -18,6 +20,7 @@ use self::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Workflow {
     pub bom_ref: BomReference,
     pub uid: String,
@@ -81,6 +84,7 @@ impl Validate for Workflow {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Task {
     pub bom_ref: BomReference,
     pub uid: String,
@@ -136,6 +140,8 @@ impl Validate for Task {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum TaskType {
     Copy,
@@ -188,6 +194,7 @@ impl Validate for TaskType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum EnvironmentVar {
     Property { name: String, value: String },
     Value(String),

--- a/cyclonedx-bom/src/models/formulation/workflow/output.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/output.rs
@@ -4,8 +4,12 @@ use crate::{
     validation::{ValidationContext, ValidationError},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::{resource_reference::ResourceReference, EnvironmentVar};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Output {
     pub required: RequiredOutputField,
@@ -40,6 +44,7 @@ impl Validate for Output {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RequiredOutputField {
     Resource(ResourceReference),
@@ -47,7 +52,9 @@ pub enum RequiredOutputField {
     Data(Attachment),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, strum::Display, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Type {
     Artifact,

--- a/cyclonedx-bom/src/models/formulation/workflow/resource_reference.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/resource_reference.rs
@@ -2,6 +2,10 @@ use crate::{
     models::external_reference::ExternalReference, prelude::Validate, validation::ValidationContext,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ResourceReference {
     Ref(String),

--- a/cyclonedx-bom/src/models/formulation/workflow/step.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/step.rs
@@ -1,5 +1,9 @@
 use crate::{models::property::Properties, prelude::Validate, validation::ValidationContext};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Step {
     pub commands: Option<Vec<Command>>,
@@ -22,6 +26,7 @@ impl Validate for Step {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Command {
     pub executed: Option<String>,

--- a/cyclonedx-bom/src/models/formulation/workflow/trigger.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/trigger.rs
@@ -9,8 +9,12 @@ use crate::{
     validation::{ValidationContext, ValidationError},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::{input::Input, output::Output, resource_reference::ResourceReference};
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Trigger {
     pub bom_ref: BomReference,
@@ -62,7 +66,9 @@ impl Validate for Trigger {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, strum::Display, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Type {
     Manual,
@@ -99,6 +105,7 @@ impl Validate for Type {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Event {
     pub uid: Option<String>,
@@ -129,6 +136,7 @@ impl Validate for Event {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Condition {
     pub description: Option<String>,

--- a/cyclonedx-bom/src/models/formulation/workflow/workspace.rs
+++ b/cyclonedx-bom/src/models/formulation/workflow/workspace.rs
@@ -4,8 +4,12 @@ use crate::{
     validation::{ValidationContext, ValidationError},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::resource_reference::ResourceReference;
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Workspace {
     pub bom_ref: BomReference,
@@ -39,7 +43,9 @@ impl Validate for Workspace {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, strum::Display)]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum AccessMode {
     ReadOnly,
@@ -72,6 +78,7 @@ pub fn validate_access_mode(access_mode: &AccessMode) -> Result<(), ValidationEr
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Volume {
     pub uid: Option<String>,
@@ -92,7 +99,9 @@ impl Validate for Volume {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, strum::Display)]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Mode {
     #[default]

--- a/cyclonedx-bom/src/models/hash.rs
+++ b/cyclonedx-bom/src/models/hash.rs
@@ -20,6 +20,8 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -27,6 +29,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashType)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Hash {
     pub alg: HashAlgorithm,
     pub content: HashValue,
@@ -42,6 +45,7 @@ impl Validate for Hash {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Hashes(pub Vec<Hash>);
 
 impl Validate for Hashes {
@@ -64,6 +68,8 @@ pub fn validate_hash_algorithm(algorithm: &HashAlgorithm) -> Result<(), Validati
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashAlg)
 #[allow(non_camel_case_types)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "SCREAMING-KEBAB-CASE"))]
 #[strum(serialize_all = "SCREAMING-KEBAB-CASE")]
 pub enum HashAlgorithm {
     MD5,
@@ -124,6 +130,7 @@ pub fn validate_hash_value(value: &HashValue) -> Result<(), ValidationError> {
 
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_hashValue)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct HashValue(pub String);
 
 #[cfg(test)]

--- a/cyclonedx-bom/src/models/license.rs
+++ b/cyclonedx-bom/src/models/license.rs
@@ -32,6 +32,8 @@ use crate::models::{
     organization::{OrganizationalContact, OrganizationalEntity},
 };
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::property::Properties;
 
@@ -40,6 +42,7 @@ use super::property::Properties;
 /// As defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_licenseChoiceType)
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LicenseChoice {
     License(License),
     Expression(SpdxExpression),
@@ -82,6 +85,7 @@ impl Validate for LicenseChoice {
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_licenseType)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct License {
     pub bom_ref: Option<BomReference>,
     pub license_identifier: LicenseIdentifier,
@@ -141,6 +145,7 @@ impl Validate for License {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Licenses(pub Vec<LicenseChoice>);
 
 impl Validate for Licenses {
@@ -180,6 +185,7 @@ pub fn validate_license_identifier(identifier: &LicenseIdentifier) -> Result<(),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LicenseIdentifier {
     /// An SPDX license identifier from the list on the [SPDX website](https://spdx.org/licenses/).
     SpdxId(SpdxIdentifier),
@@ -204,6 +210,7 @@ impl Validate for LicenseIdentifier {
 ///
 /// For more details see: https://cyclonedx.org/docs/1.5/json/#metadata_licenses_oneOf_i0_items_license_licensing
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Licensing {
     pub alt_ids: Option<Vec<NormalizedString>>,
     pub licensor: Option<LicenseContact>,
@@ -238,6 +245,7 @@ impl Validate for Licensing {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LicenseContact {
     Organization(OrganizationalEntity),
     Contact(OrganizationalContact),
@@ -261,6 +269,8 @@ fn validate_license_type(license_type: &LicenseType) -> Result<(), ValidationErr
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 #[repr(u16)]
 pub enum LicenseType {

--- a/cyclonedx-bom/src/models/lifecycle.rs
+++ b/cyclonedx-bom/src/models/lifecycle.rs
@@ -17,17 +17,22 @@
  */
 
 use crate::prelude::NormalizedString;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Lifecycles(pub Vec<Lifecycle>);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Lifecycle {
     Phase(Phase),
     Description(Description),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Phase {
     Design,
     PreBuild,
@@ -73,6 +78,7 @@ impl Phase {
 
 /// A description of a `Lifecycle`.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Description {
     pub name: NormalizedString,
     pub description: Option<NormalizedString>,

--- a/cyclonedx-bom/src/models/metadata.rs
+++ b/cyclonedx-bom/src/models/metadata.rs
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::external_models::date_time::{DateTime, DateTimeError};
@@ -34,6 +36,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_metadata)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Metadata {
     pub timestamp: Option<DateTime>,
     pub tools: Option<Tools>,

--- a/cyclonedx-bom/src/models/modelcard.rs
+++ b/cyclonedx-bom/src/models/modelcard.rs
@@ -20,6 +20,8 @@ use crate::{
     prelude::{Validate, ValidationResult},
     validation::{ValidationContext, ValidationError},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{
     bom::{BomReference, SpecVersion},
@@ -31,6 +33,7 @@ use super::{
 ///
 /// For more details see: https://cyclonedx.org/docs/1.5/json/#metadata_component_modelCard
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ModelCard {
     pub bom_ref: Option<BomReference>,
     pub model_parameters: Option<ModelParameters>,
@@ -58,6 +61,7 @@ impl Validate for ModelCard {
 ///
 /// For more details see: https://cyclonedx.org/docs/1.5/json/#metadata_component_modelCard_modelParameters
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ModelParameters {
     pub approach: Option<ModelParametersApproach>,
     pub task: Option<String>,
@@ -80,6 +84,7 @@ impl Validate for ModelParameters {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ModelParametersApproach {
     pub approach_type: Option<ApproachType>,
 }
@@ -109,6 +114,7 @@ pub fn validate_approach_type(approach_type: &ApproachType) -> Result<(), Valida
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ApproachType {
     Supervised,
     Unsupervised,
@@ -147,6 +153,7 @@ impl std::fmt::Display for ApproachType {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Datasets(pub Vec<Dataset>);
 
 impl Validate for Datasets {
@@ -161,6 +168,7 @@ impl Validate for Datasets {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Dataset {
     Component(ComponentData),
     Reference(String),
@@ -176,6 +184,7 @@ impl Validate for Dataset {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Inputs(pub Vec<MLParameter>);
 
 impl Validate for Inputs {
@@ -187,6 +196,7 @@ impl Validate for Inputs {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Outputs(pub Vec<MLParameter>);
 
 impl Validate for Outputs {
@@ -202,6 +212,7 @@ pub fn validate_mlparameter(_parameter: &MLParameter) -> Result<(), ValidationEr
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MLParameter {
     pub format: Option<String>,
 }
@@ -215,6 +226,7 @@ impl MLParameter {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct QuantitativeAnalysis {
     pub performance_metrics: Option<PerformanceMetrics>,
     pub graphics: Option<GraphicsCollection>,
@@ -234,6 +246,7 @@ impl Validate for QuantitativeAnalysis {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PerformanceMetrics(pub Vec<PerformanceMetric>);
 
 impl Validate for PerformanceMetrics {
@@ -245,6 +258,7 @@ impl Validate for PerformanceMetrics {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PerformanceMetric {
     pub metric_type: Option<String>,
     pub value: Option<String>,
@@ -259,6 +273,7 @@ impl Validate for PerformanceMetric {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ConfidenceInterval {
     pub lower_bound: Option<String>,
     pub upper_bound: Option<String>,
@@ -266,6 +281,7 @@ pub struct ConfidenceInterval {
 
 /// TODO: implement struct
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Considerations {}
 
 impl Validate for Considerations {

--- a/cyclonedx-bom/src/models/organization.rs
+++ b/cyclonedx-bom/src/models/organization.rs
@@ -23,6 +23,8 @@ use crate::{
     },
     validation::{Validate, ValidationContext, ValidationResult},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::{validate_bom_ref, BomReference, SpecVersion};
 
@@ -30,6 +32,7 @@ use super::bom::{validate_bom_ref, BomReference, SpecVersion};
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_organizationalContact)
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OrganizationalContact {
     pub bom_ref: Option<BomReference>,
     pub name: Option<NormalizedString>,
@@ -71,6 +74,7 @@ impl Validate for OrganizationalContact {
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_organizationalEntity)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OrganizationalEntity {
     pub bom_ref: Option<BomReference>,
     pub name: Option<NormalizedString>,

--- a/cyclonedx-bom/src/models/property.rs
+++ b/cyclonedx-bom/src/models/property.rs
@@ -20,6 +20,8 @@ use crate::{
     external_models::normalized_string::{validate_normalized_string, NormalizedString},
     validation::{Validate, ValidationContext, ValidationResult},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -29,6 +31,7 @@ use super::bom::SpecVersion;
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_propertyType). Please see the
 /// [CycloneDX use case](https://cyclonedx.org/use-cases/#properties--name-value-store) for more information and examples.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Properties(pub Vec<Property>);
 
 impl Validate for Properties {
@@ -45,6 +48,7 @@ impl Validate for Properties {
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_propertyType)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Property {
     pub name: String,
     pub value: NormalizedString,

--- a/cyclonedx-bom/src/models/service.rs
+++ b/cyclonedx-bom/src/models/service.rs
@@ -24,6 +24,8 @@ use crate::models::license::Licenses;
 use crate::models::organization::OrganizationalEntity;
 use crate::models::property::Properties;
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 use super::data_governance::DataGovernance;
@@ -33,6 +35,7 @@ use super::signature::Signature;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_service)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Service {
     pub bom_ref: Option<String>,
     pub provider: Option<OrganizationalEntity>,
@@ -115,6 +118,7 @@ impl Validate for Service {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Services(pub Vec<Service>);
 
 impl Validate for Services {
@@ -128,6 +132,7 @@ impl Validate for Services {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Data {
     ServiceData(Vec<ServiceData>),
     Classification(Vec<DataClassification>),
@@ -147,6 +152,7 @@ impl Validate for Data {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ServiceData {
     pub name: Option<NormalizedString>,
     pub description: Option<NormalizedString>,
@@ -184,6 +190,7 @@ pub fn validate_data_flow_type(data_flow_type: &DataFlowType) -> Result<(), Vali
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_dataClassificationType)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DataClassification {
     pub flow: DataFlowType,
     pub classification: NormalizedString,
@@ -206,6 +213,8 @@ impl Validate for DataClassification {
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.3/xml/#type_dataFlowType)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum DataFlowType {
     Inbound,

--- a/cyclonedx-bom/src/models/signature.rs
+++ b/cyclonedx-bom/src/models/signature.rs
@@ -20,9 +20,12 @@ use crate::{
     prelude::{SpecVersion, Validate, ValidationResult},
     validation::{ValidationContext, ValidationError},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Enveloped signature in [JSON Signature Format (JSF)](https://cyberphone.github.io/doc/security/jsf.html)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Signature {
     /// Multiple signatures
     Signers(Vec<Signer>),
@@ -51,6 +54,7 @@ impl Validate for Signature {
 
 /// For now the [`Signer`] struct only holds algorithm and value
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Signer {
     /// Signature algorithm.
     pub algorithm: Algorithm,
@@ -104,6 +108,7 @@ impl Signature {
 
 /// Supported signature algorithms.
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Algorithm {
     RS256,
     RS384,

--- a/cyclonedx-bom/src/models/tool.rs
+++ b/cyclonedx-bom/src/models/tool.rs
@@ -19,6 +19,8 @@
 use crate::external_models::normalized_string::{validate_normalized_string, NormalizedString};
 use crate::models::hash::Hashes;
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 use super::component::Components;
@@ -30,6 +32,7 @@ use super::service::Services;
 /// In version 1.5 the type of this property changed to
 /// https://cyclonedx.org/docs/1.5/json/#metadata_tools_oneOf_i0_services .
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Tools {
     /// Legacy https://cyclonedx.org/docs/1.4/json/#metadata_tools
     List(Vec<Tool>),
@@ -72,6 +75,7 @@ impl Validate for Tools {
 ///
 /// Defined via the [CycloneDX XML schema](https://cyclonedx.org/docs/1.3/xml/#type_toolType)
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tool {
     pub vendor: Option<NormalizedString>,
     pub name: Option<NormalizedString>,

--- a/cyclonedx-bom/src/models/vulnerability.rs
+++ b/cyclonedx-bom/src/models/vulnerability.rs
@@ -29,6 +29,8 @@ use crate::models::vulnerability_reference::VulnerabilityReferences;
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::models::vulnerability_target::VulnerabilityTargets;
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::attachment::Attachment;
 use super::bom::SpecVersion;
@@ -37,6 +39,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilitiesType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Vulnerability {
     pub bom_ref: Option<String>,
     pub id: Option<NormalizedString>,
@@ -142,6 +145,7 @@ impl Validate for Vulnerability {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Vulnerabilities(pub Vec<Vulnerability>);
 
 impl Validate for Vulnerabilities {
@@ -155,6 +159,7 @@ impl Validate for Vulnerabilities {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityProofOfConcept {
     pub reproduction_steps: Option<String>,
     pub environment: Option<String>,

--- a/cyclonedx-bom/src/models/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/models/vulnerability_analysis.rs
@@ -21,6 +21,8 @@ use crate::{
     prelude::DateTime,
     validation::{Validate, ValidationContext, ValidationError, ValidationResult},
 };
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -28,6 +30,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilityType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityAnalysis {
     pub state: Option<ImpactAnalysisState>,
     pub justification: Option<ImpactAnalysisJustification>,
@@ -103,6 +106,8 @@ pub fn validate_impact_analysis_state(state: &ImpactAnalysisState) -> Result<(),
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisStateType)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "snake_case")]
 pub enum ImpactAnalysisState {
     Resolved,
@@ -146,6 +151,8 @@ pub fn validate_impact_analysis_justification(
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisJustificationType)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "snake_case")]
 pub enum ImpactAnalysisJustification {
     CodeNotPresent,
@@ -192,6 +199,8 @@ pub fn validate_impact_analysis_response(
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisResponsesType)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "snake_case")]
 pub enum ImpactAnalysisResponse {
     CanNotFix,

--- a/cyclonedx-bom/src/models/vulnerability_credits.rs
+++ b/cyclonedx-bom/src/models/vulnerability_credits.rs
@@ -18,11 +18,14 @@
 
 use crate::models::organization::{OrganizationalContact, OrganizationalEntity};
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
 /// Provides credits to organizations or individuals who contributed to a vulnerability.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityCredits {
     pub organizations: Option<Vec<OrganizationalEntity>>,
     pub individuals: Option<Vec<OrganizationalContact>>,

--- a/cyclonedx-bom/src/models/vulnerability_rating.rs
+++ b/cyclonedx-bom/src/models/vulnerability_rating.rs
@@ -21,6 +21,8 @@ use ordered_float::OrderedFloat;
 use crate::external_models::normalized_string::{validate_normalized_string, NormalizedString};
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -28,6 +30,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_ratingType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityRating {
     pub vulnerability_source: Option<VulnerabilitySource>,
     pub score: Option<Score>,
@@ -79,6 +82,7 @@ impl Validate for VulnerabilityRating {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityRatings(pub Vec<VulnerabilityRating>);
 
 impl Validate for VulnerabilityRatings {
@@ -97,6 +101,7 @@ impl Validate for VulnerabilityRatings {
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_ratingType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Score(OrderedFloat<f32>);
 
 impl Score {
@@ -136,6 +141,8 @@ pub fn validate_severity(severity: &Severity) -> Result<(), ValidationError> {
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_severityType)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Severity {
     Critical,
@@ -185,6 +192,7 @@ pub fn validate_score_method(
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_scoreSourceType)
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u16)]
 pub enum ScoreMethod {
     CVSSv2 = 1,

--- a/cyclonedx-bom/src/models/vulnerability_reference.rs
+++ b/cyclonedx-bom/src/models/vulnerability_reference.rs
@@ -19,6 +19,8 @@
 use crate::external_models::normalized_string::{validate_normalized_string, NormalizedString};
 use crate::models::vulnerability_source::VulnerabilitySource;
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -27,6 +29,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilityType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityReference {
     pub id: NormalizedString,
     pub vulnerability_source: VulnerabilitySource,
@@ -63,6 +66,7 @@ impl Validate for VulnerabilityReference {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityReferences(pub Vec<VulnerabilityReference>);
 
 impl Validate for VulnerabilityReferences {

--- a/cyclonedx-bom/src/models/vulnerability_source.rs
+++ b/cyclonedx-bom/src/models/vulnerability_source.rs
@@ -20,6 +20,8 @@ use crate::external_models::normalized_string::validate_normalized_string;
 use crate::external_models::uri::validate_uri;
 use crate::external_models::{normalized_string::NormalizedString, uri::Uri};
 use crate::validation::{Validate, ValidationContext, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -27,6 +29,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilitySourceType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilitySource {
     pub name: Option<NormalizedString>,
     pub url: Option<Uri>,

--- a/cyclonedx-bom/src/models/vulnerability_target.rs
+++ b/cyclonedx-bom/src/models/vulnerability_target.rs
@@ -21,6 +21,8 @@ use regex::Regex;
 
 use crate::external_models::normalized_string::NormalizedString;
 use crate::validation::{Validate, ValidationContext, ValidationError, ValidationResult};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::bom::SpecVersion;
 
@@ -28,6 +30,7 @@ use super::bom::SpecVersion;
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_vulnerabilityType)
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityTarget {
     pub bom_ref: String,
     pub versions: Option<Versions>,
@@ -57,6 +60,7 @@ impl Validate for VulnerabilityTarget {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VulnerabilityTargets(pub Vec<VulnerabilityTarget>);
 
 impl Validate for VulnerabilityTargets {
@@ -68,6 +72,7 @@ impl Validate for VulnerabilityTargets {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Versions(pub Vec<Version>);
 
 impl Validate for Versions {
@@ -79,6 +84,7 @@ impl Validate for Versions {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Version {
     pub version_range: VersionRange,
     pub status: Status,
@@ -120,6 +126,7 @@ pub fn validate_version_range(range: &VersionRange) -> Result<(), ValidationErro
 /// Defined via the [PURL specification](https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst)
 /// Spec for version ranges still work in progress [PURL version-range-spec](https://github.com/package-url/purl-spec/blob/version-range-spec/VERSION-RANGE-SPEC.rst)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum VersionRange {
     #[strum(default)]
     Version(NormalizedString),
@@ -157,6 +164,8 @@ pub fn validate_status(status: &Status) -> Result<(), ValidationError> {
 ///
 /// Defined via the [XML schema](https://cyclonedx.org/docs/1.4/xml/#type_impactAnalysisAffectedStatusType)
 #[derive(Clone, Debug, PartialEq, Eq, strum::Display)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[strum(serialize_all = "kebab-case")]
 pub enum Status {
     Affected,


### PR DESCRIPTION
Though the intended way to interact with the crate is to use the individual serialization functions for the different specs, sometimes it is desirable to parse into the main types directly when working with custom intermediate formats, or to only (de-)serialize part of a BOM (e.g. only `vulnerabilities`).

This PR adds optional `Serialize` and `Deserialize` derives to the main `Bom` struct and all others that require it, but only when compiling with the `serde` feature. The `serde` feature is opt-in, so as to preserve the current default behavior, and avoid potentially confusing new users with the intended usage.