### PR TITLE
Add --workspace-sboms flag for workspace SBOMs

### DIFF
--- a/cargo-cyclonedx/CHANGELOG.md
+++ b/cargo-cyclonedx/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+ - Added `--workspace-sboms` flag to control whether SBOMs are generated for every workspace member (`all`, default) or only for the manifest specified by `--manifest-path` or the current directory (`manifest-only`).
+
 ## 0.5.9 - 2026-03-19
 
 ### Added

--- a/cargo-cyclonedx/README.md
+++ b/cargo-cyclonedx/README.md
@@ -43,6 +43,12 @@ This produces a `bom.xml` file adjacent to every `Cargo.toml` file that exists i
           - binaries:          A separate SBOM is emitted for each binary (bin, cdylib) while all other targets are ignored
           - all-cargo-targets: A separate SBOM is emitted for each Cargo target, including things that aren't directly executable (e.g rlib)
 
+      --workspace-sboms <WORKSPACE_SBOMS>
+          Which workspace members to include when generating SBOMs
+          Possible values:
+          - all:            Generate an SBOM for every workspace member (default)
+          - manifest-only:  Generate an SBOM only for the manifest specified by `--manifest-path` or the current directory
+
   -v, --verbose...
           Use verbose output (-vv for debug logging, -vvv for tracing)
 

--- a/cargo-cyclonedx/src/cli.rs
+++ b/cargo-cyclonedx/src/cli.rs
@@ -2,7 +2,7 @@ use cargo_cyclonedx::{
     config::{
         Describe, Features, FilenameOverride, FilenameOverrideError, FilenamePattern,
         IncludedDependencies, LicenseParserOptions, OutputOptions, ParseMode, PlatformSuffix,
-        SbomConfig, Target,
+        SbomConfig, Target, WorkspaceSboms,
     },
     format::Format,
 };
@@ -41,6 +41,10 @@ pub struct Args {
     // the ValueEnum derive provides ample help text
     #[clap(long = "describe")]
     pub describe: Option<Describe>,
+
+    // the ValueEnum derive provides ample help text
+    #[clap(long = "workspace-sboms")]
+    pub workspace_sboms: Option<WorkspaceSboms>,
 
     /// Use verbose output (-vv for debug logging, -vvv for tracing)
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
@@ -182,6 +186,7 @@ impl Args {
         let describe = self.describe;
         let spec_version = self.spec_version;
         let only_normal_deps = Some(self.no_build_deps);
+        let workspace_sboms = self.workspace_sboms;
 
         Ok(SbomConfig {
             format: self.format,
@@ -193,6 +198,7 @@ impl Args {
             describe,
             spec_version,
             only_normal_deps,
+            workspace_sboms,
         })
     }
 }
@@ -238,6 +244,27 @@ mod tests {
         assert!(contains_feature(&config, "foo"));
         assert!(contains_feature(&config, "bar"));
         assert!(!contains_feature(&config, ""));
+    }
+
+    #[test]
+    fn parse_workspace_sboms() {
+        let args = vec!["cyclonedx"];
+        let config = parse_to_config(&args);
+        assert!(config.workspace_sboms.is_none());
+
+        let args = vec!["cyclonedx", "--workspace-sboms=all"];
+        let config = parse_to_config(&args);
+        assert_eq!(
+            config.workspace_sboms,
+            Some(WorkspaceSboms::All)
+        );
+
+        let args = vec!["cyclonedx", "--workspace-sboms=manifest-only"];
+        let config = parse_to_config(&args);
+        assert_eq!(
+            config.workspace_sboms,
+            Some(WorkspaceSboms::ManifestOnly)
+        );
     }
 
     fn contains_feature(config: &SbomConfig, feature: &str) -> bool {

--- a/cargo-cyclonedx/src/config.rs
+++ b/cargo-cyclonedx/src/config.rs
@@ -34,6 +34,7 @@ pub struct SbomConfig {
     pub describe: Option<Describe>,
     pub spec_version: Option<SpecVersion>,
     pub only_normal_deps: Option<bool>,
+    pub workspace_sboms: Option<WorkspaceSboms>,
 }
 
 impl SbomConfig {
@@ -60,6 +61,7 @@ impl SbomConfig {
             describe: other.describe.or(self.describe),
             spec_version: other.spec_version.or(self.spec_version),
             only_normal_deps: other.only_normal_deps.or(self.only_normal_deps),
+            workspace_sboms: other.workspace_sboms.or(self.workspace_sboms),
         }
     }
 
@@ -93,6 +95,10 @@ impl SbomConfig {
 
     pub fn license_parser(&self) -> LicenseParserOptions {
         self.license_parser.clone().unwrap_or_default()
+    }
+
+    pub fn workspace_sboms(&self) -> WorkspaceSboms {
+        self.workspace_sboms.unwrap_or_default()
     }
 }
 
@@ -248,6 +254,17 @@ pub enum ParseMode {
     /// Parse licenses in lax mode
     #[default]
     Lax,
+}
+
+/// Which workspace members to include when generating SBOMs.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum WorkspaceSboms {
+    /// Generate an SBOM for every workspace member (default)
+    #[default]
+    All,
+    /// Generate an SBOM only for the manifest specified by `--manifest-path` or the current directory
+    #[value(name = "manifest-only")]
+    ManifestOnly,
 }
 
 /// What does the SBOM describe?

--- a/cargo-cyclonedx/src/generator.rs
+++ b/cargo-cyclonedx/src/generator.rs
@@ -21,6 +21,7 @@ use std::collections::HashSet;
 use crate::config::FilenamePattern;
 use crate::config::PlatformSuffix;
 use crate::config::SbomConfig;
+use crate::config::WorkspaceSboms;
 use crate::config::{IncludedDependencies, ParseMode};
 use crate::format::Format;
 use crate::purl::get_purl;
@@ -119,15 +120,24 @@ pub struct TargetKinds(
 impl SbomGenerator {
     pub fn create_sboms(
         meta: CargoMetadata,
+        root_manifest_path: &Path,
         config: &SbomConfig,
     ) -> Result<Vec<GeneratedSbom>, GeneratorError> {
         log::trace!("Processing the workspace {}", meta.workspace_root);
         let members: Vec<PackageId> = meta.workspace_members;
         let packages = index_packages(meta.packages);
         let resolve = index_resolve(meta.resolve.unwrap().nodes);
+        let root_manifest_path = absolute_path(root_manifest_path);
+        let manifest_only = config.workspace_sboms() == WorkspaceSboms::ManifestOnly;
 
         let mut result = Vec::with_capacity(members.len());
         for member in members.iter() {
+            let manifest_path = packages[member].manifest_path.clone().into_std_path_buf();
+
+            if manifest_only && absolute_path(&manifest_path) != root_manifest_path {
+                continue;
+            }
+
             log::trace!("Processing the package {}", member);
 
             let dep_kinds = index_dep_kinds(member, &resolve);
@@ -138,8 +148,6 @@ impl SbomGenerator {
                 } else {
                     top_level_dependencies(member, &packages, &resolve, config)
                 };
-
-            let manifest_path = packages[member].manifest_path.clone().into_std_path_buf();
 
             let mut crate_hashes = HashMap::new();
             match locate_cargo_lock(&manifest_path) {
@@ -173,6 +181,12 @@ impl SbomGenerator {
             };
 
             result.push(generated);
+        }
+
+        if manifest_only && result.is_empty() {
+            return Err(GeneratorError::NoMatchingWorkspaceMember {
+                manifest_path: root_manifest_path.display().to_string(),
+            });
         }
 
         Ok(result)
@@ -702,6 +716,12 @@ pub enum GeneratorError {
 
     #[error("Could not parse author string: {}", .0)]
     AuthorParseError(String),
+
+    #[error(
+        "No workspace member matches manifest path {manifest_path}. \
+         Point --manifest-path at a crate's Cargo.toml, or use --workspace-sboms all."
+    )]
+    NoMatchingWorkspaceMember { manifest_path: String },
 }
 
 /// Generates the `Dependencies` field in the final SBOM
@@ -994,6 +1014,11 @@ impl GeneratedSbom {
             self.sbom_config.format()
         )
     }
+}
+
+/// Normalizes a path for comparison without resolving symlinks, matching `locate_manifest`.
+fn absolute_path(path: &Path) -> PathBuf {
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// Locates the corresponding `Cargo.lock` file given the location of `Cargo.toml`.

--- a/cargo-cyclonedx/src/main.rs
+++ b/cargo-cyclonedx/src/main.rs
@@ -76,7 +76,7 @@ fn generate_sboms(args: &Args) -> Result<Vec<GeneratedSbom>> {
     log::trace!("Running `cargo metadata` finished");
 
     log::trace!("SBOM generation started");
-    let boms = SbomGenerator::create_sboms(metadata, &config)?;
+    let boms = SbomGenerator::create_sboms(metadata, &manifest_path, &config)?;
     log::trace!("SBOM generation finished");
 
     Ok(boms)
@@ -193,18 +193,35 @@ fn get_metadata(
 #[cfg(test)]
 mod tests {
     use cyclonedx_bom::prelude::NormalizedString;
+    use std::path::{Path, PathBuf};
+
+    fn fixture_manifest(crate_path: &[&str]) -> PathBuf {
+        let mut manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest.push("tests/fixtures/build_then_runtime_dep");
+        for segment in crate_path {
+            manifest.push(segment);
+        }
+        manifest.push("Cargo.toml");
+        manifest
+    }
+
+    fn workspace_member_count(manifest: &Path) -> usize {
+        cargo_metadata::MetadataCommand::new()
+            .manifest_path(manifest)
+            .no_deps()
+            .exec()
+            .expect("fixture manifest should be valid for cargo metadata")
+            .workspace_members
+            .len()
+    }
 
     #[test]
     fn parse_toml_only_normal() {
         use crate::cli;
         use crate::generate_sboms;
         use clap::Parser;
-        use cyclonedx_bom::models::component::Scope;
-        use std::path::PathBuf;
 
-        let mut test_cargo_toml = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        test_cargo_toml.push("tests/fixtures/build_then_runtime_dep/Cargo.toml");
-
+        let test_cargo_toml = fixture_manifest(&[]);
         let path_arg = &format!("--manifest-path={}", test_cargo_toml.display());
         let args = ["cyclonedx", path_arg, "--no-build-deps"];
         let args_parsed = cli::Args::parse_from(args.iter());
@@ -215,7 +232,7 @@ mod tests {
         assert!(components
             .0
             .iter()
-            .all(|f| f.scope == Some(Scope::Required)));
+            .all(|f| f.scope == Some(cyclonedx_bom::models::component::Scope::Required)));
     }
 
     #[test]
@@ -224,11 +241,8 @@ mod tests {
         use crate::generate_sboms;
         use clap::Parser;
         use cyclonedx_bom::models::component::Scope;
-        use std::path::PathBuf;
 
-        let mut test_cargo_toml = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        test_cargo_toml.push("tests/fixtures/build_then_runtime_dep/Cargo.toml");
-
+        let test_cargo_toml = fixture_manifest(&[]);
         let path_arg = &format!("--manifest-path={}", test_cargo_toml.display());
         let args = ["cyclonedx", path_arg];
         let args_parsed = cli::Args::parse_from(args.iter());
@@ -246,5 +260,91 @@ mod tests {
         assert!(components.0.iter().all(|c| c.name
             != NormalizedString::new("runtime_dep_of_build_dep")
             || c.scope == Some(Scope::Excluded)));
+    }
+
+    #[test]
+    fn generate_all_workspace_sboms_by_default() {
+        use crate::cli;
+        use crate::generate_sboms;
+        use clap::Parser;
+
+        let workspace_manifest = fixture_manifest(&[]);
+        let expected_member_count = workspace_member_count(&workspace_manifest);
+        assert!(
+            expected_member_count > 1,
+            "fixture should be a multi-member workspace"
+        );
+
+        let path_arg = &format!("--manifest-path={}", workspace_manifest.display());
+        let args = ["cyclonedx", path_arg];
+        let args_parsed = cli::Args::parse_from(args.iter());
+
+        let sboms = generate_sboms(&args_parsed).unwrap();
+
+        assert_eq!(sboms.len(), expected_member_count);
+    }
+
+    #[test]
+    fn member_manifest_still_generates_all_by_default() {
+        use crate::cli;
+        use crate::generate_sboms;
+        use clap::Parser;
+
+        let workspace_manifest = fixture_manifest(&[]);
+        let member_manifest = fixture_manifest(&["top_level_crate"]);
+        let expected_member_count = workspace_member_count(&workspace_manifest);
+
+        let path_arg = &format!("--manifest-path={}", member_manifest.display());
+        let args = ["cyclonedx", path_arg];
+        let args_parsed = cli::Args::parse_from(args.iter());
+
+        let sboms = generate_sboms(&args_parsed).unwrap();
+
+        assert_eq!(sboms.len(), expected_member_count);
+    }
+
+    #[test]
+    fn generate_manifest_only_workspace_sbom() {
+        use crate::cli;
+        use crate::generate_sboms;
+        use clap::Parser;
+
+        let member_manifest = fixture_manifest(&["top_level_crate"]);
+
+        let path_arg = &format!("--manifest-path={}", member_manifest.display());
+        let args = ["cyclonedx", path_arg, "--workspace-sboms=manifest-only"];
+        let args_parsed = cli::Args::parse_from(args.iter());
+
+        let sboms = generate_sboms(&args_parsed).unwrap();
+
+        assert_eq!(sboms.len(), 1);
+        assert_eq!(sboms[0].package_name, "top_level_crate");
+    }
+
+    #[test]
+    fn manifest_only_errors_on_virtual_workspace_root() {
+        use crate::cli;
+        use crate::generate_sboms;
+        use clap::Parser;
+
+        let workspace_manifest = fixture_manifest(&[]);
+        let path_arg = &format!("--manifest-path={}", workspace_manifest.display());
+        let args = [
+            "cyclonedx",
+            path_arg,
+            "--workspace-sboms=manifest-only",
+        ];
+        let args_parsed = cli::Args::parse_from(args.iter());
+
+        let error = generate_sboms(&args_parsed).expect_err(
+            "virtual workspace root manifest should not match any workspace member",
+        );
+
+        assert!(
+            error
+                .to_string()
+                .contains("No workspace member matches manifest path"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/cargo-cyclonedx/tests/cli.rs
+++ b/cargo-cyclonedx/tests/cli.rs
@@ -133,6 +133,57 @@ fn find_content_in_stderr() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn manifest_only_writes_single_member_bom() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = make_temp_workspace()?;
+    let mut cmd = Command::new(assert_cmd::cargo_bin!());
+
+    cmd.current_dir(tmp_dir.path().join("crate_a"))
+        .arg("cyclonedx")
+        .arg("--workspace-sboms=manifest-only")
+        .arg("--override-filename=bom")
+        .arg("--format=json")
+        .arg("-qq");
+
+    cmd.assert().success().stdout("");
+
+    tmp_dir
+        .child("crate_a/bom.json")
+        .assert(predicate::path::exists());
+    assert!(!tmp_dir.child("crate_b/bom.json").path().exists());
+
+    tmp_dir.close()?;
+
+    Ok(())
+}
+
+fn make_temp_workspace() -> Result<assert_fs::TempDir, assert_fs::fixture::FixtureError> {
+    let tmp_dir = assert_fs::TempDir::new()?;
+
+    tmp_dir.child("Cargo.toml").write_str(
+        r#"
+[workspace]
+members = ["crate_a", "crate_b"]
+"#,
+    )?;
+
+    for crate_name in ["crate_a", "crate_b"] {
+        let crate_dir = tmp_dir.child(crate_name);
+        crate_dir
+            .child("src/main.rs")
+            .write_str("fn main() {}")?;
+        crate_dir.child("Cargo.toml").write_str(&format!(
+            r#"
+[package]
+name = "{crate_name}"
+version = "0.0.0"
+"#,
+        ))?;
+    }
+
+    Ok(tmp_dir)
+}
+
 fn make_temp_rust_project() -> Result<assert_fs::TempDir, assert_fs::fixture::FixtureError> {
     let tmp_dir = assert_fs::TempDir::new()?;
     tmp_dir.child("src/main.rs").touch()?;


### PR DESCRIPTION
When `cargo cyclonedx` runs against a rust workspace, it currently emits an SBOM for every workspace member. Some workflows only need the SBOM for the crate being built from a specific manifest.

Add --workspace-sboms with values `all` (default) and `manifest-only`. The default preserves existing behavior. `manifest-only` limits output to the manifest from `--manifest-path` or the current directory.

Return a clear error when `manifest-only` is used with a virtual workspace root manifest that does not match any member crate.

We've been using a fork of this repo with these changes (without the CLI flag) for a while now without issue and wanted to bring the feature upstream.

I wasn't sure if it is appropriate to fill out the `CHANGELOG.md` with an `Unreleased` section or not and can revert that if needed.