### PR TITLE
Use `response` instead of `responses` when serializing `VulnerabilityAnalysis`

### DIFF
--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_4__test__it_should_serialize_a_complex_example_to_json.snap
@@ -1,6 +1,5 @@
 ---
 source: cyclonedx-bom/src/specs/common/bom.rs
-assertion_line: 654
 expression: actual
 ---
 {
@@ -561,7 +560,7 @@ expression: actual
       "analysis": {
         "state": "not_affected",
         "justification": "code_not_reachable",
-        "responses": [
+        "response": [
           "update"
         ],
         "detail": "detail"

--- a/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
+++ b/cyclonedx-bom/src/specs/common/snapshots/cyclonedx_bom__specs__common__bom__v1_5__test__it_should_serialize_a_complex_example_to_json.snap
@@ -814,7 +814,7 @@ expression: actual
       "analysis": {
         "state": "not_affected",
         "justification": "code_not_reachable",
-        "responses": [
+        "response": [
           "update"
         ],
         "detail": "detail",

--- a/cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
+++ b/cyclonedx-bom/src/specs/common/vulnerability_analysis.rs
@@ -44,7 +44,7 @@ pub(crate) mod base {
         #[serde(skip_serializing_if = "Option::is_none")]
         justification: Option<ImpactAnalysisJustification>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        responses: Option<Vec<ImpactAnalysisResponse>>,
+        response: Option<Vec<ImpactAnalysisResponse>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         detail: Option<String>,
         #[versioned("1.5")]
@@ -60,7 +60,7 @@ pub(crate) mod base {
             Self {
                 state: convert_optional(other.state),
                 justification: convert_optional(other.justification),
-                responses: convert_optional_vec(other.responses),
+                response: convert_optional_vec(other.responses),
                 detail: other.detail,
                 #[versioned("1.5")]
                 first_issued: other.first_issued.map(|d| d.to_string()),
@@ -75,7 +75,7 @@ pub(crate) mod base {
             Self {
                 state: convert_optional(other.state),
                 justification: convert_optional(other.justification),
-                responses: convert_optional_vec(other.responses),
+                responses: convert_optional_vec(other.response),
                 detail: other.detail,
                 #[versioned("1.4")]
                 first_issued: None,
@@ -115,7 +115,7 @@ pub(crate) mod base {
                 write_simple_tag(writer, JUSTIFICATION_TAG, &justification.0)?;
             }
 
-            if let Some(responses) = &self.responses {
+            if let Some(responses) = &self.response {
                 write_start_tag(writer, RESPONSES_TAG)?;
 
                 for response in responses {
@@ -227,7 +227,7 @@ pub(crate) mod base {
             Ok(Self {
                 state,
                 justification,
-                responses,
+                response: responses,
                 detail,
                 #[versioned("1.5")]
                 first_issued,
@@ -302,7 +302,7 @@ pub(crate) mod base {
                 justification: Some(ImpactAnalysisJustification(
                     "code_not_reachable".to_string(),
                 )),
-                responses: Some(vec![ImpactAnalysisResponse("update".to_string())]),
+                response: Some(vec![ImpactAnalysisResponse("update".to_string())]),
                 detail: Some("detail".to_string()),
             }
         }
@@ -314,7 +314,7 @@ pub(crate) mod base {
                 justification: Some(ImpactAnalysisJustification(
                     "code_not_reachable".to_string(),
                 )),
-                responses: Some(vec![ImpactAnalysisResponse("update".to_string())]),
+                response: Some(vec![ImpactAnalysisResponse("update".to_string())]),
                 detail: Some("detail".to_string()),
                 first_issued: Some("2024-01-02".to_string()),
                 last_updated: Some("2024-01-10".to_string()),

--- a/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-vulnerability-1.4.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.4/it_should_parse_all_of_the_valid_json_specifications@valid-vulnerability-1.4.json.snap
@@ -1,7 +1,7 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_4.rs
 expression: bom_output
-input_file: cyclonedx-bom/tests/data/1.4/valid-vulnerability-1.4.json
+input_file: cyclonedx-bom/tests/spec/1.4/valid-vulnerability-1.4.json
 ---
 {
   "bomFormat": "CycloneDX",
@@ -100,6 +100,10 @@ input_file: cyclonedx-bom/tests/data/1.4/valid-vulnerability-1.4.json
       "analysis": {
         "state": "not_affected",
         "justification": "code_not_reachable",
+        "response": [
+          "will_not_fix",
+          "update"
+        ],
         "detail": "An optional explanation of why the application is not affected by the vulnerable component."
       },
       "affects": [

--- a/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-vulnerability-1.5.json.snap
+++ b/cyclonedx-bom/tests/spec/snapshots/1.5/it_should_parse_all_of_the_valid_json_specifications@valid-vulnerability-1.5.json.snap
@@ -1,6 +1,5 @@
 ---
 source: cyclonedx-bom/tests/specification_tests_v1_5.rs
-assertion_line: 55
 expression: bom_output
 input_file: cyclonedx-bom/tests/spec/1.5/valid-vulnerability-1.5.json
 ---
@@ -128,6 +127,10 @@ input_file: cyclonedx-bom/tests/spec/1.5/valid-vulnerability-1.5.json
       "analysis": {
         "state": "not_affected",
         "justification": "code_not_reachable",
+        "response": [
+          "will_not_fix",
+          "update"
+        ],
         "detail": "An optional explanation of why the application is not affected by the vulnerable component.",
         "firstIssued": "2022-01-01T00:00:00.000Z",
         "lastUpdated": "2022-02-01T00:00:00.000Z"


### PR DESCRIPTION
The spec actually names this `response` (singular) as opposed to `responses` (plural). Tools like Dependency Track also use the singular `response`, despite the fact that it describes an array.

See: https://cyclonedx.org/docs/1.5/json/#vulnerabilities_items_analysis_response